### PR TITLE
refactor : member profile 관련 코드 정리

### DIFF
--- a/src/main/java/com/example/runningservice/controller/MemberController.java
+++ b/src/main/java/com/example/runningservice/controller/MemberController.java
@@ -1,10 +1,6 @@
 package com.example.runningservice.controller;
 
-import com.example.runningservice.dto.*;
-import com.example.runningservice.dto.member.MemberResponseDto;
-import com.example.runningservice.dto.member.PasswordRequestDto;
-import com.example.runningservice.dto.member.ProfileVisibilityRequestDto;
-import com.example.runningservice.dto.member.UpdateMemberRequestDto;
+import com.example.runningservice.dto.member.*;
 import com.example.runningservice.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/runningservice/dto/member/DeleteRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/member/DeleteRequestDto.java
@@ -1,5 +1,6 @@
-package com.example.runningservice.dto;
+package com.example.runningservice.dto.member;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DeleteRequestDto {
+
+    @NotBlank
     private String password;
 }

--- a/src/main/java/com/example/runningservice/dto/member/PasswordRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/member/PasswordRequestDto.java
@@ -1,6 +1,9 @@
 package com.example.runningservice.dto.member;
 
 
+import com.example.runningservice.util.validator.PasswordMatches;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,8 +11,17 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@PasswordMatches(message = "새 비밀번호와 확인 비밀번호가 일치하지 않습니다.")
 public class PasswordRequestDto {
+
+    @NotBlank
     private String oldPassword;
+
+    //영문+숫자+특수문자 포함, 8~50자
+    @NotBlank
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@#$%^&+=!]).{8,50}$", message = "비밀번호는 영문, 숫자, 특수문자를 포함하여 8 ~ 50자 이내여야 합니다.")
     private String newPassword;
-    private String confirmPassword;
+
+    @NotBlank
+    private String confirmNewPassword;
 }

--- a/src/main/java/com/example/runningservice/dto/member/ProfileVisibilityResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/member/ProfileVisibilityResponseDto.java
@@ -1,4 +1,4 @@
-package com.example.runningservice.dto;
+package com.example.runningservice.dto.member;
 
 import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.enums.Visibility;

--- a/src/main/java/com/example/runningservice/dto/member/UpdateMemberRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/member/UpdateMemberRequestDto.java
@@ -11,8 +11,8 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor
 public class UpdateMemberRequestDto {
     private String nickName;
-    private Gender gender;
+    private int gender;
     private Integer birthYear;
-    private Region activityRegion;
+    private String activityRegion;
     private MultipartFile profileImage;
 }

--- a/src/main/java/com/example/runningservice/entity/MemberEntity.java
+++ b/src/main/java/com/example/runningservice/entity/MemberEntity.java
@@ -110,10 +110,10 @@ public class MemberEntity extends BaseEntity {
     }
 
     public void updateProfileVisibility(
-        int nameVisibility, int phoneNumberVisibility, int genderVisibility, int birthYearVisibility) {
-        this.nameVisibility = Visibility.fromCode(nameVisibility);
-        this.phoneNumberVisibility = Visibility.fromCode(phoneNumberVisibility);
-        this.genderVisibility = Visibility.fromCode(genderVisibility);
-        this.birthYearVisibility = Visibility.fromCode(birthYearVisibility);
+        Visibility nameVisibility, Visibility phoneNumberVisibility, Visibility genderVisibility, Visibility birthYearVisibility) {
+        this.nameVisibility = nameVisibility;
+        this.phoneNumberVisibility = phoneNumberVisibility;
+        this.genderVisibility = genderVisibility;
+        this.birthYearVisibility = birthYearVisibility;
     }
 }

--- a/src/main/java/com/example/runningservice/repository/MemberRepository.java
+++ b/src/main/java/com/example/runningservice/repository/MemberRepository.java
@@ -1,6 +1,8 @@
 package com.example.runningservice.repository;
 
 import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,4 +16,8 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
     boolean existsByPhoneNumber(String encryptedPhoneNumber);
 
+    default MemberEntity findMemberById(Long userId) {
+        return findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+    }
 }

--- a/src/main/java/com/example/runningservice/service/MemberService.java
+++ b/src/main/java/com/example/runningservice/service/MemberService.java
@@ -1,11 +1,10 @@
 package com.example.runningservice.service;
 
-import com.example.runningservice.dto.*;
-import com.example.runningservice.dto.member.MemberResponseDto;
-import com.example.runningservice.dto.member.PasswordRequestDto;
-import com.example.runningservice.dto.member.ProfileVisibilityRequestDto;
-import com.example.runningservice.dto.member.UpdateMemberRequestDto;
+import com.example.runningservice.dto.member.*;
 import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.Region;
+import com.example.runningservice.enums.Visibility;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.MemberRepository;
@@ -29,33 +28,27 @@ public class MemberService {
     private final S3FileUtil s3FileUtil;
 
     // 사용자 정보 조회
-    public MemberResponseDto getMemberProfile(Long user_id) throws Exception {
-        MemberEntity memberEntity = memberRepository.findById(user_id)
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
-
+    @Transactional
+    public MemberResponseDto getMemberProfile(Long userId) throws Exception {
+        MemberEntity memberEntity = memberRepository.findMemberById(userId);
         return MemberResponseDto.of(memberEntity, aesUtil);
     }
 
     // 사용자 정보 수정
     @Transactional
-    public MemberResponseDto updateMemberProfile(
-        Long user_id, UpdateMemberRequestDto updateMemberRequestDto) throws Exception {
+    public MemberResponseDto updateMemberProfile(Long userId,
+                                                 UpdateMemberRequestDto updateMemberRequestDto) throws Exception {
+        MemberEntity memberEntity = memberRepository.findMemberById(userId);
 
-        MemberEntity memberEntity = memberRepository.findById(user_id)
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+        // 프로필 이미지 업로드
+        profileImageUploadHandler(updateMemberRequestDto.getProfileImage(), userId, memberEntity);
 
-        // 프로필 이미지가 있는 경우
-        MultipartFile profileImage = updateMemberRequestDto.getProfileImage();
-        if (profileImage != null && !profileImage.isEmpty()) {
-            String fileName = "user-" + user_id;
-            s3FileUtil.putObject(fileName, profileImage);
-            String imageUrl = s3FileUtil.getImgUrl(fileName);
-            memberEntity.updateProfileImageUrl(imageUrl);
-        }
-
-        memberEntity.updateMemberProfile(updateMemberRequestDto.getNickName(),
-            updateMemberRequestDto.getBirthYear(), updateMemberRequestDto.getGender(),
-            updateMemberRequestDto.getActivityRegion());
+        memberEntity.updateMemberProfile(
+            updateMemberRequestDto.getNickName(),
+            updateMemberRequestDto.getBirthYear(),
+            Gender.fromCode(updateMemberRequestDto.getGender()),
+            Region.valueOf(updateMemberRequestDto.getActivityRegion())
+        );
 
         memberRepository.save(memberEntity);
 
@@ -64,22 +57,12 @@ public class MemberService {
 
     // 비밀번호 변경
     @Transactional
-    public void updateMemberPassword(Long user_id, PasswordRequestDto passwordRequestDto) {
-        MemberEntity memberEntity = memberRepository.findById(user_id)
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+    public void updateMemberPassword(Long userId, PasswordRequestDto passwordRequestDto) {
+        MemberEntity memberEntity = memberRepository.findMemberById(userId);
 
         try {
             // 저장된 비밀번호화 입력한 oldPassword가 일치하는지 확인
-            if (!passwordEncoder.matches(passwordRequestDto.getOldPassword(),
-                memberEntity.getPassword())) {
-                throw new CustomException(ErrorCode.INVALID_PASSWORD);
-            }
-
-            // 새 비밀번호 확인
-            if (!passwordRequestDto.getNewPassword()
-                .equals(passwordRequestDto.getConfirmPassword())) {
-                throw new CustomException(ErrorCode.INVALID_PASSWORD);
-            }
+            validateOldPassword(passwordRequestDto.getOldPassword(), memberEntity.getPassword());
 
             // 새 비밀번호 암호화하여 저장
             String encryptedNewPassword = aesUtil.encrypt(passwordRequestDto.getNewPassword());
@@ -93,17 +76,17 @@ public class MemberService {
     }
 
     // 사용자 프로필 공개여부 설정
-    public ProfileVisibilityResponseDto updateProfileVisibility(Long user_id,
+    @Transactional
+    public ProfileVisibilityResponseDto updateProfileVisibility(Long userId,
                                                                 ProfileVisibilityRequestDto profileVisibilityRequestDto) {
-        MemberEntity memberEntity = memberRepository.findById(user_id)
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+        MemberEntity memberEntity = memberRepository.findMemberById(userId);
 
         // 프로필 공개여부 설정
         memberEntity.updateProfileVisibility(
-            profileVisibilityRequestDto.getUserName(),
-            profileVisibilityRequestDto.getPhoneNumber(),
-            profileVisibilityRequestDto.getGender(),
-            profileVisibilityRequestDto.getBirthYear());
+            Visibility.fromCode(profileVisibilityRequestDto.getUserName()),
+            Visibility.fromCode(profileVisibilityRequestDto.getPhoneNumber()),
+            Visibility.fromCode(profileVisibilityRequestDto.getGender()),
+            Visibility.fromCode(profileVisibilityRequestDto.getBirthYear()));
 
         memberRepository.save(memberEntity);
 
@@ -111,21 +94,38 @@ public class MemberService {
     }
 
     // 회원 탈퇴
-    public void deleteMember(Long user_id, DeleteRequestDto deleteRequestDto) {
-        MemberEntity memberEntity = memberRepository.findById(user_id)
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+    @Transactional
+    public void deleteMember(Long userId, DeleteRequestDto deleteRequestDto) {
+        MemberEntity memberEntity = memberRepository.findMemberById(userId);
 
         try {
             // 저장된 비밀번호화 입력한 oldPassword가 일치하는지 확인
-            if (!passwordEncoder.matches(deleteRequestDto.getPassword(),
-                memberEntity.getPassword())) {
-                throw new CustomException(ErrorCode.INVALID_PASSWORD);
-            }
+            validateOldPassword(deleteRequestDto.getPassword(), memberEntity.getPassword());
+
             // 회원 탈퇴
             memberRepository.delete(memberEntity);
         } catch (Exception e) {
             throw new CustomException(ErrorCode.ENCRYPTION_ERROR);
         }
     }
+
+    // 이미지 업데이트
+    private void profileImageUploadHandler(
+        MultipartFile profileImage, Long userId, MemberEntity memberEntity) {
+        if (profileImage != null && !profileImage.isEmpty()) {
+            String fileName = "user-" + userId;
+            s3FileUtil.putObject(fileName, profileImage);
+            String imageUrl = s3FileUtil.getImgUrl(fileName);
+            memberEntity.updateProfileImageUrl(imageUrl);
+        }
+    }
+
+    // 기존 비밀번호 확인
+    private void validateOldPassword(String oldPassword, String storedPassword) {
+        if (!passwordEncoder.matches(oldPassword, storedPassword)) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
+    }
+
 }
 

--- a/src/main/java/com/example/runningservice/util/validator/PasswordMatchesValidator.java
+++ b/src/main/java/com/example/runningservice/util/validator/PasswordMatchesValidator.java
@@ -1,6 +1,7 @@
 package com.example.runningservice.util.validator;
 
 import com.example.runningservice.dto.SignupRequestDto;
+import com.example.runningservice.dto.member.PasswordRequestDto;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
@@ -12,7 +13,13 @@ public class PasswordMatchesValidator implements ConstraintValidator<PasswordMat
 
     @Override
     public boolean isValid(Object obj, ConstraintValidatorContext context) {
-        SignupRequestDto signupRequestDto = (SignupRequestDto) obj;
-        return signupRequestDto.getPassword().equals(signupRequestDto.getConfirmPassword());
+        if (obj instanceof SignupRequestDto) {
+            SignupRequestDto signupRequestDto = (SignupRequestDto) obj;
+            return signupRequestDto.getPassword().equals(signupRequestDto.getConfirmPassword());
+        } else if (obj instanceof PasswordRequestDto) {
+            PasswordRequestDto passwordRequestDto = (PasswordRequestDto) obj;
+            return passwordRequestDto.getNewPassword().equals(passwordRequestDto.getConfirmNewPassword());
+        }
+        return false;
     }
 }


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제

### 이 PR에서 변경된 사항
- Dto에 필수 입력값에 대해 NotNull 어노테이션 적용
- PasswordRequestDto의 새 비밀번호 조건 설정 및 비밀번호 확인 validator 적용
- MemberService 중복되는 코드 분리, 이미지 업로드 코드 분리
- MemberEntity에 작성된 비즈니스 로직을 MemberService로 이동
- Profile과 관련된 Dto member package로 이동
- 변경된 사항에 맞게 test 코드 수정

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [ ] API 테스트
