### PR TITLE
Feat crew create 002 : AWS S3 버전 변경, 임시 자격 증명 방식

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,9 @@ dependencies {
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 
     // image server :: s3
-    implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.757')
-    implementation 'com.amazonaws:aws-java-sdk-s3'
+    implementation platform('software.amazon.awssdk:bom:2.21.1')
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:sts'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/runningservice/config/S3Config.java
+++ b/src/main/java/com/example/runningservice/config/S3Config.java
@@ -1,31 +1,40 @@
 package com.example.runningservice.config;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 @Configuration
 public class S3Config {
 
-    @Value("${aws.s3.accessKey}")
-    private String accessKey;
-
-    @Value("${aws.s3.secretKey}")
-    private String secretKey;
-
-    @Value("${aws.s3.region}")
-    private String region;
+    @Value("${aws.s3.roleArn}")
+    private String roleARN;
 
     @Bean
-    public AmazonS3 amazonS3Client() {
-        return AmazonS3ClientBuilder.standard()
-            .withCredentials(
-                new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
-            .withRegion(region)
+    public StsClient stsClient() {
+        return StsClient.create();
+    }
+
+    @Bean
+    public AwsCredentialsProvider credentialsProvider(StsClient stsClient) {
+        return StsAssumeRoleCredentialsProvider.builder()
+            .stsClient(stsClient)
+            .refreshRequest(AssumeRoleRequest.builder()
+                .roleArn(roleARN)
+                .roleSessionName("tempSession")
+                .build())
+            .build();
+    }
+
+    @Bean
+    public S3Client amazonS3Client(AwsCredentialsProvider credentialsProvider) {
+        return S3Client.builder()
+            .credentialsProvider(credentialsProvider)
             .build();
     }
 }

--- a/src/main/java/com/example/runningservice/util/S3FileUtil.java
+++ b/src/main/java/com/example/runningservice/util/S3FileUtil.java
@@ -1,23 +1,25 @@
 package com.example.runningservice.util;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class S3FileUtil {
 
-    private final AmazonS3 amazonS3Client;
+    private final S3Client amazonS3Client;
 
     @Value("${aws.s3.region}")
     private String region;
@@ -37,22 +39,22 @@ public class S3FileUtil {
      */
     @Async
     public void putObject(String fileName, MultipartFile multipartFile) {
-        ObjectMetadata objectMetadata = new ObjectMetadata();
-        objectMetadata.setContentType(multipartFile.getContentType());
-        objectMetadata.setContentLength(multipartFile.getSize());
-
         PutObjectRequest putObjectRequest;
         try {
-            putObjectRequest = new PutObjectRequest(
-                bucketName,
-                fileName,
-                multipartFile.getInputStream(),
-                objectMetadata);
+            putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .contentType(multipartFile.getContentType())
+                .contentLength(multipartFile.getSize())
+                .build();
+
+            amazonS3Client.putObject(putObjectRequest,
+                RequestBody.fromInputStream(multipartFile.getInputStream(),
+                    multipartFile.getSize()));
         } catch (IOException e) {
+            log.error(ErrorCode.FAILED_UPLOAD_IMAGE.name(), e);
             throw new CustomException(ErrorCode.FAILED_UPLOAD_IMAGE);
         }
-
-        amazonS3Client.putObject(putObjectRequest);
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,13 +38,11 @@ aes:
 jwt:
   secret: ENC(vujfcECDx3dhsf/tAiuUjfdL//SvziutrLQxXL4WGmGWV+6Ytv3gFSukbwpPZdqPHbnoFTY9uf4=)
 
-
 aws:
   s3:
-    accessKey: ${AWS_ACCESS_KEY}
-    secretKey: ${AWS_SECRET_KEY}
-    region: ap-northeast-2
-    bucketName: running-service
+    region: ENC(psk5C0nSk1GQPjS6B93mgpT/poUDVkBi)
+    bucketName: ENC(jZdTJvbbCltjdX3lsuC85xGMwnbayMQU)
+    roleArn: ENC(itgAU5raT4FloGKQIkdq81aO8izs5lfRJ9Ri3H7aNKdiARVq+R9klghOjG7W1pErPL61M2UmocK19uIYwSdR+w==)
     
 mailgun:
   domain: ENC(d2mRT2EIISaUsreQyOzXsTUMlpfbmx/dIAY9RHP0yPccGY2XecumaB1LgoWxpZAZ9+i/e/uDuEGbouY0YnPNpw==)


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- aws sdk를 곧 지원이 종료되는 1.x 버전에서 2.x 버전으로 업그레이드
- 장기 증명 방식에서 키 탈취 시 보안에 치명적이므로 짧은 시간 발급받아 사용
- bucket name이나 region도 외부 접속이 될 시, 파일 접근 가능성이 있으므로 암호화

### 이 PR에서 변경된 사항
- 버전 변경으로 인한 코드 변경
- bucket name, region, arn 암호화

### 참고 스크린샷

### 기타
- aws sdk가 환경 변수를 통해 조회하므로 AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION 설정 필요

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
