### PR TITLE
프로필 정보 수정시 이미지 업데이트 추가

### DIFF
--- a/src/main/java/com/example/runningservice/controller/MemberController.java
+++ b/src/main/java/com/example/runningservice/controller/MemberController.java
@@ -22,17 +22,17 @@ public class MemberController {
 
     // 사용자 정보 조회
     @GetMapping("/{user_id}/profile")
-    public ResponseEntity<MemberResponseDto> getMemberProfile(@PathVariable("user_id") Long userId) throws Exception{
+    public ResponseEntity<MemberResponseDto> getMemberProfile(@PathVariable("user_id") Long userId) throws Exception {
         return ResponseEntity.ok(memberService.getMemberProfile(userId));
     }
 
     // 사용자 정보 수정
     @PutMapping("/{user_id}/profile")
     public ResponseEntity<MemberResponseDto> updateMemberProfile(
-        @PathVariable("user_id") Long userId, @RequestBody @Valid UpdateMemberRequestDto updateMemberRequestDto) throws Exception{
+        @PathVariable("user_id") Long userId, @RequestBody @Valid UpdateMemberRequestDto updateMemberRequestDto) throws Exception {
         return ResponseEntity.ok(memberService.updateMemberProfile(userId, updateMemberRequestDto));
     }
-    
+
     // 비밀번호 변경
     @PutMapping("/{user_id}/password")
     public ResponseEntity<?> updateMemberPassword(
@@ -40,14 +40,14 @@ public class MemberController {
         memberService.updateMemberPassword(userId, passwordRequestDto);
         return ResponseEntity.ok().build();
     }
-    
+
     //사용자 프로필 공개여부 설정
     @PutMapping("/{user_id}/profile-visibility")
     public ResponseEntity<ProfileVisibilityResponseDto> updateMemberProfileVisibility(
         @PathVariable("user_id") Long userId, @RequestBody @Valid ProfileVisibilityRequestDto profileVisibilityRequestDto) {
         return ResponseEntity.ok(memberService.updateProfileVisibility(userId, profileVisibilityRequestDto));
     }
-    
+
     // 회원 탈퇴
     @DeleteMapping("/{user_id}")
     public ResponseEntity<?> deleteMember(@PathVariable("user_id") Long userId, @RequestBody DeleteRequestDto deleteRequestDto) {

--- a/src/main/java/com/example/runningservice/dto/member/UpdateMemberRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/member/UpdateMemberRequestDto.java
@@ -3,6 +3,7 @@ package com.example.runningservice.dto.member;
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Region;
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Builder
@@ -13,4 +14,5 @@ public class UpdateMemberRequestDto {
     private Gender gender;
     private Integer birthYear;
     private Region activityRegion;
+    private MultipartFile profileImage;
 }

--- a/src/test/java/com/example/runningservice/member/TestMemberProfile.java
+++ b/src/test/java/com/example/runningservice/member/TestMemberProfile.java
@@ -3,9 +3,7 @@ package com.example.runningservice.member;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.example.runningservice.dto.DeleteRequestDto;
 import com.example.runningservice.dto.ProfileVisibilityResponseDto;
@@ -23,12 +21,16 @@ import com.example.runningservice.service.MemberService;
 import com.example.runningservice.util.AESUtil;
 import java.util.List;
 import java.util.Optional;
+
+import com.example.runningservice.util.S3FileUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 public class TestMemberProfile {
@@ -41,6 +43,9 @@ public class TestMemberProfile {
 
     @Mock
     private AESUtil aesUtil;
+
+    @Mock
+    private S3FileUtil s3FileUtil;
 
     @InjectMocks
     private MemberService memberService;
@@ -81,9 +86,13 @@ public class TestMemberProfile {
     }
 
     @Test
-    public void testUpdateMemberProfile() throws Exception{
+    public void testUpdateMemberProfile() throws Exception {
         // given
         Long userId = 1L;
+
+        String fileName = "user-" + userId;
+        String oldImageUrl = "http://example.s3.region.amazonaws.com/oldImage";
+        String imageUrl = s3FileUtil.getImgUrl(fileName);
 
         MemberEntity mockMemberEntity = MemberEntity.builder()
             .id(userId)
@@ -91,30 +100,36 @@ public class TestMemberProfile {
             .birthYear(1998)
             .gender(Gender.MALE)
             .activityRegion(Region.BUSAN)
+            .profileImageUrl(oldImageUrl)
             .build();
+
+        when(memberRepository.findById(userId)).thenReturn(Optional.of(mockMemberEntity));
+        when(memberRepository.save(any(MemberEntity.class))).thenReturn(mockMemberEntity);
+
+        MultipartFile profileImage = mock(MultipartFile.class);
 
         UpdateMemberRequestDto updateMemberRequestDto = UpdateMemberRequestDto.builder()
             .nickName("test22")
             .birthYear(1996)
             .gender(Gender.FEMALE)
             .activityRegion(Region.CHUNGBUK)
+            .profileImage(profileImage)
             .build();
 
-        // when
-        when(memberRepository.findById(userId)).thenReturn(Optional.of(mockMemberEntity));
-        when(memberRepository.save(any(MemberEntity.class))).thenReturn(mockMemberEntity);
+        when(s3FileUtil.getImgUrl(fileName)).thenReturn(imageUrl);
 
+        // when
         MemberResponseDto memberResponseDto = memberService.updateMemberProfile(userId, updateMemberRequestDto);
 
         // then
-        assertNotNull(updateMemberRequestDto);
-        assertEquals("test22", updateMemberRequestDto.getNickName());
-        assertEquals(1996, updateMemberRequestDto.getBirthYear());
-        assertEquals(Gender.FEMALE, updateMemberRequestDto.getGender());
-        assertEquals(Region.CHUNGBUK, updateMemberRequestDto.getActivityRegion());
-
         verify(memberRepository, times(1)).findById(userId);
         verify(memberRepository, times(1)).save(mockMemberEntity);
+
+        assertEquals("test22", memberResponseDto.getNickName());
+        assertEquals(1996, memberResponseDto.getBirthYear());
+        assertEquals(Gender.FEMALE, memberResponseDto.getGender());
+        assertEquals(Region.CHUNGBUK, memberResponseDto.getActivityRegion());
+        assertEquals(imageUrl, memberResponseDto.getImageUrl());
     }
 
     @Test


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제

### 이 PR에서 변경된 사항
- MemberService의 updateMemberProfile 메서드 동작시 프로필 이미지가 있는 경우 업데이트하도록 설정
- UpdateMemberRequestDto에 MultipartFile profileImage 추가
- updateMemberProfile Test 코드 수정

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [ ] API 테스트
