### PR TITLE
feat : Login/Logout-002 로그아웃 기능 추가 & 테스트 코드 작성

### DIFF
--- a/src/main/java/com/example/runningservice/controller/AuthController.java
+++ b/src/main/java/com/example/runningservice/controller/AuthController.java
@@ -33,5 +33,4 @@ public class AuthController {
         return ResponseEntity.ok(authService.refreshToken(refreshToken));
     }
 
-
 }

--- a/src/main/java/com/example/runningservice/controller/AuthController.java
+++ b/src/main/java/com/example/runningservice/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.example.runningservice.controller;
 import com.example.runningservice.dto.JwtResponse;
 import com.example.runningservice.dto.LoginRequestDto;
 import com.example.runningservice.service.AuthService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -28,9 +29,10 @@ public class AuthController {
 
     @PostMapping("/token/refresh")
     public ResponseEntity<JwtResponse> refreshToken(
-        @RequestHeader(name = "Authorization") String refreshToken) throws Exception {
+        @RequestHeader(name = "Authorization") String refreshToken, Principal principal)
+        throws Exception {
         refreshToken = refreshToken.replace("Bearer ", "");
-        return ResponseEntity.ok(authService.refreshToken(refreshToken));
+        return ResponseEntity.ok(authService.refreshToken(refreshToken, principal));
     }
 
 }

--- a/src/main/java/com/example/runningservice/controller/LogoutController.java
+++ b/src/main/java/com/example/runningservice/controller/LogoutController.java
@@ -1,0 +1,28 @@
+package com.example.runningservice.controller;
+
+import com.example.runningservice.service.LogoutService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class LogoutController {
+
+    private final LogoutService logoutService;
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@RequestHeader("Authorization") String refreshToken,
+        Authentication authentication,
+        HttpServletRequest request) {
+
+        logoutService.logout(request, null, authentication);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/runningservice/dto/CustomErrorResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/CustomErrorResponseDto.java
@@ -1,0 +1,9 @@
+package com.example.runningservice.dto;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class CustomErrorResponseDto {
+    private String errorCode;
+    private String message;
+}

--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -6,11 +6,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "토큰이 만료되었습니다."),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "토큰이 만료되었거나 사용자가 유효하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "사용 불가한 토큰입니다."),
     UNABLE_TO_GET_TOKEN(HttpStatus.BAD_REQUEST, "발급된 토큰이 없습니다."),
     CHECK_HEADER_BEARER(HttpStatus.BAD_REQUEST, "토큰의 접두사를 확인하세요."),
-    INVALID_LOGIN(HttpStatus.BAD_REQUEST, "잘못된 아이디 또는 비밀번호입니다."),
+    INVALID_LOGIN(HttpStatus.BAD_REQUEST, "사용자의 비밀번호가 일치하지 않습니다."),
     ALREADY_EXIST_LOGINID(HttpStatus.BAD_REQUEST, "이미 존재하는 아이디입니다."),
     NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."),
     ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "해당 이메일로 가입한 내역이 있습니다."),
@@ -19,7 +19,6 @@ public enum ErrorCode {
     FAILED_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "잘못된 인증코드입니다."),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "인증되지 않은 이메일 입니다."),
-    // 추가
     ENCRYPTION_ERROR(HttpStatus.BAD_REQUEST, ""),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     NOT_FOUND_CREW(HttpStatus.BAD_REQUEST, "크루를 찾을 수 없습니다.");

--- a/src/main/java/com/example/runningservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/runningservice/exception/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package com.example.runningservice.exception;
 
+import com.example.runningservice.dto.CustomErrorResponseDto;
 import com.example.runningservice.dto.NotValidResponseDto;
 import com.example.runningservice.dto.UnexpectedErrorResponseDto;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -29,7 +31,6 @@ public class GlobalExceptionHandler {
                 .field(fieldError.getField())
                 .build());
         }
-
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(response);
@@ -50,5 +51,18 @@ public class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(response);
+    }
+
+    // CustomException 예외 처리 핸들러
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<CustomErrorResponseDto> handleCustomException(CustomException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        CustomErrorResponseDto errorResponse = new CustomErrorResponseDto(
+            errorCode.name(),
+            errorCode.getMessage()
+        );
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(errorResponse);
     }
 }

--- a/src/main/java/com/example/runningservice/security/CustomUserDetails.java
+++ b/src/main/java/com/example/runningservice/security/CustomUserDetails.java
@@ -1,34 +1,40 @@
 package com.example.runningservice.security;
 
-import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.enums.Role;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+
 @RequiredArgsConstructor
+@AllArgsConstructor
 @Component
 public class CustomUserDetails implements UserDetails {
 
-    private MemberEntity memberEntity;
+    private String email;
+    private String password;
+    private List<Role> roles;
 
     @Override
     public String getPassword() {
-        return memberEntity.getPassword();
+        return password;
     }
 
     @Override
     public String getUsername() {
-        return memberEntity.getEmail();
+        return email;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return memberEntity.getRoles().stream()
-            .map(role -> new SimpleGrantedAuthority("ROLE_" + role.name()))
+        return roles.stream()
+            .map(role -> new SimpleGrantedAuthority(role.name()))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/example/runningservice/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/runningservice/security/CustomUserDetailsService.java
@@ -6,16 +6,10 @@ import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,15 +20,16 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        log.debug("Load user by username: {}", email);
+        log.debug("Loading user by email: {}", email);
         MemberEntity memberEntity = memberRepository.findByEmail(email)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+        //이메일 인증여부 확인
+        if (!memberEntity.isEmailVerified()) throw new CustomException(ErrorCode.INVALID_EMAIL);
 
-        List<GrantedAuthority> authorities = memberEntity.getRoles().stream()
-            .map(role -> new SimpleGrantedAuthority(role.name())).collect(Collectors.toList());
+        log.debug("User found: {}", email);
 
-        return User.builder().username(memberEntity.getEmail())
-            .password(memberEntity.getPassword()).authorities(authorities).build();
+        return new CustomUserDetails(memberEntity.getEmail(), memberEntity.getPassword(),
+            memberEntity.getRoles());
     }
 }
 

--- a/src/main/java/com/example/runningservice/security/SecurityConfig.java
+++ b/src/main/java/com/example/runningservice/security/SecurityConfig.java
@@ -61,8 +61,7 @@ public class SecurityConfig {
             .logout( // 로그아웃 성공 시 / 주소로 이동
                 (logoutConfig) -> logoutConfig
                     .logoutUrl("/logout")
-                    .addLogoutHandler(logoutService)
-                    .logoutSuccessUrl("/"))
+                    .addLogoutHandler(logoutService))
             // OAuth2 로그인 기능에 대한 여러 설정
             .oauth2Login(Customizer.withDefaults());
         return http.build();

--- a/src/main/java/com/example/runningservice/security/SecurityConfig.java
+++ b/src/main/java/com/example/runningservice/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.runningservice.security;
 
+import com.example.runningservice.service.LogoutService;
 import com.example.runningservice.service.OAuth2Service;
 import com.example.runningservice.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,7 @@ public class SecurityConfig {
     private final OAuth2Service oAuth2Service;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, LogoutService logoutService) throws Exception {
         http.authorizeHttpRequests(
                 request -> request.requestMatchers(
                         "/",
@@ -58,7 +59,10 @@ public class SecurityConfig {
             .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
             .formLogin(AbstractHttpConfigurer::disable)
             .logout( // 로그아웃 성공 시 / 주소로 이동
-                (logoutConfig) -> logoutConfig.logoutSuccessUrl("/"))
+                (logoutConfig) -> logoutConfig
+                    .logoutUrl("/logout")
+                    .addLogoutHandler(logoutService)
+                    .logoutSuccessUrl("/"))
             // OAuth2 로그인 기능에 대한 여러 설정
             .oauth2Login(Customizer.withDefaults());
         return http.build();

--- a/src/main/java/com/example/runningservice/service/AuthService.java
+++ b/src/main/java/com/example/runningservice/service/AuthService.java
@@ -2,12 +2,12 @@ package com.example.runningservice.service;
 
 import com.example.runningservice.dto.JwtResponse;
 import com.example.runningservice.dto.LoginRequestDto;
-import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
-import com.example.runningservice.repository.MemberRepository;
 import com.example.runningservice.security.CustomUserDetailsService;
 import com.example.runningservice.util.JwtUtil;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -18,9 +18,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -30,17 +27,8 @@ public class AuthService {
     private final CustomUserDetailsService customUserDetailsService;
     private final JwtUtil jwtUtil;
     private final BlackList blackList;
-    private final MemberRepository memberRepository;
 
     public JwtResponse authenticate(LoginRequestDto loginRequestDto) throws Exception {
-        //이메일 인증여부 확인
-        MemberEntity memberEntity = memberRepository.findByEmail(loginRequestDto.getEmail())
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
-
-        if (!memberEntity.isEmailVerified()) {
-            throw new CustomException(ErrorCode.INVALID_EMAIL);
-        }
-
         //loginId와 비밀번호 일치여부 확인 (불일치 시 예외 발생)
         try {
             Authentication authenticate = authenticationManager.authenticate(
@@ -54,7 +42,7 @@ public class AuthService {
         // 해당 이메일로 회원정보 가져오기
         final UserDetails userDetails = customUserDetailsService.loadUserByUsername(
             loginRequestDto.getEmail());
-        log.debug("UserService.loadUserByUsername(loginForm.getUsername()) successful");
+
         // 회원 권한 가져오기
         List<GrantedAuthority> authorities = new ArrayList<>(userDetails.getAuthorities());
         log.debug("Authorities : {}", authorities);
@@ -70,13 +58,13 @@ public class AuthService {
         if (blackList.isListed(refreshToken)) {
             throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
-        //토큰 유효성 검사(본인 확인)
-        String email = jwtUtil.extractEmail(refreshToken);
-        if (!jwtUtil.validateToken(email, refreshToken)) {
-            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        //토큰 유효성 검사(올바른 서명 & 유효기간)
+        if (jwtUtil.isTokenExpired(refreshToken)) {
+            throw new CustomException(ErrorCode.TOKEN_EXPIRED);
         }
 
         // 새로운 accessToken, refreshToken 생성
+        String email = jwtUtil.extractEmail(refreshToken);
         UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
         List<GrantedAuthority> authorities = new ArrayList<>(userDetails.getAuthorities());
         final String newAccessToken = jwtUtil.generateToken(email, authorities);

--- a/src/main/java/com/example/runningservice/service/LogoutService.java
+++ b/src/main/java/com/example/runningservice/service/LogoutService.java
@@ -1,0 +1,47 @@
+package com.example.runningservice.service;
+
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.security.CustomUserDetails;
+import com.example.runningservice.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LogoutService implements LogoutHandler {
+
+    private final BlackList blackList;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) {
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        String refreshToken = authHeader.substring("Bearer ".length());
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        if (!jwtUtil.validateToken(userDetails.getUsername(), refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        if (blackList.isListed(refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        blackList.add(refreshToken);
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/src/main/java/com/example/runningservice/util/JwtUtil.java
+++ b/src/main/java/com/example/runningservice/util/JwtUtil.java
@@ -6,7 +6,6 @@ import com.example.runningservice.enums.Role;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.security.SignatureException;
@@ -100,7 +99,7 @@ public class JwtUtil {
     }
 
     public boolean validateToken(String email, String token) {
-        boolean equals = extractAllClaims(token).getSubject().equals(email);
+        boolean equals = extractEmail(token).equals(email);
         log.debug("user email equals token owner email: {}", equals);
         return equals && !isTokenExpired(token);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,7 +39,6 @@ spring:
     path-match:
       matching-strategy: ant_path_matcher
 
-
 jasypt:
   encryptor:
     property:
@@ -64,8 +63,8 @@ aws:
     roleArn: ENC(itgAU5raT4FloGKQIkdq81aO8izs5lfRJ9Ri3H7aNKdiARVq+R9klghOjG7W1pErPL61M2UmocK19uIYwSdR+w==)
     
 mailgun:
-  domain: ENC(d2mRT2EIISaUsreQyOzXsTUMlpfbmx/dIAY9RHP0yPccGY2XecumaB1LgoWxpZAZ9+i/e/uDuEGbouY0YnPNpw==)
-  api-key: ENC(g+JyCVEQcZPt7OT8/HK6oXZ6HpE/blrkUdG7LwrIZZlKyhEf77c9THtfdp5bzDvf67SqeEQ4U1T3722TfIqFhA==)
+  domain: ENC(zPmaD0glNj5N1aCws5wE7zrwzIzdVqGk7sQ8g4kgtEYaSS9FQlDmrM2SuOXnLQ1/V/KUJbCCH1/4pFNzZoIrvQ==)
+  api-key: ENC(wQtu6ruB7EvprF3yegJ9Bo/BJs7CbsAP9VznEeabsnYwiMAVHXZGmcUP4MGLSF1N9KaL0CWy8Gk0x4fsBPlGjw==)
 
 logging:
   level:

--- a/src/test/java/com/example/runningservice/dto/SignupRequestDtoTest.java
+++ b/src/test/java/com/example/runningservice/dto/SignupRequestDtoTest.java
@@ -1,6 +1,7 @@
 package com.example.runningservice.dto;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Region;
@@ -11,7 +12,6 @@ import jakarta.validation.ValidatorFactory;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 class SignupRequestDtoTest {
 

--- a/src/test/java/com/example/runningservice/service/AuthServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/AuthServiceTest.java
@@ -1,0 +1,221 @@
+package com.example.runningservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.runningservice.dto.JwtResponse;
+import com.example.runningservice.dto.LoginRequestDto;
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.enums.Role;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.MemberRepository;
+import com.example.runningservice.security.CustomUserDetails;
+import com.example.runningservice.security.CustomUserDetailsService;
+import com.example.runningservice.util.JwtUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private BlackList blackList;
+
+    @Mock
+    private CustomUserDetails userDetails;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    void testAuthenticate_success() throws Exception {
+        // Given
+        LoginRequestDto loginRequestDto = new LoginRequestDto();
+        loginRequestDto.setEmail("test@example.com");
+        loginRequestDto.setPassword("password");
+
+        List<Role> roles = new ArrayList<>(List.of(Role.ROLE_USER));
+        List<GrantedAuthority> authorities = roles.stream()
+            .map(role -> new SimpleGrantedAuthority(role.name())).collect(Collectors.toList());
+        when(authenticationManager.authenticate(
+            any(UsernamePasswordAuthenticationToken.class))).thenReturn(authentication);
+        when(customUserDetailsService.loadUserByUsername(anyString())).thenReturn(
+            userDetails);
+        when(userDetails.getUsername()).thenReturn("test@example.com");
+        when(userDetails.getAuthorities()).thenAnswer(invocation -> authorities);
+        when(jwtUtil.generateToken("test@example.com", authorities)).thenReturn("access-token");
+        when(jwtUtil.generateRefreshToken("test@example.com", authorities)).thenReturn(
+            "refresh-token");
+
+        // When
+        JwtResponse jwtResponse = authService.authenticate(loginRequestDto);
+
+        // Then
+        assertNotNull(jwtResponse);
+        assertEquals("access-token", jwtResponse.getAccessJwt());
+        assertEquals("refresh-token", jwtResponse.getRefreshJwt());
+
+        verify(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
+        verify(customUserDetailsService).loadUserByUsername(anyString());
+        verify(jwtUtil).generateToken(anyString(), anyList());
+        verify(jwtUtil).generateRefreshToken(anyString(), anyList());
+    }
+
+    @Test
+    void testAuthenticate_EmailPasswordMisMatch() {
+        // given
+        LoginRequestDto loginRequestDto = new LoginRequestDto();
+        loginRequestDto.setEmail("test@example.com");
+        loginRequestDto.setPassword("wrong-password");
+
+        MemberEntity memberEntity = MemberEntity.builder()
+            .email("test@example.com")
+            .password(passwordEncoder.encode("correct-password"))
+            .build();
+
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+            .thenThrow(new BadCredentialsException("Invalid credentials"));
+
+        // When
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            authService.authenticate(loginRequestDto);
+        });
+        // Then
+        assertEquals(ErrorCode.INVALID_LOGIN, exception.getErrorCode());
+    }
+
+    @Test
+    void testAuthenticate_UserNotFound() {
+        // Given
+        LoginRequestDto loginRequestDto = new LoginRequestDto();
+        loginRequestDto.setEmail("nonexistent@example.com");
+        loginRequestDto.setPassword("password");
+
+        customUserDetailsService = new CustomUserDetailsService(memberRepository);
+
+        when(memberRepository.findByEmail(anyString())).thenReturn(Optional.empty());
+
+        try {
+            when(customUserDetailsService.loadUserByUsername(anyString())).thenCallRealMethod();
+        } catch (CustomException ex) {
+            assertEquals(ErrorCode.NOT_FOUND_USER, ex.getErrorCode());
+        }
+    }
+
+    @Test
+    void testAuthenticate_EmailNotVerified() {
+        // Given
+        LoginRequestDto loginRequestDto = new LoginRequestDto();
+        loginRequestDto.setEmail("test@example.com");
+        loginRequestDto.setPassword("password");
+
+        MemberEntity memberEntity = MemberEntity.builder()
+            .email("test@example.com")
+            .password(passwordEncoder.encode("password"))
+            .emailVerified(false)
+            .build();
+
+        when(memberRepository.findByEmail(anyString())).thenReturn(Optional.of(memberEntity));
+        customUserDetailsService = new CustomUserDetailsService(memberRepository);
+
+        try {
+            when(customUserDetailsService.loadUserByUsername(anyString())).thenCallRealMethod();
+        } catch (CustomException ex) {
+            assertEquals(ErrorCode.INVALID_EMAIL, ex.getErrorCode());
+        }
+    }
+
+    @Test
+    void testRefreshToken_success() throws Exception {
+        //given
+        String refreshToken = "refresh-token";
+
+        when(blackList.isListed(refreshToken)).thenReturn(false);
+        when(jwtUtil.isTokenExpired(refreshToken)).thenReturn(false);
+        when(jwtUtil.extractEmail(refreshToken)).thenReturn("test@example.com");
+        when(customUserDetailsService.loadUserByUsername("test@example.com")).thenReturn(userDetails);
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        when(jwtUtil.generateToken("test@example.com", authorities)).thenReturn("access-token");
+        when(jwtUtil.generateRefreshToken("test@example.com", authorities)).thenReturn("refresh-token");
+
+        //when
+        JwtResponse jwtResponse = authService.refreshToken(refreshToken);
+        //then
+        assertNotNull(jwtResponse);
+        assertEquals("refresh-token", jwtResponse.getRefreshJwt());
+        assertEquals("access-token", jwtResponse.getAccessJwt());
+        verify(blackList).isListed(refreshToken);
+    }
+
+    @Test
+    void testRefreshToken_BlacklistedToken() {
+        // Given
+        String refreshToken = "blacklisted-refresh-token";
+        when(blackList.isListed(refreshToken)).thenReturn(true);
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            authService.refreshToken(refreshToken);
+        });
+
+        assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, exception.getErrorCode());
+        verify(blackList).isListed(refreshToken);
+        verify(jwtUtil, never()).isTokenExpired(anyString());
+    }
+
+    @Test
+    void testRefreshToken_TokenExpired() {
+        // Given
+        String refreshToken = "expired-refresh-token";
+        when(blackList.isListed(refreshToken)).thenReturn(false);
+        when(jwtUtil.isTokenExpired(refreshToken)).thenReturn(true);
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            authService.refreshToken(refreshToken);
+        });
+
+        assertEquals(ErrorCode.TOKEN_EXPIRED, exception.getErrorCode());
+        verify(jwtUtil).isTokenExpired(refreshToken);
+    }
+}

--- a/src/test/java/com/example/runningservice/service/LogoutServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/LogoutServiceTest.java
@@ -1,0 +1,143 @@
+package com.example.runningservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.security.CustomUserDetails;
+import com.example.runningservice.util.JwtUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class LogoutServiceTest {
+
+    @Mock
+    private BlackList blackList;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private CustomUserDetails customUserDetails;
+
+    @InjectMocks
+    private LogoutService logoutService;
+
+    @Test
+    void testLogout_NullToken() {
+        //given
+        when(request.getHeader("Authorization")).thenReturn(null);
+        //when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> logoutService.logout(request, response, authentication));
+        //then
+        assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());
+    }
+
+    @Test
+    void testLogout_TokenNotStartingWithBearer() {
+        // given
+        when(request.getHeader("Authorization")).thenReturn("InvalidToken");
+
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> logoutService.logout(request, response, authentication));
+
+        // then
+        assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());
+    }
+
+    @Test
+    void testLogout_UserEmailTokenEmailMisMatch() {
+        //given
+        when(request.getHeader("Authorization")).thenReturn("Bearer validRefreshToken");
+        when(authentication.getPrincipal()).thenReturn(customUserDetails);
+        when(customUserDetails.getUsername()).thenReturn("username");
+        when(jwtUtil.validateToken("username", "validRefreshToken")).thenCallRealMethod();
+        Claims mockClaims = mock(Claims.class);
+        when(mockClaims.getSubject()).thenReturn("differentEmail");
+        when(jwtUtil.extractAllClaims("validRefreshToken")).thenReturn(mockClaims);
+
+        //when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> logoutService.logout(request, response, authentication));
+
+        //then
+        assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());
+    }
+
+    @Test
+    void testLogout_ExpiredToken() {
+        // given
+        when(request.getHeader("Authorization")).thenReturn("Bearer validRefreshToken");
+        when(authentication.getPrincipal()).thenReturn(customUserDetails);
+        when(customUserDetails.getUsername()).thenReturn("username");
+        when(jwtUtil.validateToken("username", "validRefreshToken")).thenCallRealMethod();
+        Claims mockClaims = mock(Claims.class);
+        when(mockClaims.getSubject()).thenReturn("username");
+        when(jwtUtil.extractAllClaims("validRefreshToken")).thenReturn(mockClaims);
+        when(jwtUtil.isTokenExpired("validRefreshToken")).thenReturn(true);
+
+        //when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> logoutService.logout(request, response, authentication));
+
+        //then
+        assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());
+    }
+
+    @Test
+    void testLogout_TokenAlreadyInBlacklist() {
+        when(request.getHeader("Authorization")).thenReturn("Bearer validRefreshToken");
+        when(authentication.getPrincipal()).thenReturn(customUserDetails);
+        when(customUserDetails.getUsername()).thenReturn("username");
+        when(jwtUtil.validateToken("username", "validRefreshToken")).thenReturn(true);
+        when(blackList.isListed("validRefreshToken")).thenReturn(true);
+
+        //when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> logoutService.logout(request, response, authentication));
+
+        //then
+        assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());
+    }
+
+    @Test
+    void testLogout_success() {
+        //given
+        when(request.getHeader("Authorization")).thenReturn("Bearer validRefreshToken");
+        when(authentication.getPrincipal()).thenReturn(customUserDetails);
+        when(customUserDetails.getUsername()).thenReturn("username");
+        when(jwtUtil.validateToken("username", "validRefreshToken")).thenReturn(true);
+        when(blackList.isListed("validRefreshToken")).thenReturn(false);
+
+        //when
+        logoutService.logout(request, response, authentication);
+
+        verify(blackList, times(1)).add("validRefreshToken");
+        assert (SecurityContextHolder.getContext().getAuthentication() == null);
+    }
+}


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 리프레시토큰을 블랙리스트에 저장하여 무효화함으로써 로그아웃 기능을 구현
- 성공케이스 및 다양한 실패 케이스 테스트
- 로그인, 로그아웃 구현한 코드 리팩토링

### 이 PR에서 변경된 사항
설정파일
- application.yml : mailgun key, domain 수정 로그인

AuthService
  - authenticate : 중복코드 제거 
    - memberRepository.findByEmail()이 authenticate와 loadUserByUsername()에서 중복되어 호출되고 있어 중복된 내용 제거함
    - CustomUserDetails에 필드(email, password, roles) 추가
    - CustomUserDetailsService 에서 CustomUserDetail을 반환하도록 수정
      - List<Role> -> List<GrantedAuthority>로 수정하는 코드를 제거함(CustomUserDetail의 getAuthority()로 통일)
      - 이메일 인증여부 검증 로직 추가 : findByEmail()의 결과값으로 검증 진행
  - refreshToken : 토큰 유효성 검사 수정
    - refreshToken 컨트롤러에 매개변수 추가(Principal principal)
    - refreshToken 서비스코드 메서드에 매개변수 추가(refrshToken(String refreshToken, Principal principal)
    - jwtUtil.validate(email, refreshToken) -> jwtUtil.isTokenExpired(refreshToken) -> jwtUtil.validate(email, refreshToken)
    - http request의 사용자 이메일과 refreshToken의 이메일이 다를 가능성이 없다고 판단하여 수정하였으나, 재수정
    - 토큰이 탈취되었을 경우 principal.getEmail()이 token 의 이메일과 다를 가능성 있음

예외처리
- GlobalExceptionHandler에 CustomException 핸들링하도록 구현
  - CustomErrorResponseDto를 반환하도록 함
  - jwtUtil의 extractAllClaims 메서드에서 예외처리 추가

로그아웃
- refresh 토큰을 블랙리스트에 저장하여 무효화하는 로직. 구현

JwtUtil 메서드 수정
- validateToken(String email, String token)
- extractAllClaims(token).getSub() -> extractEmail(token)

테스트
- 로그인 : 성공, 실패(비밀번호 불일치, 사용자 없음, 이메일 미인증)
- 토큰 갱신 : 성공, 실패(블랙리스트에 존재, 토큰 유효기간 만료)
- 로그아웃 : 성공, 실패(토큰 null, Bear없는 토큰, 사용자 이메일&토큰 이메일 불일치, 유효기간만료 토큰, 이미 blacklist에 저장)

### 참고 스크린샷

### 기타
- 로그아웃과 토큰 갱신에 사용되는 blackList는 Redis를 통해 확장시킬 수 있음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
