### PR TITLE
Feat crew update 001 : 크루 수정 및 삭제

### DIFF
--- a/src/main/java/com/example/runningservice/controller/CrewController.java
+++ b/src/main/java/com/example/runningservice/controller/CrewController.java
@@ -2,12 +2,15 @@ package com.example.runningservice.controller;
 
 import com.example.runningservice.dto.crew.CrewRequestDto;
 import com.example.runningservice.dto.crew.CrewResponseDto;
+import com.example.runningservice.dto.crew.CrewResponseDto.CrewData;
 import com.example.runningservice.service.CrewService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,5 +32,16 @@ public class CrewController {
         return ResponseEntity
             .status(HttpStatus.CREATED)
             .body(crewService.createCrew(request));
+    }
+
+    /**
+     * 크루 정보 수정
+     */
+    @PutMapping("/{crewId}")
+    public ResponseEntity<CrewData> updateCrew(@Valid CrewRequestDto.Update request,
+        @PathVariable("crewId") Long crewId) {
+        request.setUpdateCrewId(crewId);
+
+        return ResponseEntity.ok(crewService.updateCrew(request));
     }
 }

--- a/src/main/java/com/example/runningservice/controller/CrewController.java
+++ b/src/main/java/com/example/runningservice/controller/CrewController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -43,5 +44,13 @@ public class CrewController {
         request.setUpdateCrewId(crewId);
 
         return ResponseEntity.ok(crewService.updateCrew(request));
+    }
+
+    /**
+     * 크루 삭제
+     */
+    @DeleteMapping("/{crewId}")
+    public ResponseEntity<CrewData> deleteCrew(@PathVariable("crewId") Long crewId) {
+        return ResponseEntity.ok(crewService.deleteCrew(crewId));
     }
 }

--- a/src/main/java/com/example/runningservice/dto/crew/CrewRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/crew/CrewRequestDto.java
@@ -57,4 +57,18 @@ public class CrewRequestDto {
             this.leaderId = userId;
         }
     }
+
+    @Getter
+    @Setter
+    @SuperBuilder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Update extends Base {
+
+        private Long crewId;
+
+        public void setUpdateCrewId(Long crewId) {
+            this.crewId = crewId;
+        }
+    }
 }

--- a/src/main/java/com/example/runningservice/entity/CrewEntity.java
+++ b/src/main/java/com/example/runningservice/entity/CrewEntity.java
@@ -1,6 +1,7 @@
 package com.example.runningservice.entity;
 
 import com.example.runningservice.dto.crew.CrewRequestDto.Create;
+import com.example.runningservice.dto.crew.CrewRequestDto.Update;
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Region;
 import jakarta.persistence.Entity;
@@ -73,5 +74,17 @@ public class CrewEntity {
             .gender(dto.getGender())
             .leaderRequired(dto.getLeaderRequired())
             .build();
+    }
+
+    public void updateFromDto(Update updateCrew) {
+        this.description = updateCrew.getDescription();
+        this.activityRegion = updateCrew.getActivityRegion();
+        this.crewCapacity = updateCrew.getCrewCapacity();
+        this.runRecordOpen = updateCrew.getRunRecordOpen();
+        this.waitingAllowed = updateCrew.getWaitingAllowed();
+        this.leaderRequired = updateCrew.getLeaderRequired();
+        this.minAge = updateCrew.getMinAge();
+        this.maxAge = updateCrew.getMaxAge();
+        this.gender = updateCrew.getGender();
     }
 }

--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -16,7 +16,8 @@ public enum ErrorCode {
     ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "해당 이메일로 가입한 내역이 있습니다."),
     ALREADY_EXIST_PHONE(HttpStatus.BAD_REQUEST, "해당 전화번호로 가입한 내역이 있습니다."),
     NO_VALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효한 리프레시 토큰이 없습니다."),
-    FAILED_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다.");
+    FAILED_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
+    NOT_FOUND_CREW(HttpStatus.BAD_REQUEST, "크루를 찾을 수 없습니다.");
 
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/example/runningservice/repository/CrewMemberRepository.java
+++ b/src/main/java/com/example/runningservice/repository/CrewMemberRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Long> {
 
     int countByCrew_CrewIdAndStatus(Long crewId, JoinStatus status);
+
+    void deleteAllByCrew_CrewId(Long crewId);
 }

--- a/src/main/java/com/example/runningservice/repository/CrewMemberRepository.java
+++ b/src/main/java/com/example/runningservice/repository/CrewMemberRepository.java
@@ -1,10 +1,12 @@
 package com.example.runningservice.repository;
 
 import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.enums.JoinStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Long> {
 
+    int countByCrew_CrewIdAndStatus(Long crewId, JoinStatus status);
 }

--- a/src/main/java/com/example/runningservice/service/CrewService.java
+++ b/src/main/java/com/example/runningservice/service/CrewService.java
@@ -67,4 +67,11 @@ public class CrewService {
             return s3FileUtil.getImgUrl("crew-default");
         }
     }
+
+    /**
+     * 크루의 현재 크루원 수 조회
+     */
+    private int getCrewOccupancy(Long crewId) {
+        return crewMemberRepository.countByCrew_CrewIdAndStatus(crewId, JoinStatus.APPROVED);
+    }
 }

--- a/src/main/java/com/example/runningservice/service/CrewService.java
+++ b/src/main/java/com/example/runningservice/service/CrewService.java
@@ -27,6 +27,7 @@ public class CrewService {
     private final CrewMemberRepository crewMemberRepository;
     private final MemberRepository memberRepository;
     private final S3FileUtil s3FileUtil;
+    private final String DEFAULT_IMAGE_NAME = "crew-default";
 
     /**
      * 크루 생성 :: db에 크루 저장 - 이미지 s3 저장 - 생성한 크루 정보 리턴
@@ -65,7 +66,7 @@ public class CrewService {
 
             return s3FileUtil.getImgUrl(fileName);
         } else { // 크루 이미지가 없으면 기본 이미지로 사용
-            return s3FileUtil.getImgUrl("crew-default");
+            return s3FileUtil.getImgUrl(DEFAULT_IMAGE_NAME);
         }
     }
 

--- a/src/main/java/com/example/runningservice/service/CrewService.java
+++ b/src/main/java/com/example/runningservice/service/CrewService.java
@@ -1,6 +1,7 @@
 package com.example.runningservice.service;
 
 import com.example.runningservice.dto.crew.CrewRequestDto.Create;
+import com.example.runningservice.dto.crew.CrewRequestDto.Update;
 import com.example.runningservice.dto.crew.CrewResponseDto.CrewData;
 import com.example.runningservice.entity.CrewEntity;
 import com.example.runningservice.entity.CrewMemberEntity;
@@ -66,6 +67,25 @@ public class CrewService {
         } else { // 크루 이미지가 없으면 기본 이미지로 사용
             return s3FileUtil.getImgUrl("crew-default");
         }
+    }
+
+    /**
+     * 크루 정보 수정 :: 크루 db 수정 - 이미지 s3 저장 - 수정된 크루 정보 리턴
+     */
+    @Transactional
+    public CrewData updateCrew(Update updateCrew) {
+        CrewEntity crewEntity = crewRepository.findById(updateCrew.getCrewId())
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW));
+
+        crewEntity.updateFromDto(updateCrew);
+
+        crewEntity.updateCrewImageUrl(uploadFileAndReturnFileName(crewEntity.getCrewId(),
+            updateCrew.getCrewImage()));
+
+        return CrewData.fromEntityAndLeaderNameAndOccupancy(
+            crewEntity,
+            crewEntity.getMember().getNickName(),
+            getCrewOccupancy(updateCrew.getCrewId()));
     }
 
     /**

--- a/src/main/java/com/example/runningservice/util/S3FileUtil.java
+++ b/src/main/java/com/example/runningservice/util/S3FileUtil.java
@@ -55,4 +55,11 @@ public class S3FileUtil {
         amazonS3Client.putObject(putObjectRequest);
     }
 
+    /**
+     * 버킷에서 파일명의 데이터를 삭제한다.
+     */
+    public void deleteObject(String fileName) {
+
+        amazonS3Client.deleteObject(bucketName, fileName);
+    }
 }

--- a/src/test/java/com/example/runningservice/service/CrewServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/CrewServiceTest.java
@@ -10,7 +10,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.example.runningservice.dto.crew.CrewRequestDto;
 import com.example.runningservice.dto.crew.CrewRequestDto.Create;
+import com.example.runningservice.dto.crew.CrewRequestDto.Update;
 import com.example.runningservice.dto.crew.CrewResponseDto.CrewData;
 import com.example.runningservice.entity.CrewEntity;
 import com.example.runningservice.entity.MemberEntity;
@@ -113,5 +115,58 @@ class CrewServiceTest {
 
         // when & then
         assertThrows(CustomException.class, () -> crewService.createCrew(newCrew));
+    }
+
+    @Test
+    @DisplayName("크루 수정 - 이미지 O")
+    public void updateCrew_WithImage() {
+        // given
+        Long crewId = 1L;
+        Update update = CrewRequestDto.Update.builder()
+            .crewId(crewId)
+            .crewImage(new MockMultipartFile("file", new byte[]{1, 2, 3}))
+            .build();
+
+        MemberEntity memberEntity = MemberEntity.builder().nickName("hi").build();
+        CrewEntity crewEntity = CrewEntity.builder().crewId(crewId).member(memberEntity).build();
+
+        given(crewRepository.findById(crewId)).willReturn(Optional.of(crewEntity));
+        given(s3FileUtil.getImgUrl(anyString())).willReturn("http://example.com/image");
+        doNothing().when(s3FileUtil).putObject(anyString(), any(MultipartFile.class));
+
+        // when
+        CrewData response = crewService.updateCrew(update);
+
+        // then
+        assertEquals(crewEntity.getCrewId(), response.getCrewId());
+        assertEquals(crewEntity.getCrewImage(), "http://example.com/image");
+        verify(s3FileUtil, times(1)).putObject("crew-" + crewEntity.getCrewId(),
+            update.getCrewImage());
+        verify(s3FileUtil, times(1)).getImgUrl("crew-" + crewEntity.getCrewId());
+    }
+
+    @Test
+    @DisplayName("크루 수정 - 이미지 X")
+    public void updateCrew_WithoutImage() {
+        // given
+        Long crewId = 1L;
+        Update update = CrewRequestDto.Update.builder()
+            .crewId(crewId)
+            .build();
+
+        MemberEntity memberEntity = MemberEntity.builder().nickName("hi").build();
+        CrewEntity crewEntity = CrewEntity.builder().crewId(crewId).member(memberEntity).build();
+
+        given(crewRepository.findById(crewId)).willReturn(Optional.of(crewEntity));
+        given(s3FileUtil.getImgUrl(anyString())).willReturn("http://example.com/default");
+
+        // when
+        CrewData response = crewService.updateCrew(update);
+
+        // then
+        assertEquals(crewEntity.getCrewId(), response.getCrewId());
+        assertEquals(crewEntity.getCrewImage(), "http://example.com/default");
+        verify(s3FileUtil, times(0)).putObject(any(), any());
+        verify(s3FileUtil, times(1)).getImgUrl("crew-default");
     }
 }

--- a/src/test/java/com/example/runningservice/service/CrewServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/CrewServiceTest.java
@@ -169,4 +169,50 @@ class CrewServiceTest {
         verify(s3FileUtil, times(0)).putObject(any(), any());
         verify(s3FileUtil, times(1)).getImgUrl("crew-default");
     }
+
+    @Test
+    @DisplayName("크루 삭제 - 사용자 이미지")
+    public void deleteCrew_WithImage() {
+        // given
+        Long crewId = 1L;
+
+        MemberEntity memberEntity = MemberEntity.builder().nickName("hi").build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(crewId)
+            .member(memberEntity)
+            .crewImage("a/b/crew-1")
+            .build();
+
+        given(crewRepository.findById(crewId)).willReturn(Optional.of(crewEntity));
+
+        // when
+        CrewData response = crewService.deleteCrew(crewId);
+
+        // then
+        assertEquals(crewEntity.getCrewId(), response.getCrewId());
+        verify(s3FileUtil, times(1)).deleteObject("crew-1");
+    }
+
+    @Test
+    @DisplayName("크루 삭제 - 기본 이미지")
+    public void deleteCrew_WithoutImage() {
+        // given
+        Long crewId = 1L;
+
+        MemberEntity memberEntity = MemberEntity.builder().nickName("hi").build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(crewId)
+            .member(memberEntity)
+            .crewImage("a/b/crew-default")
+            .build();
+
+        given(crewRepository.findById(crewId)).willReturn(Optional.of(crewEntity));
+
+        // when
+        CrewData response = crewService.deleteCrew(crewId);
+
+        // then
+        assertEquals(crewEntity.getCrewId(), response.getCrewId());
+        verify(s3FileUtil, times(0)).deleteObject(anyString());
+    }
 }


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 크루 수정 후 현재 크루원 수를 반환할 수 있도록 함
- "crew-default" 고정된 값을 실수를 막기 위해 직접 입력하지 않고, 쉽게 변경될 수 있는 전역 상수로 설정

### 이 PR에서 변경된 사항
- **CrewMemberRepository** : Crew의 크루원을 count하는 메서드 추가
- **CrewService** : 크루 수정/삭제 로직 메서드, 크루원 수 조회 메서드 추가
- **CrewRequestDto** : Base를 통해 생성과 중복되는 부분은 상속 받은 크루 수정 Dto 추가
- **CrewController** : 크루 수정/삭제 API 추가
- **ErrorCode** : 크루가 존재하지 않을때 반환할 NOT_FOUND_CREW 추가
- **S3Util** : s3 파일 삭제 기능 추가

### 참고 스크린샷

### 기타
- 버전 변경으로 인해 병합 후 s3 파일 삭제 부분 수정 예정

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
