### PR TITLE
크루 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,10 @@ dependencies {
     //jasypt
     implementation 'io.github.cdimascio:java-dotenv:5.2.2'
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
+    // image server :: s3
+    implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.757')
+    implementation 'com.amazonaws:aws-java-sdk-s3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/runningservice/config/S3Config.java
+++ b/src/main/java/com/example/runningservice/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.example.runningservice.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.s3.accessKey}")
+    private String accessKey;
+
+    @Value("${aws.s3.secretKey}")
+    private String secretKey;
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        return AmazonS3ClientBuilder.standard()
+            .withCredentials(
+                new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
+            .withRegion(region)
+            .build();
+    }
+}

--- a/src/main/java/com/example/runningservice/controller/CrewController.java
+++ b/src/main/java/com/example/runningservice/controller/CrewController.java
@@ -1,0 +1,33 @@
+package com.example.runningservice.controller;
+
+import com.example.runningservice.dto.crew.CrewRequestDto;
+import com.example.runningservice.dto.crew.CrewResponseDto;
+import com.example.runningservice.service.CrewService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/crew")
+public class CrewController {
+
+    private final CrewService crewService;
+
+    /**
+     * 크루 생성
+     */
+    @PostMapping
+    public ResponseEntity<CrewResponseDto.CrewData> createCrew(
+        @Valid CrewRequestDto.Create request) {
+        request.setLoginUserId(1L); // TODO: 현재 로그인 한 사용자 id로 설정
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(crewService.createCrew(request));
+    }
+}

--- a/src/main/java/com/example/runningservice/dto/NotValidResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/NotValidResponseDto.java
@@ -1,0 +1,30 @@
+package com.example.runningservice.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NotValidResponseDto {
+
+    List<Message> data;
+
+    public NotValidResponseDto() {
+        data = new ArrayList<>();
+    }
+
+    public void addErrorMessage(Message message) {
+        data.add(message);
+    }
+
+    @Builder
+    @Getter
+    public static class Message {
+
+        String field;
+        String message;
+    }
+}

--- a/src/main/java/com/example/runningservice/dto/crew/CrewRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/crew/CrewRequestDto.java
@@ -1,0 +1,60 @@
+package com.example.runningservice.dto.crew;
+
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.Region;
+import com.example.runningservice.util.validator.UniqueCrewName;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.springframework.web.multipart.MultipartFile;
+
+public class CrewRequestDto {
+
+    @Getter
+    @Setter
+    @SuperBuilder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Base {
+
+        @NotBlank(message = "크루 소개를 입력해 주세요.")
+        @Size(max = 500, message = "크루 소개는 500자 이내로 작성해야 합니다.")
+        protected String description;
+        @Min(value = 1, message = "크루 정원은 1 이상 입력해야 합니다.")
+        private Integer crewCapacity;
+        private Region activityRegion;
+        private MultipartFile crewImage;
+        private String crewImageUrl;
+        @NotNull(message = "러닝 공개 여부는 필수 선택입니다.")
+        private Boolean runRecordOpen;
+        private Boolean waitingAllowed;
+        private Boolean leaderRequired;
+        private Integer minAge;
+        private Integer maxAge;
+        private Gender gender;
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @SuperBuilder
+    public static class Create extends Base {
+
+        @NotBlank(message = "크루명을 입력해 주세요.")
+        @Size(max = 30, message = "30자 이내로 작성해야 합니다.")
+        @UniqueCrewName
+        private String crewName;
+        private Long leaderId;
+
+        public void setLoginUserId(Long userId) {
+            this.leaderId = userId;
+        }
+    }
+}

--- a/src/main/java/com/example/runningservice/dto/crew/CrewResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/crew/CrewResponseDto.java
@@ -1,0 +1,39 @@
+package com.example.runningservice.dto.crew;
+
+import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.enums.Region;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+public class CrewResponseDto {
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @SuperBuilder
+    @Getter
+    public static class CrewData {
+
+        private Long crewId;
+        private String crewName;
+        private String leader;
+        private Integer crewCapacity;
+        private Integer crewOccupancy;
+        private Region activityRegion;
+
+        public static CrewData fromEntityAndLeaderNameAndOccupancy(CrewEntity crewEntity,
+            String nickname,
+            int occupancy) {
+
+            return CrewData.builder()
+                .crewId(crewEntity.getCrewId())
+                .leader(nickname)
+                .crewName(crewEntity.getCrewName())
+                .crewCapacity(crewEntity.getCrewCapacity())
+                .crewOccupancy(occupancy)
+                .activityRegion(crewEntity.getActivityRegion())
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/example/runningservice/entity/CrewEntity.java
+++ b/src/main/java/com/example/runningservice/entity/CrewEntity.java
@@ -1,5 +1,6 @@
 package com.example.runningservice.entity;
 
+import com.example.runningservice.dto.crew.CrewRequestDto.Create;
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Region;
 import jakarta.persistence.Entity;
@@ -52,4 +53,25 @@ public class CrewEntity {
     private LocalDateTime createdAt;
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public void updateCrewImageUrl(String imageUrl) {
+        this.crewImage = imageUrl;
+    }
+
+    @Builder
+    public static CrewEntity toEntity(Create dto, MemberEntity memberEntity) {
+        return CrewEntity.builder()
+            .member(memberEntity)
+            .crewName(dto.getCrewName())
+            .description(dto.getDescription())
+            .crewCapacity(dto.getCrewCapacity())
+            .activityRegion(dto.getActivityRegion())
+            .waitingAllowed(dto.getWaitingAllowed())
+            .runRecordOpen(dto.getRunRecordOpen())
+            .minAge(dto.getMinAge())
+            .maxAge(dto.getMaxAge())
+            .gender(dto.getGender())
+            .leaderRequired(dto.getLeaderRequired())
+            .build();
+    }
 }

--- a/src/main/java/com/example/runningservice/entity/CrewEntity.java
+++ b/src/main/java/com/example/runningservice/entity/CrewEntity.java
@@ -1,0 +1,55 @@
+package com.example.runningservice.entity;
+
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.Region;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "crew")
+@EntityListeners(AuditingEntityListener.class)
+public class CrewEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long crewId;
+    @ManyToOne
+    @JoinColumn(name = "leader_id")
+    private MemberEntity member;
+    private String crewName;
+    private String crewImage;
+    private String description;
+    private Integer crewCapacity;
+    @Enumerated(EnumType.STRING)
+    private Region activityRegion;
+    private Boolean waitingAllowed;
+    private Boolean runRecordOpen;
+    private Integer minAge;
+    private Integer maxAge;
+    private Gender gender;
+    private Boolean leaderRequired;
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/runningservice/entity/CrewMemberEntity.java
+++ b/src/main/java/com/example/runningservice/entity/CrewMemberEntity.java
@@ -1,0 +1,50 @@
+package com.example.runningservice.entity;
+
+import com.example.runningservice.enums.CrewRole;
+import com.example.runningservice.enums.JoinStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "crew_member", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"member_id", "crew_id"})
+})
+@EntityListeners(AuditingEntityListener.class)
+public class CrewMemberEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private MemberEntity member;
+    @ManyToOne
+    @JoinColumn(name = "crew_id")
+    private CrewEntity crew;
+    @Enumerated(EnumType.STRING)
+    private CrewRole role;
+    @CreatedDate
+    private LocalDateTime joinedAt;
+    @Enumerated(EnumType.STRING)
+    private JoinStatus status;
+}

--- a/src/main/java/com/example/runningservice/enums/CrewRole.java
+++ b/src/main/java/com/example/runningservice/enums/CrewRole.java
@@ -1,0 +1,5 @@
+package com.example.runningservice.enums;
+
+public enum CrewRole {
+    LEADER, STAFF, MEMBER
+}

--- a/src/main/java/com/example/runningservice/enums/JoinStatus.java
+++ b/src/main/java/com/example/runningservice/enums/JoinStatus.java
@@ -1,0 +1,5 @@
+package com.example.runningservice.enums;
+
+public enum JoinStatus {
+    PENDING, APPROVED, REJECTED
+}

--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -15,7 +15,8 @@ public enum ErrorCode {
     NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."),
     ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "해당 이메일로 가입한 내역이 있습니다."),
     ALREADY_EXIST_PHONE(HttpStatus.BAD_REQUEST, "해당 전화번호로 가입한 내역이 있습니다."),
-    NO_VALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효한 리프레시 토큰이 없습니다.");
+    NO_VALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효한 리프레시 토큰이 없습니다."),
+    FAILED_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다.");
 
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/example/runningservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/runningservice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.example.runningservice.exception;
+
+import com.example.runningservice.dto.NotValidResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // @Valid 검증에서 실패했을 때 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<NotValidResponseDto> handleNotValidException(
+        MethodArgumentNotValidException e) {
+        BindingResult bindingResult = e.getBindingResult();
+
+        NotValidResponseDto response = new NotValidResponseDto();
+
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            response.addErrorMessage(NotValidResponseDto.Message.builder()
+                .message(fieldError.getDefaultMessage())
+                .field(fieldError.getField())
+                .build());
+        }
+
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(response);
+    }
+}

--- a/src/main/java/com/example/runningservice/repository/CrewMemberRepository.java
+++ b/src/main/java/com/example/runningservice/repository/CrewMemberRepository.java
@@ -1,0 +1,10 @@
+package com.example.runningservice.repository;
+
+import com.example.runningservice.entity.CrewMemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Long> {
+
+}

--- a/src/main/java/com/example/runningservice/repository/CrewRepository.java
+++ b/src/main/java/com/example/runningservice/repository/CrewRepository.java
@@ -1,0 +1,10 @@
+package com.example.runningservice.repository;
+
+import com.example.runningservice.entity.CrewEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CrewRepository extends JpaRepository<CrewEntity, Long> {
+
+}

--- a/src/main/java/com/example/runningservice/repository/CrewRepository.java
+++ b/src/main/java/com/example/runningservice/repository/CrewRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CrewRepository extends JpaRepository<CrewEntity, Long> {
 
+    boolean existsByCrewName(String crewName);
 }

--- a/src/main/java/com/example/runningservice/service/CrewService.java
+++ b/src/main/java/com/example/runningservice/service/CrewService.java
@@ -1,0 +1,70 @@
+package com.example.runningservice.service;
+
+import com.example.runningservice.dto.crew.CrewRequestDto.Create;
+import com.example.runningservice.dto.crew.CrewResponseDto.CrewData;
+import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.enums.CrewRole;
+import com.example.runningservice.enums.JoinStatus;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.CrewMemberRepository;
+import com.example.runningservice.repository.CrewRepository;
+import com.example.runningservice.repository.MemberRepository;
+import com.example.runningservice.util.S3FileUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class CrewService {
+
+    private final CrewRepository crewRepository;
+    private final CrewMemberRepository crewMemberRepository;
+    private final MemberRepository memberRepository;
+    private final S3FileUtil s3FileUtil;
+
+    /**
+     * 크루 생성 :: db에 크루 저장 - 이미지 s3 저장 - 생성한 크루 정보 리턴
+     */
+    @Transactional
+    public CrewData createCrew(Create newCrew) {
+        MemberEntity memberEntity = memberRepository.findById(newCrew.getLeaderId())
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        CrewEntity crewEntity = CrewEntity.toEntity(newCrew, memberEntity);
+        crewRepository.save(crewEntity);
+
+        crewEntity.updateCrewImageUrl(uploadFileAndReturnFileName(crewEntity.getCrewId(),
+            newCrew.getCrewImage()));
+
+        crewMemberRepository.save(CrewMemberEntity.builder()
+            .crew(crewEntity)
+            .member(memberEntity)
+            .role(CrewRole.LEADER)
+            .status(JoinStatus.APPROVED)
+            .build());
+
+        return CrewData.fromEntityAndLeaderNameAndOccupancy(
+            crewEntity,
+            memberEntity.getNickName(),
+            1);
+    }
+
+    /**
+     * s3에 크루 이미지 저장 :: crew-{crewId}로 저장
+     */
+    private String uploadFileAndReturnFileName(Long crewId, MultipartFile crewImage) {
+        if (crewImage != null) {
+            String fileName = "crew-" + crewId;
+            s3FileUtil.putObject(fileName, crewImage);
+
+            return s3FileUtil.getImgUrl(fileName);
+        } else { // 크루 이미지가 없으면 기본 이미지로 사용
+            return s3FileUtil.getImgUrl("crew-default");
+        }
+    }
+}

--- a/src/main/java/com/example/runningservice/util/S3FileUtil.java
+++ b/src/main/java/com/example/runningservice/util/S3FileUtil.java
@@ -1,0 +1,58 @@
+package com.example.runningservice.util;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+
+@Component
+@RequiredArgsConstructor
+public class S3FileUtil {
+
+    private final AmazonS3 amazonS3Client;
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Value("${aws.s3.bucketName}")
+    private String bucketName;
+
+    /**
+     * fileName을 이용해 이미지 url을 조회한다.
+     */
+    public String getImgUrl(String fileName) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, fileName);
+    }
+
+    /**
+     * s3 이미지 업로드 :: s3 버킷에 multipartFile을 fileName으로 저장
+     */
+    @Async
+    public void putObject(String fileName, MultipartFile multipartFile) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(multipartFile.getContentType());
+        objectMetadata.setContentLength(multipartFile.getSize());
+
+        PutObjectRequest putObjectRequest;
+        try {
+            putObjectRequest = new PutObjectRequest(
+                bucketName,
+                fileName,
+                multipartFile.getInputStream(),
+                objectMetadata);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.FAILED_UPLOAD_IMAGE);
+        }
+
+        amazonS3Client.putObject(putObjectRequest);
+    }
+
+}

--- a/src/main/java/com/example/runningservice/util/validator/UniqueCrewName.java
+++ b/src/main/java/com/example/runningservice/util/validator/UniqueCrewName.java
@@ -1,0 +1,20 @@
+package com.example.runningservice.util.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = UniqueCrewNameValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UniqueCrewName {
+
+    String message() default "이미 존재하는 크루명입니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/example/runningservice/util/validator/UniqueCrewNameValidator.java
+++ b/src/main/java/com/example/runningservice/util/validator/UniqueCrewNameValidator.java
@@ -1,0 +1,22 @@
+package com.example.runningservice.util.validator;
+
+import com.example.runningservice.repository.CrewRepository;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UniqueCrewNameValidator implements ConstraintValidator<UniqueCrewName, String> {
+
+    private final CrewRepository crewRepository;
+
+    @Override
+    public void initialize(UniqueCrewName constraintAnnotation) {
+
+    }
+
+    @Override
+    public boolean isValid(String crewName, ConstraintValidatorContext context) {
+        return !crewRepository.existsByCrewName(crewName);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,10 @@ aes:
 
 jwt:
   secret: ENC(vujfcECDx3dhsf/tAiuUjfdL//SvziutrLQxXL4WGmGWV+6Ytv3gFSukbwpPZdqPHbnoFTY9uf4=)
+
+aws:
+  s3:
+    accessKey: ${AWS_ACCESS_KEY}
+    secretKey: ${AWS_SECRET_KEY}
+    region: ap-northeast-2
+    bucketName: running-service

--- a/src/test/java/com/example/runningservice/service/CrewServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/CrewServiceTest.java
@@ -1,0 +1,117 @@
+package com.example.runningservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.example.runningservice.dto.crew.CrewRequestDto.Create;
+import com.example.runningservice.dto.crew.CrewResponseDto.CrewData;
+import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.repository.CrewMemberRepository;
+import com.example.runningservice.repository.CrewRepository;
+import com.example.runningservice.repository.MemberRepository;
+import com.example.runningservice.util.S3FileUtil;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+
+@ExtendWith(MockitoExtension.class)
+class CrewServiceTest {
+
+    @Mock
+    private CrewRepository crewRepository;
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private CrewMemberRepository crewMemberRepository;
+    @Mock
+    private S3FileUtil s3FileUtil;
+    @InjectMocks
+    private CrewService crewService;
+
+    @Test
+    @DisplayName("크루 생성 - 이미지 O")
+    void createCrew_WithImage() {
+        // given
+        Long leaderId = 1L;
+        Create create = Create.builder()
+            .leaderId((leaderId))
+            .crewImage(new MockMultipartFile("file", new byte[]{1, 2, 3}))
+            .build();
+
+        MemberEntity memberEntity = MemberEntity.builder().id(leaderId).build();
+        CrewEntity crewEntity = CrewEntity.toEntity(create, memberEntity);
+
+        given(memberRepository.findById(leaderId)).willReturn(Optional.of(memberEntity));
+        given(crewRepository.save(any(CrewEntity.class))).willReturn(crewEntity);
+        given(s3FileUtil.getImgUrl(anyString())).willReturn("http://example.com/image");
+        doNothing().when(s3FileUtil).putObject(anyString(), any(MultipartFile.class));
+
+        // when
+        CrewData response = crewService.createCrew(create);
+
+        // then
+        assertEquals(crewEntity.getCrewId(), response.getCrewId());
+        verify(s3FileUtil, times(1)).putObject("crew-" + crewEntity.getCrewId(),
+            create.getCrewImage());
+        verify(s3FileUtil, times(1)).getImgUrl("crew-" + crewEntity.getCrewId());
+        verify(crewRepository, times(1)).save(any(CrewEntity.class));
+    }
+
+    @Test
+    @DisplayName("크루 생성 - 이미지 X")
+    public void createCrew_WithoutImage() {
+        // given
+        Long leaderId = 1L;
+        Create newCrew = Create.builder()
+            .leaderId(leaderId)
+            .build();
+
+        MemberEntity memberEntity = new MemberEntity();
+        CrewEntity crewEntity = CrewEntity.toEntity(newCrew, memberEntity);
+
+        given(memberRepository.findById(leaderId)).willReturn(Optional.of(memberEntity));
+        given(crewRepository.save(any(CrewEntity.class))).willReturn(crewEntity);
+        given(s3FileUtil.getImgUrl(anyString())).willReturn("http://example.com/default");
+
+        // when
+        CrewData response = crewService.createCrew(newCrew);
+
+        // then
+        assertEquals(crewEntity.getCrewId(), response.getCrewId());
+        // 이미지가 없는 경우 putObject는 호출되지 않아야 함
+        verify(s3FileUtil, never()).putObject(anyString(), any(MultipartFile.class));
+        verify(s3FileUtil, times(1)).getImgUrl("crew-default");
+        verify(crewRepository, times(1)).save(any(CrewEntity.class));
+    }
+
+    @Test
+    @DisplayName("크루 생성 (실패) - 사용자 없음")
+    public void createCrew_UserNotFound() {
+        // given
+        Long leaderId = 1L;
+        Create newCrew = Create.builder()
+            .leaderId(leaderId)
+            .build();
+
+        given(memberRepository.findById(leaderId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThrows(CustomException.class, () -> crewService.createCrew(newCrew));
+    }
+}


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- s3를 통해 이미지를 업로드할 수 있도록 한다.
- 크루명 중복인 경우 Valid로 미리 파악할 수 있도록 한다.
- 유효성 검증 시, 프론트에서 어떤 필드에서 에러가 발생하고 그 이유를 알 수 있도록 한다.
- 크루 데이터를 생성한다.

### 이 PR에서 변경된 사항
- application.yml에서 AWS 키와 s3 버킷 정보 저장
- build.gradle에서 aws sdk 의존성 추가
- S3Config에서 s3 Client Bean 추가
- Crew Entity/Repository 추가
- CrewMember Entity/Repository 추가
- (CrewRole) 크루 권한 값 제한을 위해 enum으로 사용
- (JoinStatus) 가입 상태 값 제한을 위해 enum으로 사용
- 크루명 중복 검증에 사용할 어노테이션 생성
- 크루명 중복 Validator 생성
- 같은 크루명이 존재하는지 확인하는 Repository 메서드 생성
- 실패한 field랑 message를 리스트로 반환하는 ResponseDto를 생성
- valid 실패 exception 발생 시, 내용을 dto에 담아 리턴
- 크루 생성 API, 서비스 로직 생성
- s3 이미지 업로드 기능 구현
- 크루 생성 요청 및 반환 dto 생성
- 이미지 업로드 실패 시 반환할 ErrorCode 추가

### 참고 스크린샷

### 기타
- AWS의 Accesskey와 Secretkey를 환경 변수에 입력해야 함

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
