### PR TITLE
Crew 조회 - fix : 페이징 처리, 크루 조회 정렬

### DIFF
--- a/src/main/java/com/example/runningservice/dto/crew/CrewResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/crew/CrewResponseDto.java
@@ -17,7 +17,7 @@ public class CrewResponseDto {
     @Getter
     public static class Summary {
 
-        List<CrewData> data;
+        private List<CrewData> data;
 
         public Summary() {
             data = new ArrayList<>();
@@ -25,6 +25,10 @@ public class CrewResponseDto {
 
         public void addCrew(CrewData crew) {
             data.add(crew);
+        }
+
+        public int size() {
+            return data.size();
         }
     }
 

--- a/src/main/java/com/example/runningservice/repository/CrewRepository.java
+++ b/src/main/java/com/example/runningservice/repository/CrewRepository.java
@@ -3,8 +3,7 @@ package com.example.runningservice.repository;
 import com.example.runningservice.entity.CrewEntity;
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Region;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,9 +20,10 @@ public interface CrewRepository extends JpaRepository<CrewEntity, Long> {
         + "AND (:maxAge IS NULL OR c.maxAge >= :maxAge) "
         + "AND (:gender IS NULL OR c.gender = :gender) "
         + "AND (:runRecordPublic IS NULL OR c.runRecordOpen = :runRecordPublic) "
-        + "AND (:leaderRequired IS NULL OR c.leaderRequired = :leaderRequired) ")
-    Page<CrewEntity> findCrewList(@Param("region") Region activityRegion,
+        + "AND (:leaderRequired IS NULL OR c.leaderRequired = :leaderRequired) "
+        + "ORDER BY c.createdAt")
+    List<CrewEntity> findCrewList(@Param("region") Region activityRegion,
         @Param("minAge") Integer minAge, @Param("maxAge") Integer maxAge,
         @Param("gender") Gender gender, @Param("runRecordPublic") Boolean runRecordPublic,
-        @Param("leaderRequired") Boolean leaderRequired, Pageable pageable);
+        @Param("leaderRequired") Boolean leaderRequired);
 }

--- a/src/main/java/com/example/runningservice/service/CrewService.java
+++ b/src/main/java/com/example/runningservice/service/CrewService.java
@@ -27,7 +27,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -61,7 +60,7 @@ public class CrewService {
             .role(CrewRole.LEADER)
             .status(JoinStatus.APPROVED)
             .build());
-        
+
         // crew 채팅방 생성
         chatRoomService.createChatRoom(crewEntity.getCrewId(),
             crewEntity.getCrewName(), ChatRoom.CREW);
@@ -196,7 +195,6 @@ public class CrewService {
     /**
      * 전체 크루 필터링 조회
      */
-    @GetMapping
     public Summary getCrewList(CrewFilterDto.CrewInfo crewFilter, Pageable pageable) {
         List<CrewEntity> crewList = crewRepository.findCrewList(crewFilter.getActivityRegion(),
             crewFilter.getMinAge(), crewFilter.getMaxAge(), crewFilter.getGender(),

--- a/src/main/java/com/example/runningservice/service/CrewService.java
+++ b/src/main/java/com/example/runningservice/service/CrewService.java
@@ -19,6 +19,7 @@ import com.example.runningservice.repository.CrewRepository;
 import com.example.runningservice.repository.MemberRepository;
 import com.example.runningservice.service.chat.ChatRoomService;
 import com.example.runningservice.util.S3FileUtil;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -197,13 +198,13 @@ public class CrewService {
      */
     @GetMapping
     public Summary getCrewList(CrewFilterDto.CrewInfo crewFilter, Pageable pageable) {
-        Pageable customPageable = PageRequest.of(pageable.getPageNumber(),
-            pageable.getPageSize(),
-            Sort.by(Sort.Order.desc("member.createdAt")));
-
-        Page<CrewEntity> crewList = crewRepository.findCrewList(crewFilter.getActivityRegion(),
+        List<CrewEntity> crewList = crewRepository.findCrewList(crewFilter.getActivityRegion(),
             crewFilter.getMinAge(), crewFilter.getMaxAge(), crewFilter.getGender(),
-            crewFilter.getRunRecordPublic(), crewFilter.getLeaderRequired(), customPageable);
+            crewFilter.getRunRecordPublic(), crewFilter.getLeaderRequired());
+
+        int startIndex = pageable.getPageSize() * pageable.getPageNumber();
+        int endIndex = startIndex + pageable.getPageSize();
+        int curIndex = 0;
 
         Summary summary = new Summary();
         for (CrewEntity crewEntity : crewList) {
@@ -214,8 +215,14 @@ public class CrewService {
                 crewFilter.getOccupancyStatus().validateFullOrAvailable( // 제한 조건에 부합하면 조회할 크루에 추가
                     crewEntity.getCrewCapacity(), occupancy)) {
 
-                summary.addCrew(CrewData.fromEntityAndLeaderNameAndOccupancy(crewEntity,
-                    crewEntity.getMember().getNickName(), occupancy));
+                if (curIndex >= startIndex && curIndex < endIndex) {
+                    summary.addCrew(CrewData.fromEntityAndLeaderNameAndOccupancy(crewEntity,
+                        crewEntity.getMember().getNickName(), occupancy));
+                }
+                curIndex++;
+                if (curIndex >= endIndex) {
+                    break;
+                }
             }
         }
 

--- a/src/main/java/com/example/runningservice/service/CrewService.java
+++ b/src/main/java/com/example/runningservice/service/CrewService.java
@@ -174,7 +174,7 @@ public class CrewService {
         Pageable pageable) {
         Pageable customPageable = PageRequest.of(pageable.getPageNumber(),
             pageable.getPageSize(),
-            Sort.by(Sort.Order.desc("member.createdAt")));
+            Sort.by(Sort.Order.desc("joinedAt")));
         Summary summaryCrew = new Summary();
         Page<CrewMemberEntity> crewMemberEntities;
 

--- a/src/test/java/com/example/runningservice/service/CrewServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/CrewServiceTest.java
@@ -296,7 +296,7 @@ class CrewServiceTest {
         CrewEntity crew1 = CrewEntity.builder().crewId(5L).build();
         CrewEntity crew2 = CrewEntity.builder().crewId(10L).build();
 
-        Pageable pageable = PageRequest.of(1, 2, Sort.by("member.createdAt").descending());
+        Pageable pageable = PageRequest.of(1, 2, Sort.by("joinedAt").descending());
         List<CrewMemberEntity> crewMembers = List.of(CrewMemberEntity.builder()
                 .crew(crew1)
                 .member(member)
@@ -325,7 +325,7 @@ class CrewServiceTest {
         CrewEntity crew1 = CrewEntity.builder().crewId(5L).build();
         CrewEntity crew2 = CrewEntity.builder().crewId(10L).build();
 
-        Pageable pageable = PageRequest.of(1, 2, Sort.by("member.createdAt").descending());
+        Pageable pageable = PageRequest.of(1, 2, Sort.by("joinedAt").descending());
         List<CrewMemberEntity> crewMembers = List.of(CrewMemberEntity.builder()
                 .crew(crew1)
                 .member(member)
@@ -357,7 +357,7 @@ class CrewServiceTest {
         CrewEntity crew1 = CrewEntity.builder().crewId(5L).build();
         CrewEntity crew2 = CrewEntity.builder().crewId(10L).build();
 
-        Pageable pageable = PageRequest.of(1, 2, Sort.by("member.createdAt").descending());
+        Pageable pageable = PageRequest.of(1, 2, Sort.by("joinedAt").descending());
         List<CrewMemberEntity> crewMembers = List.of(CrewMemberEntity.builder()
                 .crew(crew1)
                 .member(member)

--- a/src/test/java/com/example/runningservice/service/CrewServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/CrewServiceTest.java
@@ -385,24 +385,23 @@ class CrewServiceTest {
     @DisplayName("전체 크루 조회_모집 마감 크루")
     public void getCrewList_Full() {
         CrewInfo crewInfo = CrewInfo.builder().occupancyStatus(OccupancyStatus.FULL).build();
-        Pageable pageable = PageRequest.of(1, 2);
+        Pageable pageable = PageRequest.of(0, 2);
         MemberEntity member = MemberEntity.builder().id(1L).build();
         CrewEntity crew1 = CrewEntity.builder().crewId(5L).member(member).crewCapacity(1).build();
         CrewEntity crew2 = CrewEntity.builder().crewId(10L).member(member).crewCapacity(10).build();
 
         List<CrewEntity> crewMembers = List.of(crew1, crew2);
-        Page<CrewEntity> result = new PageImpl<>(crewMembers, pageable, crewMembers.size());
 
         given(crewMemberRepository.countByCrew_CrewIdAndStatus(crew1.getCrewId(),
             JoinStatus.APPROVED)).willReturn(1);
         given(crewMemberRepository.countByCrew_CrewIdAndStatus(crew2.getCrewId(),
             JoinStatus.APPROVED)).willReturn(1);
-        given(crewRepository.findCrewList(any(), any(), any(), any(), any(), any(),
-            any())).willReturn(result);
+        given(crewRepository.findCrewList(any(), any(), any(), any(), any(), any()
+            )).willReturn(crewMembers);
 
         Summary summary = crewService.getCrewList(crewInfo, pageable);
 
-        assertEquals(summary.getData().size(), 1);
+        assertEquals(summary.size(), 1);
         assertEquals(summary.getData().get(0).getCrewId(), crew1.getCrewId());
     }
 
@@ -410,20 +409,19 @@ class CrewServiceTest {
     @DisplayName("전체 크루 조회")
     public void getCrewList() {
         CrewInfo crewInfo = CrewInfo.builder().build();
-        Pageable pageable = PageRequest.of(1, 2);
+        Pageable pageable = PageRequest.of(0, 2);
         MemberEntity member = MemberEntity.builder().id(1L).build();
         CrewEntity crew1 = CrewEntity.builder().crewId(5L).member(member).crewCapacity(1).build();
         CrewEntity crew2 = CrewEntity.builder().crewId(10L).member(member).crewCapacity(10).build();
 
         List<CrewEntity> crewMembers = List.of(crew1, crew2);
-        Page<CrewEntity> result = new PageImpl<>(crewMembers, pageable, crewMembers.size());
 
         given(crewMemberRepository.countByCrew_CrewIdAndStatus(crew1.getCrewId(),
             JoinStatus.APPROVED)).willReturn(1);
         given(crewMemberRepository.countByCrew_CrewIdAndStatus(crew2.getCrewId(),
             JoinStatus.APPROVED)).willReturn(1);
-        given(crewRepository.findCrewList(any(), any(), any(), any(), any(), any(),
-            any())).willReturn(result);
+        given(crewRepository.findCrewList(any(), any(), any(), any(), any(), any()
+            )).willReturn(crewMembers);
 
         Summary summary = crewService.getCrewList(crewInfo, pageable);
 


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 기존에 페이징해서 데이터를 불러온 다음 다시 필터링을 해서 리스트 크기가 작아지므로 페이지 크기를 유지하기 위해 전체를 불러온 다음 직접 페이징을 처리한다.
- 사용자가 가입한 크루를 조회할때, 사용자의 가입 날짜로 정렬되고 있어서 크루의 가입 날짜로 정렬하는 것으로 수정

### 이 PR에서 변경된 사항
**CrewService**
- 전체 데이터를 불러와서 후에 페이징
- 사용자가 가입한 크루 조회의 정렬 조건을 [크루 가입 날짜]로 수정

**CrewServiceTest**
- pageNumber가 0부터 시작하므로 0으로 변경
- findCrewList가 Page가 아닌 List를 리턴하도록 수정

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
