### PR TITLE
feat: Profile-002 프로필 공개여부 설정 구현

### DIFF
--- a/src/main/java/com/example/runningservice/controller/MemberController.java
+++ b/src/main/java/com/example/runningservice/controller/MemberController.java
@@ -6,12 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -51,14 +46,14 @@ public class MemberController {
 
     // 사용자 정보 조회
     @GetMapping("/{user_id}/profile")
-    public ResponseEntity<MemberResponseDto> getMemberProfile(@PathVariable("user_id") Long userId) {
+    public ResponseEntity<MemberResponseDto> getMemberProfile(@PathVariable("user_id") Long userId) throws Exception{
         return ResponseEntity.ok(memberService.getMemberProfile(userId));
     }
 
     // 사용자 정보 수정
     @PutMapping("/{user_id}/profile")
     public ResponseEntity<MemberResponseDto> updateMemberProfile(
-        @PathVariable("user_id") Long userId, @RequestBody @Valid UpdateMemberRequestDto updateMemberRequestDto) {
+        @PathVariable("user_id") Long userId, @RequestBody @Valid UpdateMemberRequestDto updateMemberRequestDto) throws Exception{
         return ResponseEntity.ok(memberService.updateMemberProfile(userId, updateMemberRequestDto));
     }
     
@@ -72,10 +67,9 @@ public class MemberController {
     
     //사용자 프로필 공개여부 설정
     @PutMapping("/{user_id}/profile-visibility")
-    public ResponseEntity<?> updateMemberProfileVisibility(
+    public ResponseEntity<ProfileVisibilityResponseDto> updateMemberProfileVisibility(
         @PathVariable("user_id") Long userId, @RequestBody @Valid ProfileVisibilityRequestDto profileVisibilityRequestDto) {
-        memberService.updateProfileVisibility(userId, profileVisibilityRequestDto);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(memberService.updateProfileVisibility(userId, profileVisibilityRequestDto));
     }
     
     // 회원 탈퇴

--- a/src/main/java/com/example/runningservice/dto/MemberResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/MemberResponseDto.java
@@ -30,17 +30,12 @@ public class MemberResponseDto {
 
     private Region activityRegion;
 
-    public static MemberResponseDto of(MemberEntity memberEntity, AESUtil aesUtil) {
-        String decryptedPhoneNumber = "";
-        try {
-            decryptedPhoneNumber = aesUtil.decrypt(memberEntity.getPhoneNumber());
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+    public static MemberResponseDto of(MemberEntity memberEntity, AESUtil aesUtil) throws Exception {
+
         return MemberResponseDto.builder()
                     .id(memberEntity.getId())
                     .email(memberEntity.getEmail())
-                    .phoneNumber(decryptedPhoneNumber)
+                    .phoneNumber(aesUtil.decrypt(memberEntity.getPhoneNumber()))
                     .name(memberEntity.getName())
                     .nickName(memberEntity.getNickName())
                     .birthYear(memberEntity.getBirthYear())

--- a/src/main/java/com/example/runningservice/dto/ProfileVisibilityRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/ProfileVisibilityRequestDto.java
@@ -8,8 +8,8 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProfileVisibilityRequestDto {
-    private String userName;
-    private String phoneNumber;
-    private Gender gender;
-    private String birthYear;
+    private int userName;
+    private int phoneNumber;
+    private int gender;
+    private int birthYear;
 }

--- a/src/main/java/com/example/runningservice/dto/ProfileVisibilityResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/ProfileVisibilityResponseDto.java
@@ -1,0 +1,28 @@
+package com.example.runningservice.dto;
+
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.enums.Visibility;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProfileVisibilityResponseDto {
+    private Visibility userName;
+    private Visibility phoneNumber;
+    private Visibility gender;
+    private Visibility birthYear;
+
+    public static ProfileVisibilityResponseDto of(MemberEntity memberEntity) {
+        return ProfileVisibilityResponseDto.builder()
+            .userName(memberEntity.getNameVisibility())
+            .phoneNumber(memberEntity.getPhoneNumberVisibility())
+            .gender(memberEntity.getGenderVisibility())
+            .birthYear(memberEntity.getBirthYearVisibility())
+            .build();
+    }
+}

--- a/src/main/java/com/example/runningservice/entity/MemberEntity.java
+++ b/src/main/java/com/example/runningservice/entity/MemberEntity.java
@@ -1,9 +1,7 @@
 package com.example.runningservice.entity;
 
 import com.example.runningservice.dto.MemberResponseDto;
-import com.example.runningservice.enums.Gender;
-import com.example.runningservice.enums.Region;
-import com.example.runningservice.enums.Role;
+import com.example.runningservice.enums.*;
 import com.example.runningservice.util.AESUtil;
 import com.example.runningservice.util.converter.GenderConverter;
 import jakarta.persistence.CollectionTable;
@@ -56,6 +54,26 @@ public class MemberEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "role")
     private List<Role> roles;
+
+    // 프로필 공개
+    @Column(name = "username_visibility")
+    private Visibility nameVisibility;
+    @Column(name = "phone_number_visibility")
+    private Visibility phoneNumberVisibility;
+    @Column(name = "gender_visibility")
+    private Visibility genderVisibility;
+    @Column(name = "birth_year_visibility")
+    private Visibility birthYearVisibility;
+
+    // 알림 설정
+    @Column(name = "post_noti")
+    private Notification postNoti;
+    @Column(name = "reply_noti")
+    private Notification replyNoti;
+    @Column(name = "mention_noti")
+    private Notification mentionNoti;
+    @Column(name = "chatting_noti")
+    private Notification chattingNoti;
 
     @Builder
     MemberEntity(
@@ -119,4 +137,11 @@ public class MemberEntity extends BaseEntity {
         this.activityRegion = activityRegion;
     }
 
+    public void updateProfileVisibility(
+        int nameVisibility, int phoneNumberVisibility, int genderVisibility, int birthYearVisibility) {
+        this.nameVisibility = Visibility.fromCode(nameVisibility);
+        this.phoneNumberVisibility = Visibility.fromCode(phoneNumberVisibility);
+        this.genderVisibility = Visibility.fromCode(genderVisibility);
+        this.birthYearVisibility = Visibility.fromCode(birthYearVisibility);
+    }
 }

--- a/src/main/java/com/example/runningservice/enums/Notification.java
+++ b/src/main/java/com/example/runningservice/enums/Notification.java
@@ -1,0 +1,20 @@
+package com.example.runningservice.enums;
+
+public enum Notification {
+    ON(0),
+    OFF(1);
+
+    private final int code;
+
+    Notification(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public static Notification fromCode(int code) {
+        return code == 0 ? ON : OFF;
+    }
+}

--- a/src/main/java/com/example/runningservice/enums/Visibility.java
+++ b/src/main/java/com/example/runningservice/enums/Visibility.java
@@ -1,0 +1,20 @@
+package com.example.runningservice.enums;
+
+public enum Visibility {
+    PUBLIC(0),
+    PRIVATE(1);
+
+    private final int code;
+
+    Visibility(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public static Visibility fromCode(int code) {
+        return code == 0 ? PUBLIC : PRIVATE;
+    }
+}

--- a/src/main/java/com/example/runningservice/service/MemberService.java
+++ b/src/main/java/com/example/runningservice/service/MemberService.java
@@ -94,9 +94,10 @@ public class MemberService {
             .append("http://localhost:8080/user/signup/email-verify?email=").append(email)
             .append("&code=").append(code);
         return new String(sb);
+    }
 
     // 사용자 정보 조회
-    public MemberResponseDto getMemberProfile(Long user_id) {
+    public MemberResponseDto getMemberProfile(Long user_id) throws Exception {
         MemberEntity memberEntity = memberRepository.findById(user_id)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
@@ -106,7 +107,7 @@ public class MemberService {
     // 사용자 정보 수정
     @Transactional
     public MemberResponseDto updateMemberProfile(
-        Long user_id, UpdateMemberRequestDto updateMemberRequestDto) {
+        Long user_id, UpdateMemberRequestDto updateMemberRequestDto) throws Exception {
         MemberEntity memberEntity = memberRepository.findById(user_id)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
@@ -152,12 +153,22 @@ public class MemberService {
     }
     
     // 사용자 프로필 공개여부 설정
-    public void updateProfileVisibility(
+    public ProfileVisibilityResponseDto updateProfileVisibility(
         Long user_id, ProfileVisibilityRequestDto profileVisibilityRequestDto) {
         MemberEntity memberEntity = memberRepository.findById(user_id)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
         
         // 프로필 공개여부 설정
+        memberEntity.updateProfileVisibility(
+            profileVisibilityRequestDto.getUserName(),
+            profileVisibilityRequestDto.getPhoneNumber(),
+            profileVisibilityRequestDto.getGender(),
+            profileVisibilityRequestDto.getBirthYear()
+        );
+
+        memberRepository.save(memberEntity);
+
+        return ProfileVisibilityResponseDto.of(memberEntity);
     }
 
     // 회원 탈퇴

--- a/src/test/java/com/example/runningservice/member/TestMemberProfile.java
+++ b/src/test/java/com/example/runningservice/member/TestMemberProfile.java
@@ -1,25 +1,28 @@
 package com.example.runningservice.member;
 
-import com.example.runningservice.dto.MemberResponseDto;
+import com.example.runningservice.dto.*;
 import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.Region;
 import com.example.runningservice.enums.Role;
+import com.example.runningservice.enums.Visibility;
 import com.example.runningservice.repository.MemberRepository;
 import com.example.runningservice.service.MemberService;
+import com.example.runningservice.util.AESUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class TestMemberProfile {
@@ -27,18 +30,25 @@ public class TestMemberProfile {
     @Mock
     private MemberRepository memberRepository;
 
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private AESUtil aesUtil;
+
     @InjectMocks
     private MemberService memberService;
 
     @Test
-    public void testGetMemberProfile() {
+    public void testGetMemberProfile() throws Exception {
         // given
         Long userId = 1L;
+        String encryptedPhoneNumber = aesUtil.encrypt("01012341234");
 
         MemberEntity mockMemberEntity = MemberEntity.builder()
             .id(userId)
             .email("test@naver.com")
-            .phoneNumber("01012341234")
+            .phoneNumber(encryptedPhoneNumber)
             .name("TestMember")
             .nickName("TestMemberNickName")
             .birthYear(1996)
@@ -48,6 +58,7 @@ public class TestMemberProfile {
 
         // when
         when(memberRepository.findById(userId)).thenReturn(Optional.of(mockMemberEntity));
+        when(aesUtil.decrypt(encryptedPhoneNumber)).thenReturn("01012341234");
 
         MemberResponseDto memberResponseDto = memberService.getMemberProfile(userId);
 
@@ -61,5 +72,127 @@ public class TestMemberProfile {
         assertEquals(1996, memberResponseDto.getBirthYear());
         assertEquals(Gender.MALE, memberResponseDto.getGender());
         assertEquals(List.of(Role.ROLE_USER), memberResponseDto.getRoles());
+    }
+
+    @Test
+    public void testUpdateMemberProfile() throws Exception{
+        // given
+        Long userId = 1L;
+
+        MemberEntity mockMemberEntity = MemberEntity.builder()
+            .id(userId)
+            .nickName("test11")
+            .birthYear(1998)
+            .gender(Gender.MALE)
+            .activityRegion(Region.BUSAN)
+            .build();
+
+        UpdateMemberRequestDto updateMemberRequestDto = UpdateMemberRequestDto.builder()
+            .nickName("test22")
+            .birthYear(1996)
+            .gender(Gender.FEMALE)
+            .activityRegion(Region.CHUNGBUK)
+            .build();
+
+        // when
+        when(memberRepository.findById(userId)).thenReturn(Optional.of(mockMemberEntity));
+        when(memberRepository.save(any(MemberEntity.class))).thenReturn(mockMemberEntity);
+
+        MemberResponseDto memberResponseDto = memberService.updateMemberProfile(userId, updateMemberRequestDto);
+
+        // then
+        assertNotNull(updateMemberRequestDto);
+        assertEquals("test22", updateMemberRequestDto.getNickName());
+        assertEquals(1996, updateMemberRequestDto.getBirthYear());
+        assertEquals(Gender.FEMALE, updateMemberRequestDto.getGender());
+        assertEquals(Region.CHUNGBUK, updateMemberRequestDto.getActivityRegion());
+
+        verify(memberRepository, times(1)).findById(userId);
+        verify(memberRepository, times(1)).save(mockMemberEntity);
+    }
+
+    @Test
+    public void testUpdatePassword() throws Exception {
+        // given
+        Long userId = 1L;
+
+        MemberEntity mockMemberEntity = MemberEntity.builder()
+            .id(userId)
+            .password("encryptedOldPassword")
+            .build();
+
+        PasswordRequestDto passwordRequestDto = new PasswordRequestDto(
+            "oldPassword", "newPassword", "newPassword");
+
+        // when
+        when(memberRepository.findById(userId)).thenReturn(Optional.of(mockMemberEntity));
+        when(passwordEncoder.matches(passwordRequestDto.getOldPassword(), mockMemberEntity.getPassword()))
+            .thenReturn(true);
+        when(aesUtil.encrypt(passwordRequestDto.getNewPassword())).thenReturn("encryptedNewPassword");
+
+        memberService.updateMemberPassword(userId, passwordRequestDto);
+
+        // then
+        verify(memberRepository, times(1)).findById(userId);
+        verify(passwordEncoder, times(1)).matches(passwordRequestDto.getOldPassword(), "encryptedOldPassword");
+        verify(aesUtil, times(1)).encrypt(passwordRequestDto.getNewPassword());
+        verify(memberRepository, times(1)).save(mockMemberEntity);
+        assertEquals("encryptedNewPassword", mockMemberEntity.getPassword());
+    }
+
+    @Test
+    public void testDeleteMemberProfile() {
+        // given
+        Long userId = 1L;
+
+        MemberEntity mockMemberEntity = MemberEntity.builder()
+            .id(userId)
+            .password("encryptedOldPassword")
+            .build();
+
+        DeleteRequestDto deleteRequestDto = new DeleteRequestDto("oldPassword");
+
+        // when
+        when(memberRepository.findById(userId)).thenReturn(Optional.of(mockMemberEntity));
+        when(passwordEncoder.matches(deleteRequestDto.getPassword(), mockMemberEntity.getPassword()))
+            .thenReturn(true);
+
+        memberService.deleteMember(userId, deleteRequestDto);
+
+        // then
+        verify(memberRepository, times(1)).findById(userId);
+        verify(passwordEncoder, times(1)).matches(deleteRequestDto.getPassword(), mockMemberEntity.getPassword());
+        verify(memberRepository, times(1)).delete(mockMemberEntity);
+    }
+
+    @Test
+    public void testUpdateVisibility() {
+        // given
+        Long userId = 1L;
+
+        MemberEntity mockMemberEntity = MemberEntity.builder()
+            .id(userId)
+            .nameVisibility(Visibility.PUBLIC)
+            .phoneNumberVisibility(Visibility.PUBLIC)
+            .genderVisibility(Visibility.PUBLIC)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .build();
+
+        ProfileVisibilityRequestDto profileVisibilityRequestDto = new ProfileVisibilityRequestDto(0, 0, 1, 1);
+
+        // when
+        when(memberRepository.findById(userId)).thenReturn(Optional.of(mockMemberEntity));
+        when(memberRepository.save(any(MemberEntity.class))).thenReturn(mockMemberEntity);
+
+        ProfileVisibilityResponseDto profileVisibilityResponseDto = memberService.updateProfileVisibility(userId, profileVisibilityRequestDto);
+
+        // then
+        verify(memberRepository, times(1)).findById(userId);
+        verify(memberRepository, times(1)).save(mockMemberEntity);
+
+        assertEquals(Visibility.PUBLIC, profileVisibilityResponseDto.getUserName());
+        assertEquals(Visibility.PUBLIC, profileVisibilityResponseDto.getPhoneNumber());
+        assertEquals(Visibility.PRIVATE, profileVisibilityResponseDto.getGender());
+        assertEquals(Visibility.PRIVATE, profileVisibilityResponseDto.getBirthYear());
     }
 }


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제

### 이 PR에서 변경된 사항
- MemberEntity 수정(알람/ 공개여부 컬럼 추가, 공개여부 setter 추가)
- Profile 공개여부 설정 기능 추가
- Member Profile 수정/삭제/비밀번호 추가/공개여부 설정 성공 테스트 코드 추가

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
