### PR TITLE
Feat resolver 001 : ArgumentResolver 생성

### DIFF
--- a/src/main/java/com/example/runningservice/controller/CrewController.java
+++ b/src/main/java/com/example/runningservice/controller/CrewController.java
@@ -11,6 +11,7 @@ import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.OccupancyStatus;
 import com.example.runningservice.enums.Region;
 import com.example.runningservice.service.CrewService;
+import com.example.runningservice.util.LoginUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -36,9 +37,9 @@ public class CrewController {
      * 크루 생성
      */
     @PostMapping
-    public ResponseEntity<CrewData> createCrew(
+    public ResponseEntity<CrewData> createCrew(@LoginUser Long userId,
         @Valid CrewRequestDto.Create request) {
-        request.setLoginUserId(1L); // TODO: 현재 로그인 한 사용자 id로 설정
+        request.setLoginUserId(userId);
 
         return ResponseEntity
             .status(HttpStatus.CREATED)

--- a/src/main/java/com/example/runningservice/controller/UserJoinController.java
+++ b/src/main/java/com/example/runningservice/controller/UserJoinController.java
@@ -1,0 +1,65 @@
+package com.example.runningservice.controller;
+
+import com.example.runningservice.dto.JoinApplyDto;
+import com.example.runningservice.dto.JoinApplyDto.SimpleResponse;
+import com.example.runningservice.dto.UpdateJoinRequestDto;
+import com.example.runningservice.service.UserJoinService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserJoinController {
+
+    private final UserJoinService userJoinService;
+
+    //가입신청
+    @PostMapping("crew/{crew_id}/join/apply")
+    public ResponseEntity<JoinApplyDto.DetailResponse> createJoinApplication(
+        @PathVariable("crew_id") Long crewId, @RequestHeader("Authorization") String token,
+        @RequestBody JoinApplyDto.Request joinRequestForm) {
+        return ResponseEntity.ok(userJoinService.saveJoinApply(crewId, joinRequestForm));
+    }
+
+    //가입신청내역 조회(사용자가 조회)
+    @GetMapping("user/{user_id}/join/apply/list")
+    public ResponseEntity<List<SimpleResponse>> getJoinApplicaations(
+        @RequestHeader("Authorization") String token, @PathVariable("user_id") Long userId) {
+        return ResponseEntity.ok(userJoinService.getJoinApplications(token, userId));
+    }
+
+    //가입신청내역 상세조회(사용자가 조회)
+    @GetMapping("user/{user_id}/join/apply")
+    public ResponseEntity<?> getJoinApplicationDetail(@PathVariable("user_id") Long userId,
+        @RequestHeader("Authorization") String token, @RequestParam Long joinApplyId) {
+
+        return ResponseEntity.ok(
+            userJoinService.getJoinApplicationDetail(token, userId, joinApplyId));
+    }
+
+    //아래 내용은 다음 PR에서 작성
+    //신청내역 수정
+    @PutMapping("user/{user_id}/join/apply")
+    public ResponseEntity<?> updateJoinRequest(@RequestParam Long crewId,
+        @RequestHeader("Authorization") String token,
+        @RequestBody UpdateJoinRequestDto updateJoinRequestDto) {
+        return null;
+    }
+
+    //크루 탈퇴
+    @DeleteMapping("/crew/{crew_id}/leave")
+    public ResponseEntity<?> leaveCrew(@PathVariable("crew_id") String crewId,
+        @RequestHeader("Authorization") String token) {
+        return null;
+    }
+}

--- a/src/main/java/com/example/runningservice/dto/JoinApplyDto.java
+++ b/src/main/java/com/example/runningservice/dto/JoinApplyDto.java
@@ -1,0 +1,65 @@
+package com.example.runningservice.dto;
+
+import com.example.runningservice.entity.JoinApplyEntity;
+import com.example.runningservice.enums.JoinStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+public class JoinApplyDto {
+
+    @Getter
+    @Builder
+    public static class Request {
+        @NotBlank
+        Long userId;
+        @Size(max = 100)
+        String message;
+    }
+
+    @Getter
+    @Builder
+    public static class SimpleResponse {
+        private String nickname;
+        private String crewName;
+        private JoinStatus status;
+        private LocalDateTime appliedAt;
+
+        public static SimpleResponse from(
+            JoinApplyEntity joinApplyEntity) {
+            return SimpleResponse.builder()
+                .nickname(joinApplyEntity.getMember().getNickName())
+                .crewName(joinApplyEntity.getCrew().getCrewName())
+                .status(joinApplyEntity.getStatus())
+                .appliedAt(joinApplyEntity.getCreatedAt())
+                .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class DetailResponse {
+        private String nickname;
+        private String crewName;
+        private JoinStatus status;
+        private String applyMessage;
+        private LocalDateTime appliedAt;
+
+        public static DetailResponse from(
+            JoinApplyEntity joinApplyEntity) {
+            return DetailResponse.builder()
+                .nickname(joinApplyEntity.getMember().getNickName())
+                .crewName(joinApplyEntity.getCrew().getCrewName())
+                .status(joinApplyEntity.getStatus())
+                .applyMessage(joinApplyEntity.getMessage())
+                .appliedAt(joinApplyEntity.getCreatedAt())
+                .build();
+        }
+    }
+
+
+
+}

--- a/src/main/java/com/example/runningservice/entity/BaseEntity.java
+++ b/src/main/java/com/example/runningservice/entity/BaseEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @SuperBuilder
+@Getter
 public class BaseEntity {
 
     @CreatedDate

--- a/src/main/java/com/example/runningservice/entity/JoinApplyEntity.java
+++ b/src/main/java/com/example/runningservice/entity/JoinApplyEntity.java
@@ -1,9 +1,7 @@
 package com.example.runningservice.entity;
 
-import com.example.runningservice.enums.CrewRole;
 import com.example.runningservice.enums.JoinStatus;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -11,27 +9,20 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
-import java.time.LocalDateTime;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.envers.AuditOverride;
 
+@Entity(name = "join_request")
 @Getter
-@AllArgsConstructor
+@SuperBuilder
 @NoArgsConstructor
-@Builder
-@Entity
-@Table(name = "crew_member", uniqueConstraints = {
-    @UniqueConstraint(columnNames = {"member_id", "crew_id"})
-})
-@EntityListeners(AuditingEntityListener.class)
-public class CrewMemberEntity {
-
+@AllArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+public class JoinApplyEntity extends BaseEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -41,18 +32,19 @@ public class CrewMemberEntity {
     @ManyToOne
     @JoinColumn(name = "crew_id")
     private CrewEntity crew;
-    @Enumerated(EnumType.STRING)
-    private CrewRole role;
-    @CreatedDate
-    private LocalDateTime joinedAt;
+    @NotNull
     @Enumerated(EnumType.STRING)
     private JoinStatus status;
-
-    public static CrewMemberEntity memberOf(MemberEntity member, CrewEntity crew) {
-        return CrewMemberEntity.builder()
+    private String message;
+    public static JoinApplyEntity of(MemberEntity member, CrewEntity crew, String message) {
+        return JoinApplyEntity.builder()
             .member(member)
             .crew(crew)
-            .role(CrewRole.MEMBER)
+            .message(message)
             .build();
+    }
+
+    public void markStatus(JoinStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -21,7 +21,18 @@ public enum ErrorCode {
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "인증되지 않은 이메일 입니다."),
     ENCRYPTION_ERROR(HttpStatus.BAD_REQUEST, ""),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    NOT_FOUND_CREW(HttpStatus.BAD_REQUEST, "크루를 찾을 수 없습니다.");
+    NOT_FOUND_CREW(HttpStatus.BAD_REQUEST, "크루를 찾을 수 없습니다."),
+    NOT_FOUND_APPLY(HttpStatus.BAD_REQUEST, "해당 신청내역을 찾을 수 없습니다."),
+
+    //크루가입
+    RECORD_OPEN_REQUIRED(HttpStatus.FORBIDDEN, "러닝 기록을 공개해야 합니다."),
+    GENDER_RESTRICTION_NOT_MET(HttpStatus.FORBIDDEN, "성별 제한을 충족하지 못했습니다."),
+    GENDER_REQUIRED(HttpStatus.FORBIDDEN, "가입을 위해 성별 정보가 필요합니다."),
+    AGE_RESTRICTION_NOT_MET(HttpStatus.FORBIDDEN, "나이 제한을 충족하지 못했습니다."),
+    AGE_REQUIRED(HttpStatus.FORBIDDEN, "가입을 위해 연령 정보가 필요합니다."),
+    //권한
+    UNAUTHORIZED_MY_APPLY_ACCESS(HttpStatus.FORBIDDEN, "잘못된 접근입니다. 자신의 가입 신청 내역만 조회할 수 있습니다.");
+
 
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/example/runningservice/repository/JoinApplicationRepository.java
+++ b/src/main/java/com/example/runningservice/repository/JoinApplicationRepository.java
@@ -1,0 +1,14 @@
+package com.example.runningservice.repository;
+
+import com.example.runningservice.entity.JoinApplyEntity;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JoinApplicationRepository extends JpaRepository<JoinApplyEntity, Long> {
+    List<JoinApplyEntity> findAllByMember_Id(Long memberId);
+    Optional<JoinApplyEntity> findByIdAndMember_Email(Long id, String email);
+    Optional<JoinApplyEntity> findByIdAndMember_Id(Long id, Long memberId);
+}

--- a/src/main/java/com/example/runningservice/security/CustomUserDetails.java
+++ b/src/main/java/com/example/runningservice/security/CustomUserDetails.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -17,6 +18,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class CustomUserDetails implements UserDetails {
 
+    @Getter
+    private Long id;
     private String email;
     private String password;
     private List<Role> roles;

--- a/src/main/java/com/example/runningservice/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/runningservice/security/CustomUserDetailsService.java
@@ -28,7 +28,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
         log.debug("User found: {}", email);
 
-        return new CustomUserDetails(memberEntity.getEmail(), memberEntity.getPassword(),
+        return new CustomUserDetails(memberEntity.getId(), memberEntity.getEmail(), memberEntity.getPassword(),
             memberEntity.getRoles());
     }
 }

--- a/src/main/java/com/example/runningservice/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/runningservice/security/JwtAuthenticationFilter.java
@@ -42,6 +42,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.info(String.format("[%s] -> %s ",
                     jwtUtil.extractEmail(accessJwt), request.getRequestURI())
             );
+            // LoginUserResolver에서 request를 통해 가져오기 위해 토큰에서 id를 가져와 저장한다.
+            request.setAttribute("loginId", jwtUtil.extractUserId(accessJwt));
         }
         log.info("Filtering request token: {}", accessJwt);
         log.info("authentication: {}", SecurityContextHolder.getContext().getAuthentication());

--- a/src/main/java/com/example/runningservice/security/LoginUserResolver.java
+++ b/src/main/java/com/example/runningservice/security/LoginUserResolver.java
@@ -1,0 +1,26 @@
+package com.example.runningservice.security;
+
+import com.example.runningservice.util.LoginUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginUserResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(LoginUser.class) != null;
+    }
+
+    @Override
+    public Long resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        return (Long) webRequest.getAttribute("loginId", RequestAttributes.SCOPE_REQUEST);
+    }
+}

--- a/src/main/java/com/example/runningservice/security/WebConfig.java
+++ b/src/main/java/com/example/runningservice/security/WebConfig.java
@@ -1,0 +1,15 @@
+package com.example.runningservice.security;
+
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginUserResolver());
+    }
+}

--- a/src/main/java/com/example/runningservice/service/UserJoinService.java
+++ b/src/main/java/com/example/runningservice/service/UserJoinService.java
@@ -1,0 +1,151 @@
+package com.example.runningservice.service;
+
+import com.example.runningservice.dto.JoinApplyDto;
+import com.example.runningservice.dto.JoinApplyDto.SimpleResponse;
+import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.entity.JoinApplyEntity;
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.JoinStatus;
+import com.example.runningservice.enums.Visibility;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.CrewMemberRepository;
+import com.example.runningservice.repository.CrewRepository;
+import com.example.runningservice.repository.JoinApplicationRepository;
+import com.example.runningservice.repository.MemberRepository;
+import com.example.runningservice.util.JwtUtil;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserJoinService {
+
+    private final JoinApplicationRepository joinApplicationRepository;
+    private final MemberRepository memberRepository;
+    private final CrewRepository crewRepository;
+    private final CrewMemberRepository crewMemberRepository;
+    private final JwtUtil jwtUtil;
+
+    //가입 승인 Off 일 시, 자동 가입되도록 구현해야 함. 가입상태 표시 & 크루원repository에 저장
+    @Transactional
+    public JoinApplyDto.DetailResponse saveJoinApply(Long crewId,
+        JoinApplyDto.Request joinRequestForm) {
+        MemberEntity memberEntity = memberRepository.findById(joinRequestForm.getUserId())
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        CrewEntity crewEntity = crewRepository.findById(crewId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW));
+
+        //멤버제한 조건 검증 : 성별(선택), 최소연령(선택), 최대연령(선택), 러닝기록 오픈여부
+        isJoinPossible(memberEntity, crewEntity);
+
+        //crew의 가입승인 필수여부 확인 & 가입승인 필수 아닐 시, 자동으로 가입
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.of(memberEntity, crewEntity,
+            joinRequestForm.getMessage());
+
+        if (!crewEntity.getLeaderRequired()) { // 가입 승인이 필요 없는 경우
+            // 가입 상태를 승인으로 설정
+            joinApplyEntity.markStatus(JoinStatus.APPROVED);
+
+            // 크루원으로 자동 가입 처리
+            CrewMemberEntity crewMemberEntity = CrewMemberEntity.memberOf(memberEntity, crewEntity);
+            crewMemberRepository.save(crewMemberEntity);
+        } else {
+            // 가입 승인이 필요한 경우
+            joinApplyEntity.markStatus(JoinStatus.PENDING);
+        }
+        // 엔티티 저장
+        JoinApplyEntity savedJoinApplyEntity = joinApplicationRepository.save(joinApplyEntity);
+
+        return JoinApplyDto.DetailResponse.from(savedJoinApplyEntity);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SimpleResponse> getJoinApplications(String token, Long memberId) {
+        token = token.substring("Bearer ".length());
+        if (!jwtUtil.validateToken(memberId, token)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_MY_APPLY_ACCESS);
+        }
+        // memberId 기준 가입신청 리스트 조회
+        return joinApplicationRepository.findAllByMember_Id(memberId).stream()
+            .map(SimpleResponse::from).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public JoinApplyDto.DetailResponse getJoinApplicationDetail(String token, Long userId,
+        Long joinApplyId) {
+        token = token.substring("Bearer ".length());
+        if (!jwtUtil.validateToken(userId, token)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_MY_APPLY_ACCESS);
+        }
+
+        // JoinApplyEntity 조회 시, joinRequestId가 잘못된 경우 (존재하지 않는 경우)
+        JoinApplyEntity joinApplyEntity = joinApplicationRepository.findByIdAndMember_Id(
+            joinApplyId, userId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_APPLY));
+
+        return JoinApplyDto.DetailResponse.from(joinApplyEntity);
+    }
+
+    private void isJoinPossible(MemberEntity memberEntity, CrewEntity crewEntity) {
+        Gender requiredGender = crewEntity.getGender();
+        Integer minAge = crewEntity.getMinAge();
+        Integer maxAge = crewEntity.getMaxAge();
+
+        // 나이 제한 있으면 검증
+        if (minAge != null || maxAge != null) {
+            //나이 검증
+            validateAge(memberEntity, crewEntity, minAge, maxAge);
+        }
+        // 성별 제한 있으면 검증
+        if (requiredGender != null) {
+            // 성별 검증
+            validateGender(memberEntity, crewEntity, requiredGender);
+        }
+        // Todo 기록 공개 여부 검증
+//        Boolean requireRecordOpen = crewEntity.getRunRecordOpen();
+//        if (requireRecordOpen && memberEntity.getRunRecordOpen().equals(Visibility.PUBLIC)) {
+//            throw new CustomException("가입 자격이 없습니다. 달리기 기록을 공개해야 합니다.");
+//        }
+    }
+
+    private void validateAge(MemberEntity memberEntity, CrewEntity crewEntity, Integer minAge,
+        Integer maxAge) {
+
+        if (minAge != null || maxAge != null) {
+            if (memberEntity.getBirthYear() == null || memberEntity.getBirthYearVisibility()
+                .equals(Visibility.PRIVATE)) {
+                throw new CustomException(ErrorCode.AGE_REQUIRED);
+            }
+
+            int memberAge = LocalDate.now().getYear() - memberEntity.getBirthYear() + 1;
+            if (minAge != null && memberAge < minAge) {
+                throw new CustomException(ErrorCode.AGE_RESTRICTION_NOT_MET);
+            }
+
+            if (maxAge != null && memberAge > maxAge) {
+                throw new CustomException(ErrorCode.AGE_RESTRICTION_NOT_MET);
+            }
+        }
+    }
+
+    private void validateGender(MemberEntity memberEntity, CrewEntity crewEntity,
+        Gender requiredGender) {
+        Gender memberGender = memberEntity.getGender();
+        Visibility memberGenderVisibility = memberEntity.getGenderVisibility();
+
+        if (requiredGender != null) {
+            if (memberGender == null || memberGenderVisibility.equals(Visibility.PRIVATE)) {
+                throw new CustomException(ErrorCode.GENDER_REQUIRED);
+            }
+            if (!memberGender.equals(requiredGender)) {
+                throw new CustomException(ErrorCode.GENDER_RESTRICTION_NOT_MET);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/runningservice/util/JwtUtil.java
+++ b/src/main/java/com/example/runningservice/util/JwtUtil.java
@@ -43,19 +43,20 @@ public class JwtUtil {
         SECRET_KEY = new SecretKeySpec(decodedKey, 0, decodedKey.length, "HmacSHA256");
     }
 
-    public String generateToken(String email, List<GrantedAuthority> authorities) {
-        return createToken(email, authorities, ACCESS_TOKEN_EXPIRATION);
+    public String generateToken(String email, Long userId, List<GrantedAuthority> authorities) {
+        return createToken(email, userId, authorities, ACCESS_TOKEN_EXPIRATION);
     }
 
-    public String generateRefreshToken(String email, List<GrantedAuthority> authorities) {
-        return createToken(email, authorities, REFRESH_TOKEN_EXPIRATION); // 7 days
+    public String generateRefreshToken(String email, Long userId,List<GrantedAuthority> authorities) {
+        return createToken(email, userId, authorities, REFRESH_TOKEN_EXPIRATION); // 7 days
     }
 
-    private String createToken(String username, List<GrantedAuthority> authorities,
+    private String createToken(String username, Long userId, List<GrantedAuthority> authorities,
         long expirationTime) {
         Map<String, Object> claims = new HashMap<>();
         claims.put("roles",
             authorities.stream().map(GrantedAuthority::getAuthority).collect(Collectors.toList()));
+        claims.put("userId", userId);
         return Jwts.builder().claims(claims).subject(username)
             .issuedAt(new Date(System.currentTimeMillis()))
             .expiration(new Date(System.currentTimeMillis() + expirationTime))
@@ -66,10 +67,7 @@ public class JwtUtil {
         log.debug("extract token: {}", token);
         try {
             log.debug("token: {}", token);
-            return Jwts.parser()
-                .verifyWith(SECRET_KEY)
-                .build()
-                .parseSignedClaims(token)
+            return Jwts.parser().verifyWith(SECRET_KEY).build().parseSignedClaims(token)
                 .getPayload();
         } catch (SignatureException e) {
             log.error("Invalid JWT signature: {}", e.getMessage());
@@ -93,6 +91,10 @@ public class JwtUtil {
         return extractAllClaims(token).getSubject();
     }
 
+    public Long extractUserId(String token) {
+        return extractAllClaims(token).get("userId", Long.class);
+    }
+
     public List<Role> extractRoles(String token) {
         List<String> roles = extractAllClaims(token).get("roles", List.class);
         return roles.stream().map(Role::valueOf).collect(Collectors.toList());
@@ -102,6 +104,10 @@ public class JwtUtil {
         boolean equals = extractEmail(token).equals(email);
         log.debug("user email equals token owner email: {}", equals);
         return equals && !isTokenExpired(token);
+    }
+
+    public boolean validateToken(Long id, String token) {
+        return extractUserId(token).equals(id) && !isTokenExpired(token);
     }
 
     public Authentication getAuthentication(String jwt) {

--- a/src/main/java/com/example/runningservice/util/LoginUser.java
+++ b/src/main/java/com/example/runningservice/util/LoginUser.java
@@ -1,0 +1,12 @@
+package com.example.runningservice.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+
+}

--- a/src/test/java/com/example/runningservice/service/AuthServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/AuthServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -87,8 +88,8 @@ class AuthServiceTest {
             userDetails);
         when(userDetails.getUsername()).thenReturn("test@example.com");
         when(userDetails.getAuthorities()).thenAnswer(invocation -> authorities);
-        when(jwtUtil.generateToken("test@example.com", authorities)).thenReturn("access-token");
-        when(jwtUtil.generateRefreshToken("test@example.com", authorities)).thenReturn(
+        when(jwtUtil.generateToken("test@example.com", userDetails.getId(), authorities)).thenReturn("access-token");
+        when(jwtUtil.generateRefreshToken("test@example.com", userDetails.getId(), authorities)).thenReturn(
             "refresh-token");
 
         // When
@@ -101,8 +102,8 @@ class AuthServiceTest {
 
         verify(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
         verify(customUserDetailsService).loadUserByUsername(anyString());
-        verify(jwtUtil).generateToken(anyString(), anyList());
-        verify(jwtUtil).generateRefreshToken(anyString(), anyList());
+        verify(jwtUtil).generateToken(anyString(), anyLong(), anyList());
+        verify(jwtUtil).generateRefreshToken(anyString(), anyLong(), anyList());
     }
 
     @Test
@@ -180,9 +181,11 @@ class AuthServiceTest {
         when(jwtUtil.extractEmail(refreshToken)).thenReturn("test@example.com");
         when(customUserDetailsService.loadUserByUsername("test@example.com")).thenReturn(userDetails);
         List<GrantedAuthority> authorities = new ArrayList<>();
-        when(jwtUtil.generateToken("test@example.com", authorities)).thenReturn("access-token");
-        when(jwtUtil.generateRefreshToken("test@example.com", authorities)).thenReturn("refresh-token");
+        when(jwtUtil.generateToken("test@example.com", userDetails.getId(), authorities)).thenReturn("access-token");
+        when(jwtUtil.generateRefreshToken("test@example.com", userDetails.getId(), authorities)).thenReturn("refresh-token");
         when(principal.getName()).thenReturn(principalEmail);
+        when(jwtUtil.validateToken(principalEmail, refreshToken)).thenCallRealMethod();
+        when(jwtUtil.isTokenExpired(refreshToken)).thenReturn(false);
         //when
         JwtResponse jwtResponse = authService.refreshToken(refreshToken, principal);
         //then

--- a/src/test/java/com/example/runningservice/service/UserJoinServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/UserJoinServiceTest.java
@@ -1,0 +1,620 @@
+package com.example.runningservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.runningservice.dto.JoinApplyDto;
+import com.example.runningservice.dto.JoinApplyDto.Request;
+import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.entity.JoinApplyEntity;
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.JoinStatus;
+import com.example.runningservice.enums.Visibility;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.CrewMemberRepository;
+import com.example.runningservice.repository.CrewRepository;
+import com.example.runningservice.repository.JoinApplicationRepository;
+import com.example.runningservice.repository.MemberRepository;
+import com.example.runningservice.util.JwtUtil;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserJoinServiceTest {
+
+    @InjectMocks
+    private UserJoinService userJoinService;
+
+    @Mock
+    private JoinApplicationRepository joinApplicationRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private CrewRepository crewRepository;
+
+    @Mock
+    private CrewMemberRepository crewMemberRepository;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Test
+    @DisplayName("승인없이 자동 가입")
+    void saveJoinApply_whenJoinPossible_thenSuccess() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1996)
+            .gender(Gender.MALE)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .leaderRequired(false)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            JoinApplyDto.Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+        // then
+        assertEquals(JoinStatus.APPROVED, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+        verify(crewMemberRepository, times(1)).save(any(CrewMemberEntity.class));
+    }
+
+    @Test
+    @DisplayName("승인 필요 시 승인대기상태로 저장")
+    void saveJoinApply_whenJoinPossible_thenSuccess_withPending() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1996)
+            .gender(Gender.MALE)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            JoinApplyDto.Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+
+    @Test
+    @DisplayName("나이제한 없음(성공)")
+    void saveJoinApply_whenJoinPossible_NoAgeLimit_thenSuccess() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1996)
+            .gender(Gender.MALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .gender(Gender.MALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            JoinApplyDto.Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+
+    @Test
+    @DisplayName("나이제한 하한만 있음(성공)")
+    void saveJoinApply_whenJoinPossible_OnlyMinAgeLimit_thenSuccess() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(2005)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .gender(Gender.MALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .minAge(20)
+            .gender(Gender.MALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            JoinApplyDto.Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+
+    @Test
+    @DisplayName("나이제한 상한만 있음")
+    void saveJoinApply_whenJoinPossible_OnlyMaxAgeLimit_thenSuccess() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1995)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .gender(Gender.MALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .maxAge(30)
+            .gender(Gender.MALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            JoinApplyDto.Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+
+    @Test
+    @DisplayName("성별제한 없음")
+    void saveJoinApply_whenJoinPossible_NoGenderLimit_thenSuccess() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1995)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .gender(Gender.FEMALE)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .maxAge(30)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            JoinApplyDto.Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+
+    @Test
+    @DisplayName("어떠한 제한도 없음")
+    void saveJoinApply_whenJoinPossible_NoLimit_thenSuccess() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            JoinApplyDto.Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+
+    @Test
+    @DisplayName("성별 불일치(실패)")
+    void saveJoinApply_whenJoinPossible_GenderLimit_Fail() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1995)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .gender(Gender.MALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .maxAge(30)
+            .gender(Gender.FEMALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> userJoinService.saveJoinApply(1L,
+                Request.builder()
+                    .userId(1L)
+                    .message("test")
+                    .build()));
+
+        // then
+        assertEquals(ErrorCode.GENDER_RESTRICTION_NOT_MET, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("나이제한 미충족(실패)")
+    void saveJoinApply_whenJoinPossible_AgeLimit_Fail() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1994)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .gender(Gender.FEMALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .maxAge(30)
+            .gender(Gender.FEMALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> userJoinService.saveJoinApply(1L,
+                Request.builder()
+                    .userId(1L)
+                    .message("test")
+                    .build()));
+
+        // then
+        assertEquals(ErrorCode.AGE_RESTRICTION_NOT_MET, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("회원나이 null(실패)")
+    void saveJoinApply_whenJoinPossible_MemberAgeNull_Fail() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(null)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .gender(Gender.FEMALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .maxAge(30)
+            .gender(Gender.FEMALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> userJoinService.saveJoinApply(1L,
+                Request.builder()
+                    .userId(1L)
+                    .message("test")
+                    .build()));
+
+        // then
+        assertEquals(ErrorCode.AGE_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("회원나이 비공개(실패)")
+    void saveJoinApply_whenJoinPossible_MemberPrivate_Fail() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1994)
+            .birthYearVisibility(Visibility.PRIVATE)
+            .gender(Gender.FEMALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .maxAge(30)
+            .gender(Gender.FEMALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> userJoinService.saveJoinApply(1L,
+                Request.builder()
+                    .userId(1L)
+                    .message("test")
+                    .build()));
+
+        // then
+        assertEquals(ErrorCode.AGE_REQUIRED, exception.getErrorCode());
+    }
+    @Test
+    @DisplayName("회원나이 비공개 & 나이제한 없음(성공)")
+    void saveJoinApply_whenJoinPossible_MemberAgePrivate_Success() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1994)
+            .birthYearVisibility(Visibility.PRIVATE)
+            .gender(Gender.FEMALE)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+
+    @Test
+    @DisplayName("회원나이 null 성공(나이제한 없음)")
+    void saveJoinApply_whenJoinPossible_MemberAgeNull_Success() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(null)
+            .birthYearVisibility(Visibility.PRIVATE)
+            .gender(Gender.FEMALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .gender(Gender.FEMALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+}


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- api를 호출하는 사용자를 조회하는 부분을 빠르게 하기 위해 ArgumentResolver 생성
- JwtFilter에서 토큰 검증이 완료되면 별도 검증없이 사용자 id를 불러올 수 있으므로 doFilter 내에서 로그인 Id를 저장한다.

### 이 PR에서 변경된 사항
- LoginUser 어노테이션, Resolver 생성
- JwtFilter에서 로그인 id 정보 request에 setAttribute
- WebConfig에서 LoginUSer Resolver 추가
- Crew 생성에서 테스트

### 기타
- 사용하려면 CrewController처럼 @,LoginUser Long userId를 쓰면 로그인한 사용자 id가 저장됩니다.
- 주현님 코드 pull 받아서 했더니 현재 같이 올라가 있는데 충돌되는 내용은 없습니다!

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [x] API 테스트
