### PR TITLE
Feat crew read 001 : 크루 조회

### DIFF
--- a/src/main/java/com/example/runningservice/controller/CrewController.java
+++ b/src/main/java/com/example/runningservice/controller/CrewController.java
@@ -1,18 +1,28 @@
 package com.example.runningservice.controller;
 
+import com.example.runningservice.dto.crew.CrewFilterDto.CrewInfo;
+import com.example.runningservice.dto.crew.CrewFilterDto.Participate;
 import com.example.runningservice.dto.crew.CrewRequestDto;
-import com.example.runningservice.dto.crew.CrewResponseDto;
+import com.example.runningservice.dto.crew.CrewRequestDto.Update;
 import com.example.runningservice.dto.crew.CrewResponseDto.CrewData;
+import com.example.runningservice.dto.crew.CrewResponseDto.Detail;
+import com.example.runningservice.dto.crew.CrewResponseDto.Summary;
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.OccupancyStatus;
+import com.example.runningservice.enums.Region;
 import com.example.runningservice.service.CrewService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,7 +36,7 @@ public class CrewController {
      * 크루 생성
      */
     @PostMapping
-    public ResponseEntity<CrewResponseDto.CrewData> createCrew(
+    public ResponseEntity<CrewData> createCrew(
         @Valid CrewRequestDto.Create request) {
         request.setLoginUserId(1L); // TODO: 현재 로그인 한 사용자 id로 설정
 
@@ -39,7 +49,7 @@ public class CrewController {
      * 크루 정보 수정
      */
     @PutMapping("/{crewId}")
-    public ResponseEntity<CrewData> updateCrew(@Valid CrewRequestDto.Update request,
+    public ResponseEntity<CrewData> updateCrew(@Valid Update request,
         @PathVariable("crewId") Long crewId) {
         request.setUpdateCrewId(crewId);
 
@@ -52,5 +62,53 @@ public class CrewController {
     @DeleteMapping("/{crewId}")
     public ResponseEntity<CrewData> deleteCrew(@PathVariable("crewId") Long crewId) {
         return ResponseEntity.ok(crewService.deleteCrew(crewId));
+    }
+
+    /**
+     * 크루 싱세 정보 조회
+     */
+    @GetMapping("/{crewId}")
+    public ResponseEntity<Detail> getCrew(@PathVariable("crewId") Long crewId) {
+        return ResponseEntity.ok(crewService.getCrew(crewId));
+    }
+
+    /**
+     * 참가 중인 크루 리스트 조회 (내가 만든 크루, 가입한 크루로 필터링하여 조회 가능)
+     */
+    @GetMapping("/participate")
+    public ResponseEntity<Summary> getParticipateCrewList(
+        @RequestParam(value = "filter", required = false) String filter,
+        Pageable pageable) {
+        Participate participate = Participate.builder()
+            .userId(1L)
+            .build();
+        participate.setFilter(filter);
+
+        return ResponseEntity.ok(crewService.getParticipateCrewList(participate, pageable));
+    }
+
+    /**
+     * 전체 크루 필터링 조회
+     */
+    @GetMapping
+    public ResponseEntity<Summary> getCrewList(
+        @RequestParam(value = "activityRegion", required = false) Region activityRegion,
+        @RequestParam(value = "minAge", required = false) Integer minAge,
+        @RequestParam(value = "maxAge", required = false) Integer maxAge,
+        @RequestParam(value = "gender", required = false) Gender gender,
+        @RequestParam(value = "runRecordPublic", required = false) Boolean runRecordPublic,
+        @RequestParam(value = "leaderRequired", required = false) Boolean leaderRequired,
+        @RequestParam(value = "occupancyStatus", required = false) OccupancyStatus occupancyStatus,
+        Pageable pageable
+    ) {
+        return ResponseEntity.ok(crewService.getCrewList(CrewInfo.builder()
+            .activityRegion(activityRegion)
+            .leaderRequired(leaderRequired)
+            .runRecordPublic(runRecordPublic)
+            .maxAge(maxAge)
+            .minAge(minAge)
+            .gender(gender)
+            .occupancyStatus(occupancyStatus)
+            .build(), pageable));
     }
 }

--- a/src/main/java/com/example/runningservice/dto/crew/CrewFilterDto.java
+++ b/src/main/java/com/example/runningservice/dto/crew/CrewFilterDto.java
@@ -1,0 +1,41 @@
+package com.example.runningservice.dto.crew;
+
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.OccupancyStatus;
+import com.example.runningservice.enums.ParticipateType;
+import com.example.runningservice.enums.Region;
+import java.util.Arrays;
+import lombok.Builder;
+import lombok.Getter;
+
+public class CrewFilterDto {
+
+    @Getter
+    @Builder
+    public static class Participate {
+
+        private Long userId;
+        private ParticipateType filter;
+
+        public void setFilter(String filter) {
+            if (filter != null && Arrays.stream(ParticipateType.values())
+                .map(Enum::name)
+                .anyMatch(name -> name.contains(filter))) {
+                this.filter = ParticipateType.valueOf(filter);
+            }
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class CrewInfo {
+
+        private Region activityRegion;
+        private Integer minAge;
+        private Integer maxAge;
+        private Gender gender;
+        private Boolean runRecordPublic;
+        private Boolean leaderRequired;
+        private OccupancyStatus occupancyStatus;
+    }
+}

--- a/src/main/java/com/example/runningservice/dto/crew/CrewResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/crew/CrewResponseDto.java
@@ -1,13 +1,32 @@
 package com.example.runningservice.dto.crew;
 
 import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Region;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 public class CrewResponseDto {
+
+    @AllArgsConstructor
+    @SuperBuilder
+    @Getter
+    public static class Summary {
+
+        List<CrewData> data;
+
+        public Summary() {
+            data = new ArrayList<>();
+        }
+
+        public void addCrew(CrewData crew) {
+            data.add(crew);
+        }
+    }
 
     @AllArgsConstructor
     @NoArgsConstructor
@@ -17,6 +36,7 @@ public class CrewResponseDto {
 
         private Long crewId;
         private String crewName;
+        private String crewImage;
         private String leader;
         private Integer crewCapacity;
         private Integer crewOccupancy;
@@ -30,10 +50,65 @@ public class CrewResponseDto {
                 .crewId(crewEntity.getCrewId())
                 .leader(nickname)
                 .crewName(crewEntity.getCrewName())
+                .crewImage(crewEntity.getCrewImage())
                 .crewCapacity(crewEntity.getCrewCapacity())
                 .crewOccupancy(occupancy)
                 .activityRegion(crewEntity.getActivityRegion())
                 .build();
         }
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @SuperBuilder
+    @Getter
+    public static class Detail extends CrewData {
+
+        private String description;
+        private int runningCount;
+        private Limit limit;
+
+        public static Detail fromEntity(CrewEntity crewEntity) {
+            return Detail.builder()
+                .crewId(crewEntity.getCrewId())
+                .crewName(crewEntity.getCrewName())
+                .crewImage(crewEntity.getCrewImage())
+                .description(crewEntity.getDescription())
+                .crewCapacity(crewEntity.getCrewCapacity())
+                .activityRegion(crewEntity.getActivityRegion())
+                .limit(Limit.builder()
+                    .gender(crewEntity.getGender())
+                    .leaderRequired(crewEntity.getLeaderRequired())
+                    .maxAge(crewEntity.getMaxAge())
+                    .minAge(crewEntity.getMinAge())
+                    .runRecordOpen(crewEntity.getRunRecordOpen())
+                    .build())
+                .build();
+        }
+
+        public void setLeaderName(String nickname) {
+            super.leader = nickname;
+        }
+
+        public void setCrewOccupancy(int occupancy) {
+            super.crewOccupancy = occupancy;
+        }
+
+        public void setRunningCount(int runningCount) {
+            this.runningCount = runningCount;
+        }
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @SuperBuilder
+    @Getter
+    public static class Limit {
+
+        private Gender gender;
+        private Integer minAge;
+        private Integer maxAge;
+        private boolean leaderRequired;
+        private boolean runRecordOpen;
     }
 }

--- a/src/main/java/com/example/runningservice/enums/OccupancyStatus.java
+++ b/src/main/java/com/example/runningservice/enums/OccupancyStatus.java
@@ -1,0 +1,18 @@
+package com.example.runningservice.enums;
+
+public enum OccupancyStatus {
+    FULL {
+        @Override
+        public boolean validateFullOrAvailable(int capacity, int occupancy) {
+            return capacity <= occupancy;
+        }
+    },
+    AVAILABLE {
+        @Override
+        public boolean validateFullOrAvailable(int capacity, int occupancy) {
+            return capacity > occupancy;
+        }
+    };
+
+    public abstract boolean validateFullOrAvailable(int capacity, int occupancy);
+}

--- a/src/main/java/com/example/runningservice/enums/ParticipateType.java
+++ b/src/main/java/com/example/runningservice/enums/ParticipateType.java
@@ -1,0 +1,13 @@
+package com.example.runningservice.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ParticipateType {
+    HOST(CrewRole.LEADER),
+    JOIN(CrewRole.MEMBER);
+
+    private final CrewRole crewRole;
+}

--- a/src/main/java/com/example/runningservice/repository/CrewMemberRepository.java
+++ b/src/main/java/com/example/runningservice/repository/CrewMemberRepository.java
@@ -1,7 +1,10 @@
 package com.example.runningservice.repository;
 
 import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.enums.CrewRole;
 import com.example.runningservice.enums.JoinStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +14,8 @@ public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Lo
     int countByCrew_CrewIdAndStatus(Long crewId, JoinStatus status);
 
     void deleteAllByCrew_CrewId(Long crewId);
+
+    Page<CrewMemberEntity> findByMember_IdAndRole(Long memberId, CrewRole role, Pageable pageable);
+
+    Page<CrewMemberEntity> findByMember_Id(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/example/runningservice/repository/CrewRepository.java
+++ b/src/main/java/com/example/runningservice/repository/CrewRepository.java
@@ -1,11 +1,29 @@
 package com.example.runningservice.repository;
 
 import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.Region;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CrewRepository extends JpaRepository<CrewEntity, Long> {
 
     boolean existsByCrewName(String crewName);
+
+    @Query("SELECT c FROM CrewEntity c "
+        + "WHERE (:region IS NULL OR c.activityRegion = :region) "
+        + "AND (:minAge IS NULL OR c.minAge <= :minAge) "
+        + "AND (:maxAge IS NULL OR c.maxAge >= :maxAge) "
+        + "AND (:gender IS NULL OR c.gender = :gender) "
+        + "AND (:runRecordPublic IS NULL OR c.runRecordOpen = :runRecordPublic) "
+        + "AND (:leaderRequired IS NULL OR c.leaderRequired = :leaderRequired) ")
+    Page<CrewEntity> findCrewList(@Param("region") Region activityRegion,
+        @Param("minAge") Integer minAge, @Param("maxAge") Integer maxAge,
+        @Param("gender") Gender gender, @Param("runRecordPublic") Boolean runRecordPublic,
+        @Param("leaderRequired") Boolean leaderRequired, Pageable pageable);
 }

--- a/src/main/java/com/example/runningservice/service/CrewService.java
+++ b/src/main/java/com/example/runningservice/service/CrewService.java
@@ -209,8 +209,9 @@ public class CrewService {
         for (CrewEntity crewEntity : crewList) {
             int occupancy = getCrewOccupancy(crewEntity.getCrewId());
 
-            if (crewFilter.getOccupancyStatus() == null ||
-                crewFilter.getOccupancyStatus().validateFullOrAvailable(
+            if (crewFilter.getOccupancyStatus() == null || // 인원 상태에 대한 조회 조건이 없거나,
+                crewEntity.getCrewCapacity() == null || // 크루에 정원 제한이 없거나,
+                crewFilter.getOccupancyStatus().validateFullOrAvailable( // 제한 조건에 부합하면 조회할 크루에 추가
                     crewEntity.getCrewCapacity(), occupancy)) {
 
                 summary.addCrew(CrewData.fromEntityAndLeaderNameAndOccupancy(crewEntity,

--- a/src/test/java/com/example/runningservice/service/CrewServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/CrewServiceTest.java
@@ -10,17 +10,26 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.example.runningservice.dto.crew.CrewRequestDto;
+import com.example.runningservice.dto.crew.CrewFilterDto.CrewInfo;
+import com.example.runningservice.dto.crew.CrewFilterDto.Participate;
 import com.example.runningservice.dto.crew.CrewRequestDto.Create;
 import com.example.runningservice.dto.crew.CrewRequestDto.Update;
 import com.example.runningservice.dto.crew.CrewResponseDto.CrewData;
+import com.example.runningservice.dto.crew.CrewResponseDto.Detail;
+import com.example.runningservice.dto.crew.CrewResponseDto.Summary;
 import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.CrewMemberEntity;
 import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.enums.CrewRole;
+import com.example.runningservice.enums.JoinStatus;
+import com.example.runningservice.enums.OccupancyStatus;
+import com.example.runningservice.enums.ParticipateType;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.repository.CrewMemberRepository;
 import com.example.runningservice.repository.CrewRepository;
 import com.example.runningservice.repository.MemberRepository;
 import com.example.runningservice.util.S3FileUtil;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +37,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -214,5 +228,172 @@ class CrewServiceTest {
         // then
         assertEquals(crewEntity.getCrewId(), response.getCrewId());
         verify(s3FileUtil, times(0)).deleteObject(anyString());
+    }
+
+    @Test
+    @DisplayName("크루 상세 조회_성공")
+    public void getCrew() {
+        Long crewId = 1L;
+
+        MemberEntity memberEntity = MemberEntity.builder().nickName("hi").build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(crewId)
+            .member(memberEntity)
+            .leaderRequired(true)
+            .runRecordOpen(true)
+            .build();
+
+        given(crewRepository.findById(crewId)).willReturn(Optional.of(crewEntity));
+        given(crewMemberRepository.countByCrew_CrewIdAndStatus(crewId,
+            JoinStatus.APPROVED)).willReturn(999);
+
+        Detail detail = crewService.getCrew(crewId);
+
+        assertEquals(detail.getLeader(), "hi");
+        verify(crewMemberRepository, times(1)).countByCrew_CrewIdAndStatus(
+            crewId, JoinStatus.APPROVED);
+        assertEquals(detail.getCrewOccupancy(), 999);
+    }
+
+    @Test
+    @DisplayName("참가 중인 크루 리스트 조회_Filter 없음")
+    public void getParticipateCrewList_NoFilter() {
+        Participate request = Participate.builder().userId(1L).build();
+        MemberEntity member = MemberEntity.builder().id(1L).build();
+        CrewEntity crew1 = CrewEntity.builder().crewId(5L).build();
+        CrewEntity crew2 = CrewEntity.builder().crewId(10L).build();
+
+        Pageable pageable = PageRequest.of(1, 2, Sort.by("createdAt").descending());
+        List<CrewMemberEntity> crewMembers = List.of(CrewMemberEntity.builder()
+                .crew(crew1)
+                .member(member)
+                .build(),
+            CrewMemberEntity.builder()
+                .crew(crew2)
+                .member(member)
+                .build());
+        Page<CrewMemberEntity> result = new PageImpl<>(crewMembers, pageable, crewMembers.size());
+
+        given(crewMemberRepository.findByMember_Id(1L, pageable)).willReturn(result);
+
+        Summary summary = crewService.getParticipateCrewList(request, pageable);
+
+        assertEquals(summary.getData().size(), 2);
+        assertEquals(summary.getData().get(0).getCrewId(), 5);
+        assertEquals(summary.getData().get(1).getCrewId(), 10);
+        verify(crewMemberRepository, never()).findByMember_IdAndRole(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("참가 중인 크루 리스트 조회_내가 만든 크루")
+    public void getParticipateCrewList_Host() {
+        Participate request = Participate.builder().userId(1L).filter(ParticipateType.HOST).build();
+        MemberEntity member = MemberEntity.builder().id(1L).build();
+        CrewEntity crew1 = CrewEntity.builder().crewId(5L).build();
+        CrewEntity crew2 = CrewEntity.builder().crewId(10L).build();
+
+        Pageable pageable = PageRequest.of(1, 2, Sort.by("createdAt").descending());
+        List<CrewMemberEntity> crewMembers = List.of(CrewMemberEntity.builder()
+                .crew(crew1)
+                .member(member)
+                .build(),
+            CrewMemberEntity.builder()
+                .crew(crew2)
+                .member(member)
+                .build());
+        Page<CrewMemberEntity> result = new PageImpl<>(crewMembers, pageable, crewMembers.size());
+
+        given(
+            crewMemberRepository.findByMember_IdAndRole(1L, CrewRole.LEADER, pageable)).willReturn(
+            result);
+
+        Summary summary = crewService.getParticipateCrewList(request, pageable);
+
+        assertEquals(summary.getData().size(), 2);
+        assertEquals(summary.getData().get(0).getCrewId(), 5);
+        assertEquals(summary.getData().get(1).getCrewId(), 10);
+        verify(crewMemberRepository, times(1)).findByMember_IdAndRole(1L, CrewRole.LEADER,
+            pageable);
+    }
+
+    @Test
+    @DisplayName("참가 중인 크루 리스트 조회_가입한 크루")
+    public void getParticipateCrewList_Join() {
+        Participate request = Participate.builder().userId(1L).filter(ParticipateType.JOIN).build();
+        MemberEntity member = MemberEntity.builder().id(1L).build();
+        CrewEntity crew1 = CrewEntity.builder().crewId(5L).build();
+        CrewEntity crew2 = CrewEntity.builder().crewId(10L).build();
+
+        Pageable pageable = PageRequest.of(1, 2, Sort.by("createdAt").descending());
+        List<CrewMemberEntity> crewMembers = List.of(CrewMemberEntity.builder()
+                .crew(crew1)
+                .member(member)
+                .build(),
+            CrewMemberEntity.builder()
+                .crew(crew2)
+                .member(member)
+                .build());
+        Page<CrewMemberEntity> result = new PageImpl<>(crewMembers, pageable, crewMembers.size());
+
+        given(
+            crewMemberRepository.findByMember_IdAndRole(1L, CrewRole.MEMBER, pageable)).willReturn(
+            result);
+
+        Summary summary = crewService.getParticipateCrewList(request, pageable);
+
+        assertEquals(summary.getData().size(), 2);
+        assertEquals(summary.getData().get(0).getCrewId(), 5);
+        assertEquals(summary.getData().get(1).getCrewId(), 10);
+        verify(crewMemberRepository, times(1)).findByMember_IdAndRole(1L, CrewRole.MEMBER,
+            pageable);
+    }
+
+    @Test
+    @DisplayName("전체 크루 조회_모집 마감 크루")
+    public void getCrewList_Full() {
+        CrewInfo crewInfo = CrewInfo.builder().occupancyStatus(OccupancyStatus.FULL).build();
+        Pageable pageable = PageRequest.of(1, 2);
+        MemberEntity member = MemberEntity.builder().id(1L).build();
+        CrewEntity crew1 = CrewEntity.builder().crewId(5L).member(member).crewCapacity(1).build();
+        CrewEntity crew2 = CrewEntity.builder().crewId(10L).member(member).crewCapacity(10).build();
+
+        List<CrewEntity> crewMembers = List.of(crew1, crew2);
+        Page<CrewEntity> result = new PageImpl<>(crewMembers, pageable, crewMembers.size());
+
+        given(crewMemberRepository.countByCrew_CrewIdAndStatus(crew1.getCrewId(),
+            JoinStatus.APPROVED)).willReturn(1);
+        given(crewMemberRepository.countByCrew_CrewIdAndStatus(crew2.getCrewId(),
+            JoinStatus.APPROVED)).willReturn(1);
+        given(crewRepository.findCrewList(any(), any(), any(), any(), any(), any(),
+            any())).willReturn(result);
+
+        Summary summary = crewService.getCrewList(crewInfo, pageable);
+
+        assertEquals(summary.getData().size(), 1);
+        assertEquals(summary.getData().get(0).getCrewId(), crew1.getCrewId());
+    }
+
+    @Test
+    @DisplayName("전체 크루 조회")
+    public void getCrewList() {
+        CrewInfo crewInfo = CrewInfo.builder().build();
+        Pageable pageable = PageRequest.of(1, 2);
+        MemberEntity member = MemberEntity.builder().id(1L).build();
+        CrewEntity crew1 = CrewEntity.builder().crewId(5L).member(member).crewCapacity(1).build();
+        CrewEntity crew2 = CrewEntity.builder().crewId(10L).member(member).crewCapacity(10).build();
+
+        List<CrewEntity> crewMembers = List.of(crew1, crew2);
+        Page<CrewEntity> result = new PageImpl<>(crewMembers, pageable, crewMembers.size());
+
+        given(crewMemberRepository.countByCrew_CrewIdAndStatus(crew1.getCrewId(),
+            JoinStatus.APPROVED)).willReturn(1);
+        given(crewMemberRepository.countByCrew_CrewIdAndStatus(crew2.getCrewId(),
+            JoinStatus.APPROVED)).willReturn(1);
+        given(crewRepository.findCrewList(any(), any(), any(), any(), any(), any(),
+            any())).willReturn(result);
+
+        Summary summary = crewService.getCrewList(crewInfo, pageable);
+
+        assertEquals(summary.getData().size(), 2);
     }
 }

--- a/src/test/java/com/example/runningservice/service/CrewServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/CrewServiceTest.java
@@ -28,6 +28,7 @@ import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.repository.CrewMemberRepository;
 import com.example.runningservice.repository.CrewRepository;
 import com.example.runningservice.repository.MemberRepository;
+import com.example.runningservice.service.chat.ChatRoomService;
 import com.example.runningservice.util.S3FileUtil;
 import java.util.List;
 import java.lang.reflect.Field;
@@ -58,6 +59,8 @@ class CrewServiceTest {
     private CrewMemberRepository crewMemberRepository;
     @Mock
     private S3FileUtil s3FileUtil;
+    @Mock
+    private ChatRoomService chatRoomService;
     @InjectMocks
     private CrewService crewService;
 
@@ -293,7 +296,7 @@ class CrewServiceTest {
         CrewEntity crew1 = CrewEntity.builder().crewId(5L).build();
         CrewEntity crew2 = CrewEntity.builder().crewId(10L).build();
 
-        Pageable pageable = PageRequest.of(1, 2, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(1, 2, Sort.by("member.createdAt").descending());
         List<CrewMemberEntity> crewMembers = List.of(CrewMemberEntity.builder()
                 .crew(crew1)
                 .member(member)
@@ -322,7 +325,7 @@ class CrewServiceTest {
         CrewEntity crew1 = CrewEntity.builder().crewId(5L).build();
         CrewEntity crew2 = CrewEntity.builder().crewId(10L).build();
 
-        Pageable pageable = PageRequest.of(1, 2, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(1, 2, Sort.by("member.createdAt").descending());
         List<CrewMemberEntity> crewMembers = List.of(CrewMemberEntity.builder()
                 .crew(crew1)
                 .member(member)
@@ -354,7 +357,7 @@ class CrewServiceTest {
         CrewEntity crew1 = CrewEntity.builder().crewId(5L).build();
         CrewEntity crew2 = CrewEntity.builder().crewId(10L).build();
 
-        Pageable pageable = PageRequest.of(1, 2, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(1, 2, Sort.by("member.createdAt").descending());
         List<CrewMemberEntity> crewMembers = List.of(CrewMemberEntity.builder()
                 .crew(crew1)
                 .member(member)


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 크루 리스트 조회, 상세 조회 기능 구현

### 이 PR에서 변경된 사항
- 참여중인 크루 중 내가 만든 크루와 가입한 크루를 구분하는 ParticipateType Enum을 추가하고 쿼리 조건으로 쓸 CrewRole을 지정
- 참여 가능한 크루를 조회하기 위해 크루 정원 상태를 구분하는OccupancyStatus Enum을 추가하고 데이터가 상태에 부합하는지 검증하는 추상 메서드 구현
- 상세 조회 및 리스트 조회에 필요한 ResponseDto 추가
- 상세 조회 / 참여 중인 크루 조회 / 조건별 전체 조회 API/서비스 로직 추가
- 크루 상세 조회 기능 구현
- filter별 참여중인 크루 조회 기능 구현
- 모집 상태별 전체 크루 조회 기능 구현
- 조회 서비스 테스트 코드 작성

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
