### PR TITLE
Feat crew update 001 : Data Binding 방식 변경, 크루 엔티티 컬럼 수정

### DIFF
--- a/src/main/java/com/example/runningservice/dto/crew/CrewRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/crew/CrewRequestDto.java
@@ -3,6 +3,7 @@ package com.example.runningservice.dto.crew;
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Region;
 import com.example.runningservice.util.validator.UniqueCrewName;
+import com.example.runningservice.util.validator.YearRange;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -14,6 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class CrewRequestDto {
 
     @Getter
+    @YearRange(minYear = "minAge", maxYear = "maxAge")
     public static class Base {
 
         @NotBlank(message = "크루 소개를 입력해 주세요.")

--- a/src/main/java/com/example/runningservice/dto/crew/CrewRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/crew/CrewRequestDto.java
@@ -7,68 +7,87 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
+import java.beans.ConstructorProperties;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.SuperBuilder;
 import org.springframework.web.multipart.MultipartFile;
 
 public class CrewRequestDto {
 
     @Getter
-    @Setter
-    @SuperBuilder
-    @AllArgsConstructor
-    @NoArgsConstructor
     public static class Base {
 
         @NotBlank(message = "크루 소개를 입력해 주세요.")
         @Size(max = 500, message = "크루 소개는 500자 이내로 작성해야 합니다.")
-        protected String description;
+        private final String description;
         @Min(value = 1, message = "크루 정원은 1 이상 입력해야 합니다.")
-        private Integer crewCapacity;
-        private Region activityRegion;
-        private MultipartFile crewImage;
-        private String crewImageUrl;
+        private final Integer crewCapacity;
+        private final Region activityRegion;
+        private final MultipartFile crewImage;
         @NotNull(message = "러닝 공개 여부는 필수 선택입니다.")
-        private Boolean runRecordOpen;
-        private Boolean waitingAllowed;
-        private Boolean leaderRequired;
-        private Integer minAge;
-        private Integer maxAge;
-        private Gender gender;
+        private final Boolean runRecordOpen;
+        @NotNull(message = "리더 승인 여부는 필수 선택입니다.")
+        private final Boolean leaderRequired;
+        private final Integer minAge;
+        private final Integer maxAge;
+        private final Gender gender;
+
+        public Base(String description, Integer crewCapacity, Region activityRegion,
+            MultipartFile crewImage, Boolean runRecordOpen, Boolean leaderRequired,
+            Integer minAge, Integer maxAge, Gender gender) {
+            this.description = description;
+            this.crewCapacity = crewCapacity;
+            this.activityRegion = activityRegion;
+            this.crewImage = crewImage;
+            this.runRecordOpen = runRecordOpen;
+            this.leaderRequired = leaderRequired;
+            this.minAge = minAge;
+            this.maxAge = maxAge;
+            this.gender = gender;
+        }
     }
 
     @Getter
-    @Setter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @SuperBuilder
     public static class Create extends Base {
 
         @NotBlank(message = "크루명을 입력해 주세요.")
         @Size(max = 30, message = "30자 이내로 작성해야 합니다.")
         @UniqueCrewName
-        private String crewName;
+        private final String crewName;
         private Long leaderId;
 
         public void setLoginUserId(Long userId) {
             this.leaderId = userId;
         }
+
+        @ConstructorProperties({"description", "crewCapacity", "activityRegion", "crewImage",
+            "runRecordOpen", "leaderRequired", "minAge", "maxAge", "gender", "crewName"})
+        public Create(String description, Integer crewCapacity, Region activityRegion,
+            MultipartFile crewImage, Boolean runRecordOpen, Boolean leaderRequired,
+            Integer minAge, Integer maxAge, Gender gender, String crewName) {
+
+            super(description, crewCapacity, activityRegion, crewImage, runRecordOpen,
+                leaderRequired, minAge, maxAge, gender);
+            this.crewName = crewName;
+        }
     }
 
     @Getter
-    @Setter
-    @SuperBuilder
-    @AllArgsConstructor
-    @NoArgsConstructor
     public static class Update extends Base {
 
         private Long crewId;
 
         public void setUpdateCrewId(Long crewId) {
             this.crewId = crewId;
+        }
+
+        @ConstructorProperties({"description", "crewCapacity", "activityRegion", "crewImage",
+            "runRecordOpen", "leaderRequired", "minAge", "maxAge", "gender"})
+        public Update(String description, Integer crewCapacity, Region activityRegion,
+            MultipartFile crewImage, Boolean runRecordOpen, Boolean leaderRequired,
+            Integer minAge, Integer maxAge, Gender gender) {
+
+            super(description, crewCapacity, activityRegion, crewImage, runRecordOpen,
+                leaderRequired, minAge, maxAge, gender);
         }
     }
 }

--- a/src/main/java/com/example/runningservice/entity/CrewEntity.java
+++ b/src/main/java/com/example/runningservice/entity/CrewEntity.java
@@ -4,6 +4,8 @@ import com.example.runningservice.dto.crew.CrewRequestDto.Create;
 import com.example.runningservice.dto.crew.CrewRequestDto.Update;
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Region;
+import com.example.runningservice.util.converter.GenderConverter;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
@@ -47,6 +49,7 @@ public class CrewEntity {
     private Boolean runRecordOpen;
     private Integer minAge;
     private Integer maxAge;
+    @Convert(converter = GenderConverter.class)
     private Gender gender;
     private Boolean leaderRequired;
     @CreatedDate

--- a/src/main/java/com/example/runningservice/entity/CrewEntity.java
+++ b/src/main/java/com/example/runningservice/entity/CrewEntity.java
@@ -36,7 +36,7 @@ public class CrewEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long crewId;
     @ManyToOne
-    @JoinColumn(name = "leader_id")
+    @JoinColumn(name = "member_id")
     private MemberEntity member;
     private String crewName;
     private String crewImage;
@@ -44,7 +44,6 @@ public class CrewEntity {
     private Integer crewCapacity;
     @Enumerated(EnumType.STRING)
     private Region activityRegion;
-    private Boolean waitingAllowed;
     private Boolean runRecordOpen;
     private Integer minAge;
     private Integer maxAge;
@@ -67,7 +66,6 @@ public class CrewEntity {
             .description(dto.getDescription())
             .crewCapacity(dto.getCrewCapacity())
             .activityRegion(dto.getActivityRegion())
-            .waitingAllowed(dto.getWaitingAllowed())
             .runRecordOpen(dto.getRunRecordOpen())
             .minAge(dto.getMinAge())
             .maxAge(dto.getMaxAge())
@@ -81,7 +79,6 @@ public class CrewEntity {
         this.activityRegion = updateCrew.getActivityRegion();
         this.crewCapacity = updateCrew.getCrewCapacity();
         this.runRecordOpen = updateCrew.getRunRecordOpen();
-        this.waitingAllowed = updateCrew.getWaitingAllowed();
         this.leaderRequired = updateCrew.getLeaderRequired();
         this.minAge = updateCrew.getMinAge();
         this.maxAge = updateCrew.getMaxAge();

--- a/src/main/java/com/example/runningservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/runningservice/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -27,6 +28,13 @@ public class GlobalExceptionHandler {
             response.addErrorMessage(NotValidResponseDto.Message.builder()
                 .message(fieldError.getDefaultMessage())
                 .field(fieldError.getField())
+                .build());
+        }
+        // 클래스 레벨 에러 처리
+        for (ObjectError globalError : bindingResult.getGlobalErrors()) {
+            response.addErrorMessage(NotValidResponseDto.Message.builder()
+                .message(globalError.getDefaultMessage())
+                .field(globalError.getObjectName())
                 .build());
         }
 

--- a/src/main/java/com/example/runningservice/service/CrewService.java
+++ b/src/main/java/com/example/runningservice/service/CrewService.java
@@ -60,7 +60,7 @@ public class CrewService {
      * s3에 크루 이미지 저장 :: crew-{crewId}로 저장
      */
     private String uploadFileAndReturnFileName(Long crewId, MultipartFile crewImage) {
-        if (crewImage != null) {
+        if (!crewImage.isEmpty()) {
             String fileName = "crew-" + crewId;
             s3FileUtil.putObject(fileName, crewImage);
 

--- a/src/main/java/com/example/runningservice/util/validator/YearRange.java
+++ b/src/main/java/com/example/runningservice/util/validator/YearRange.java
@@ -1,0 +1,24 @@
+package com.example.runningservice.util.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = YearRangeValidator.class)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface YearRange {
+
+    String message() default "최소 나이가 최대 나이보다 작아야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    String minYear();
+
+    String maxYear();
+}

--- a/src/main/java/com/example/runningservice/util/validator/YearRangeValidator.java
+++ b/src/main/java/com/example/runningservice/util/validator/YearRangeValidator.java
@@ -1,0 +1,46 @@
+package com.example.runningservice.util.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.lang.reflect.Field;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class YearRangeValidator implements ConstraintValidator<YearRange, Object> {
+
+    private String minYear;
+    private String maxYear;
+
+    @Override
+    public void initialize(YearRange constraintAnnotation) {
+        this.minYear = constraintAnnotation.minYear();
+        this.maxYear = constraintAnnotation.maxYear();
+    }
+
+    @Override
+    public boolean isValid(Object object, ConstraintValidatorContext context) {
+        Integer minYear = getFieldValue(object, this.minYear);
+        if (minYear == null) {
+            return true;
+        }
+        Integer maxYear = getFieldValue(object, this.maxYear);
+        if (maxYear == null) {
+            return true;
+        }
+        return minYear >= maxYear;
+    }
+
+    private Integer getFieldValue(Object object, String fieldName) {
+        Class<?> clazz = object.getClass().getSuperclass();
+        Field yearField;
+        try {
+            yearField = clazz.getDeclaredField(fieldName);
+            yearField.setAccessible(true);
+            Object target = yearField.get(object);
+
+            return (Integer) target;
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/example/runningservice/service/CrewServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/CrewServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.example.runningservice.dto.crew.CrewRequestDto;
 import com.example.runningservice.dto.crew.CrewRequestDto.Create;
 import com.example.runningservice.dto.crew.CrewRequestDto.Update;
 import com.example.runningservice.dto.crew.CrewResponseDto.CrewData;
@@ -21,6 +20,7 @@ import com.example.runningservice.repository.CrewMemberRepository;
 import com.example.runningservice.repository.CrewRepository;
 import com.example.runningservice.repository.MemberRepository;
 import com.example.runningservice.util.S3FileUtil;
+import java.lang.reflect.Field;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,13 +48,19 @@ class CrewServiceTest {
 
     @Test
     @DisplayName("크루 생성 - 이미지 O")
-    void createCrew_WithImage() {
+    void createCrew_WithImage() throws Exception {
         // given
         Long leaderId = 1L;
-        Create create = Create.builder()
-            .leaderId((leaderId))
-            .crewImage(new MockMultipartFile("file", new byte[]{1, 2, 3}))
-            .build();
+
+        Create create = new Create(null, null, null, null, null, null,
+            null, null, null, null);
+        Field f1 = Create.class.getDeclaredField("leaderId");
+        f1.setAccessible(true);
+        f1.set(create, leaderId);
+
+        Field f2 = Create.class.getSuperclass().getDeclaredField("crewImage");
+        f2.setAccessible(true);
+        f2.set(create, new MockMultipartFile("file", new byte[]{1, 2, 3}));
 
         MemberEntity memberEntity = MemberEntity.builder().id(leaderId).build();
         CrewEntity crewEntity = CrewEntity.toEntity(create, memberEntity);
@@ -77,12 +83,19 @@ class CrewServiceTest {
 
     @Test
     @DisplayName("크루 생성 - 이미지 X")
-    public void createCrew_WithoutImage() {
+    public void createCrew_WithoutImage() throws Exception {
         // given
         Long leaderId = 1L;
-        Create newCrew = Create.builder()
-            .leaderId(leaderId)
-            .build();
+
+        Create newCrew = new Create(null, null, null, null, null, null,
+            null, null, null, null);
+        Field f1 = Create.class.getDeclaredField("leaderId");
+        f1.setAccessible(true);
+        f1.set(newCrew, leaderId);
+
+        Field f2 = Create.class.getSuperclass().getDeclaredField("crewImage");
+        f2.setAccessible(true);
+        f2.set(newCrew, new MockMultipartFile("file", new byte[0]));
 
         MemberEntity memberEntity = new MemberEntity();
         CrewEntity crewEntity = CrewEntity.toEntity(newCrew, memberEntity);
@@ -104,12 +117,15 @@ class CrewServiceTest {
 
     @Test
     @DisplayName("크루 생성 (실패) - 사용자 없음")
-    public void createCrew_UserNotFound() {
+    public void createCrew_UserNotFound() throws Exception {
         // given
         Long leaderId = 1L;
-        Create newCrew = Create.builder()
-            .leaderId(leaderId)
-            .build();
+
+        Create newCrew = new Create(null, null, null, null, null, null,
+            null, null, null, null);
+        Field f1 = Create.class.getDeclaredField("leaderId");
+        f1.setAccessible(true);
+        f1.set(newCrew, leaderId);
 
         given(memberRepository.findById(leaderId)).willReturn(Optional.empty());
 
@@ -119,13 +135,19 @@ class CrewServiceTest {
 
     @Test
     @DisplayName("크루 수정 - 이미지 O")
-    public void updateCrew_WithImage() {
+    public void updateCrew_WithImage() throws Exception {
         // given
         Long crewId = 1L;
-        Update update = CrewRequestDto.Update.builder()
-            .crewId(crewId)
-            .crewImage(new MockMultipartFile("file", new byte[]{1, 2, 3}))
-            .build();
+
+        Update update = new Update(null, null, null, null, null
+            , null, null, null, null);
+        Field f1 = Update.class.getDeclaredField("crewId");
+        f1.setAccessible(true);
+        f1.set(update, crewId);
+
+        Field f2 = Update.class.getSuperclass().getDeclaredField("crewImage");
+        f2.setAccessible(true);
+        f2.set(update, new MockMultipartFile("file", new byte[]{1, 2, 3}));
 
         MemberEntity memberEntity = MemberEntity.builder().nickName("hi").build();
         CrewEntity crewEntity = CrewEntity.builder().crewId(crewId).member(memberEntity).build();
@@ -147,12 +169,19 @@ class CrewServiceTest {
 
     @Test
     @DisplayName("크루 수정 - 이미지 X")
-    public void updateCrew_WithoutImage() {
+    public void updateCrew_WithoutImage() throws Exception {
         // given
         Long crewId = 1L;
-        Update update = CrewRequestDto.Update.builder()
-            .crewId(crewId)
-            .build();
+
+        Update update = new Update(null, null, null, null, null
+            , null, null, null, null);
+        Field f1 = Update.class.getDeclaredField("crewId");
+        f1.setAccessible(true);
+        f1.set(update, crewId);
+
+        Field f2 = Update.class.getSuperclass().getDeclaredField("crewImage");
+        f2.setAccessible(true);
+        f2.set(update, new MockMultipartFile("file", new byte[0]));
 
         MemberEntity memberEntity = MemberEntity.builder().nickName("hi").build();
         CrewEntity crewEntity = CrewEntity.builder().crewId(crewId).member(memberEntity).build();


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- Setter 사용을 하지 않기 위해 생성자로 바인딩 받을 수 있도록 설정
- 사용하지 않기로 한 waitingAllowed (대기 허용) 속성 삭제
- 외래키를 현 테이블에 맞는 이름을 지정했었지만(leader_id) 헷갈릴 수 있어서 수정(member_id)
- 최소 나이가 최대 나이보다 큰 값으로 입력되지 않도록 validator 추가

### 이 PR에서 변경된 사항
- 받아올 데이터의 생성자 추가, 파라미터 key 명시
- Test에서 Builder 삭제로 인해 생성 후, reflector로 필드값 설정
- waitingAllowed 컬럼 삭제
- 외래키 컬럼 table_id로 통일
- Crew Entity 성별 Converter로 저장

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
