### PR TITLE
Feat activity 001 : 정기러닝 생성/수정/삭제/조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'com.mashape.unirest:unirest-java:1.4.9'
     implementation 'org.apache.commons:commons-lang3:3.16.0'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     //jackson
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'

--- a/src/main/java/com/example/runningservice/aop/CrewRoleCheck.java
+++ b/src/main/java/com/example/runningservice/aop/CrewRoleCheck.java
@@ -1,0 +1,13 @@
+package com.example.runningservice.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CrewRoleCheck {
+
+    String role();
+}

--- a/src/main/java/com/example/runningservice/aop/CrewRoleCheck.java
+++ b/src/main/java/com/example/runningservice/aop/CrewRoleCheck.java
@@ -9,5 +9,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CrewRoleCheck {
 
-    String role();
+    String[] role();
 }

--- a/src/main/java/com/example/runningservice/aop/CrewRoleCheckAspect.java
+++ b/src/main/java/com/example/runningservice/aop/CrewRoleCheckAspect.java
@@ -1,0 +1,38 @@
+package com.example.runningservice.aop;
+
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.enums.CrewRole;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.CrewMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class CrewRoleCheckAspect {
+
+    private final CrewMemberRepository crewMemberRepository;
+
+    @Before("execution(* com.example.runningservice.controller..*(..)) && @annotation(crewRoleCheck)")
+    public void crewRoleCheckBeforeAccess(JoinPoint joinPoint, CrewRoleCheck crewRoleCheck) {
+        Object[] args = joinPoint.getArgs();
+
+        Long loginId = (Long) args[0];
+        Long crewId = (Long) args[1];
+
+        CrewMemberEntity crewMemberEntity = crewMemberRepository.findByCrew_CrewIdAndMember_Id(
+                crewId, loginId)
+            .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED_CREW_ACCESS));
+
+        if (crewRoleCheck.role().equals("leaderAndStaff")) {
+            if (crewMemberEntity.getRole().equals(CrewRole.MEMBER)) {
+                throw new CustomException(ErrorCode.UNAUTHORIZED_CREW_ACCESS);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/runningservice/aop/CrewRoleCheckAspect.java
+++ b/src/main/java/com/example/runningservice/aop/CrewRoleCheckAspect.java
@@ -5,6 +5,8 @@ import com.example.runningservice.enums.CrewRole;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.CrewMemberRepository;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
@@ -29,10 +31,11 @@ public class CrewRoleCheckAspect {
                 crewId, loginId)
             .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED_CREW_ACCESS));
 
-        if (crewRoleCheck.role().equals("leaderAndStaff")) {
-            if (crewMemberEntity.getRole().equals(CrewRole.MEMBER)) {
-                throw new CustomException(ErrorCode.UNAUTHORIZED_CREW_ACCESS);
-            }
+        List<CrewRole> allowList = Arrays.stream(crewRoleCheck.role()).map(CrewRole::valueOf)
+            .toList();
+
+        if (!allowList.contains(crewMemberEntity.getRole())) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_CREW_ACCESS);
         }
     }
 }

--- a/src/main/java/com/example/runningservice/config/AopConfig.java
+++ b/src/main/java/com/example/runningservice/config/AopConfig.java
@@ -1,0 +1,10 @@
+package com.example.runningservice.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@Configuration
+@EnableAspectJAutoProxy
+public class AopConfig {
+
+}

--- a/src/main/java/com/example/runningservice/controller/CrewController.java
+++ b/src/main/java/com/example/runningservice/controller/CrewController.java
@@ -11,6 +11,7 @@ import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.OccupancyStatus;
 import com.example.runningservice.enums.Region;
 import com.example.runningservice.service.CrewService;
+import com.example.runningservice.util.LoginUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -36,9 +37,9 @@ public class CrewController {
      * 크루 생성
      */
     @PostMapping
-    public ResponseEntity<CrewData> createCrew(
+    public ResponseEntity<CrewData> createCrew(@LoginUser Long userId,
         @Valid CrewRequestDto.Create request) {
-        request.setLoginUserId(1L); // TODO: 현재 로그인 한 사용자 id로 설정
+        request.setLoginUserId(userId);
 
         return ResponseEntity
             .status(HttpStatus.CREATED)

--- a/src/main/java/com/example/runningservice/controller/RegularRunController.java
+++ b/src/main/java/com/example/runningservice/controller/RegularRunController.java
@@ -1,0 +1,27 @@
+package com.example.runningservice.controller;
+
+import com.example.runningservice.dto.regular_run.RegularRunRequestDto;
+import com.example.runningservice.service.RegularRunService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RegularRunController {
+
+    private final RegularRunService regularRunService;
+
+    /**
+     * 크루의 정기러닝 생성
+     */
+    @PostMapping("/crew/{crewId}/regular")
+    public ResponseEntity<?> createRegularRun(@PathVariable("crewId") Long crewId,
+        @RequestBody RegularRunRequestDto request) {
+
+        return ResponseEntity.ok(regularRunService.createRegularRun(crewId, request));
+    }
+}

--- a/src/main/java/com/example/runningservice/controller/RegularRunController.java
+++ b/src/main/java/com/example/runningservice/controller/RegularRunController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,5 +24,16 @@ public class RegularRunController {
         @RequestBody RegularRunRequestDto request) {
 
         return ResponseEntity.ok(regularRunService.createRegularRun(crewId, request));
+    }
+
+    /**
+     * 크루의 정기러닝 수정
+     */
+    @PutMapping("/crew/{crewId}/regular/{regularId}")
+    public ResponseEntity<?> createRegularRun(@PathVariable("crewId") Long crewId,
+        @PathVariable("regularId") Long regularId,
+        @RequestBody RegularRunRequestDto request) {
+
+        return ResponseEntity.ok(regularRunService.updateRegularRun(regularId, request));
     }
 }

--- a/src/main/java/com/example/runningservice/controller/RegularRunController.java
+++ b/src/main/java/com/example/runningservice/controller/RegularRunController.java
@@ -1,7 +1,9 @@
 package com.example.runningservice.controller;
 
+import com.example.runningservice.aop.CrewRoleCheck;
 import com.example.runningservice.dto.regular_run.RegularRunRequestDto;
 import com.example.runningservice.service.RegularRunService;
+import com.example.runningservice.util.LoginUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,8 +21,10 @@ public class RegularRunController {
     /**
      * 크루의 정기러닝 생성
      */
+    @CrewRoleCheck(role = "leaderAndStaff")
     @PostMapping("/crew/{crewId}/regular")
-    public ResponseEntity<?> createRegularRun(@PathVariable("crewId") Long crewId,
+    public ResponseEntity<?> createRegularRun(@LoginUser Long loginId,
+        @PathVariable("crewId") Long crewId,
         @RequestBody RegularRunRequestDto request) {
 
         return ResponseEntity.ok(regularRunService.createRegularRun(crewId, request));
@@ -29,11 +33,14 @@ public class RegularRunController {
     /**
      * 크루의 정기러닝 수정
      */
+    @CrewRoleCheck(role = "leaderAndStaff")
     @PutMapping("/crew/{crewId}/regular/{regularId}")
-    public ResponseEntity<?> createRegularRun(@PathVariable("crewId") Long crewId,
+    public ResponseEntity<?> createRegularRun(@LoginUser Long loginId,
+        @PathVariable("crewId") Long crewId,
         @PathVariable("regularId") Long regularId,
         @RequestBody RegularRunRequestDto request) {
 
-        return ResponseEntity.ok(regularRunService.updateRegularRun(regularId, request));
+        return ResponseEntity.ok(
+            regularRunService.updateRegularRun(regularId, request));
     }
 }

--- a/src/main/java/com/example/runningservice/controller/RegularRunController.java
+++ b/src/main/java/com/example/runningservice/controller/RegularRunController.java
@@ -6,6 +6,7 @@ import com.example.runningservice.service.RegularRunService;
 import com.example.runningservice.util.LoginUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -42,5 +43,18 @@ public class RegularRunController {
 
         return ResponseEntity.ok(
             regularRunService.updateRegularRun(regularId, request));
+    }
+
+    /**
+     * 크루의 정기러닝 삭제
+     */
+    @CrewRoleCheck(role = {"LEADER","STAFF"})
+    @DeleteMapping("/crew/{crewId}/regular/{regularId}")
+    public ResponseEntity<?> deleteRegularRun(@LoginUser Long loginId,
+        @PathVariable("crewId") Long crewId,
+        @PathVariable("regularId") Long regularId) {
+
+        return ResponseEntity.ok(
+            regularRunService.deleteRegularRun(regularId));
     }
 }

--- a/src/main/java/com/example/runningservice/controller/RegularRunController.java
+++ b/src/main/java/com/example/runningservice/controller/RegularRunController.java
@@ -21,7 +21,7 @@ public class RegularRunController {
     /**
      * 크루의 정기러닝 생성
      */
-    @CrewRoleCheck(role = "leaderAndStaff")
+    @CrewRoleCheck(role = {"LEADER","STAFF"})
     @PostMapping("/crew/{crewId}/regular")
     public ResponseEntity<?> createRegularRun(@LoginUser Long loginId,
         @PathVariable("crewId") Long crewId,
@@ -33,7 +33,7 @@ public class RegularRunController {
     /**
      * 크루의 정기러닝 수정
      */
-    @CrewRoleCheck(role = "leaderAndStaff")
+    @CrewRoleCheck(role = {"LEADER","STAFF"})
     @PutMapping("/crew/{crewId}/regular/{regularId}")
     public ResponseEntity<?> createRegularRun(@LoginUser Long loginId,
         @PathVariable("crewId") Long crewId,

--- a/src/main/java/com/example/runningservice/controller/RegularRunController.java
+++ b/src/main/java/com/example/runningservice/controller/RegularRunController.java
@@ -1,12 +1,17 @@
 package com.example.runningservice.controller;
 
 import com.example.runningservice.aop.CrewRoleCheck;
+import com.example.runningservice.dto.regular_run.CrewRegularRunResponseDto;
 import com.example.runningservice.dto.regular_run.RegularRunRequestDto;
+import com.example.runningservice.dto.regular_run.RegularRunResponseDto;
 import com.example.runningservice.service.RegularRunService;
 import com.example.runningservice.util.LoginUser;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -22,9 +27,9 @@ public class RegularRunController {
     /**
      * 크루의 정기러닝 생성
      */
-    @CrewRoleCheck(role = {"LEADER","STAFF"})
+    @CrewRoleCheck(role = {"LEADER", "STAFF"})
     @PostMapping("/crew/{crewId}/regular")
-    public ResponseEntity<?> createRegularRun(@LoginUser Long loginId,
+    public ResponseEntity<RegularRunResponseDto> createRegularRun(@LoginUser Long loginId,
         @PathVariable("crewId") Long crewId,
         @RequestBody RegularRunRequestDto request) {
 
@@ -34,9 +39,9 @@ public class RegularRunController {
     /**
      * 크루의 정기러닝 수정
      */
-    @CrewRoleCheck(role = {"LEADER","STAFF"})
+    @CrewRoleCheck(role = {"LEADER", "STAFF"})
     @PutMapping("/crew/{crewId}/regular/{regularId}")
-    public ResponseEntity<?> createRegularRun(@LoginUser Long loginId,
+    public ResponseEntity<RegularRunResponseDto> createRegularRun(@LoginUser Long loginId,
         @PathVariable("crewId") Long crewId,
         @PathVariable("regularId") Long regularId,
         @RequestBody RegularRunRequestDto request) {
@@ -48,13 +53,39 @@ public class RegularRunController {
     /**
      * 크루의 정기러닝 삭제
      */
-    @CrewRoleCheck(role = {"LEADER","STAFF"})
+    @CrewRoleCheck(role = {"LEADER", "STAFF"})
     @DeleteMapping("/crew/{crewId}/regular/{regularId}")
-    public ResponseEntity<?> deleteRegularRun(@LoginUser Long loginId,
+    public ResponseEntity<RegularRunResponseDto> deleteRegularRun(@LoginUser Long loginId,
         @PathVariable("crewId") Long crewId,
         @PathVariable("regularId") Long regularId) {
 
         return ResponseEntity.ok(
             regularRunService.deleteRegularRun(regularId));
+    }
+
+    /**
+     * 크루별 정기러닝 정보 조회
+     */
+    @GetMapping("/crew/regular")
+    public ResponseEntity<List<CrewRegularRunResponseDto>> getRegularRunList(Pageable pageable) {
+        return ResponseEntity.ok(regularRunService.getRegularRunList(pageable));
+    }
+
+    /**
+     * 특정 크루 정기 러닝 정보 조회
+     */
+    @GetMapping("/crew/{crewId}/regular")
+    public ResponseEntity<CrewRegularRunResponseDto> getCrewRegularRunList(
+        @PathVariable("crewId") Long crewId, Pageable pageable) {
+        return ResponseEntity.ok(regularRunService.getCrewRegularRunList(crewId, pageable));
+    }
+
+    /**
+     * 특정 정기 러닝 정보 조회
+     */
+    @GetMapping("/crew/{crewId}/regular/{regularId}")
+    public ResponseEntity<RegularRunResponseDto> getRegularRun(
+        @PathVariable("crewId") Long crewId, @PathVariable("regularId") Long regularId) {
+        return ResponseEntity.ok(regularRunService.getRegularRun(regularId));
     }
 }

--- a/src/main/java/com/example/runningservice/controller/UserJoinController.java
+++ b/src/main/java/com/example/runningservice/controller/UserJoinController.java
@@ -1,0 +1,65 @@
+package com.example.runningservice.controller;
+
+import com.example.runningservice.dto.JoinApplyDto;
+import com.example.runningservice.dto.JoinApplyDto.SimpleResponse;
+import com.example.runningservice.dto.UpdateJoinRequestDto;
+import com.example.runningservice.service.UserJoinService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserJoinController {
+
+    private final UserJoinService userJoinService;
+
+    //가입신청
+    @PostMapping("crew/{crew_id}/join/apply")
+    public ResponseEntity<JoinApplyDto.DetailResponse> createJoinApplication(
+        @PathVariable("crew_id") Long crewId, @RequestHeader("Authorization") String token,
+        @RequestBody JoinApplyDto.Request joinRequestForm) {
+        return ResponseEntity.ok(userJoinService.saveJoinApply(crewId, joinRequestForm));
+    }
+
+    //가입신청내역 조회(사용자가 조회)
+    @GetMapping("user/{user_id}/join/apply/list")
+    public ResponseEntity<List<SimpleResponse>> getJoinApplicaations(
+        @RequestHeader("Authorization") String token, @PathVariable("user_id") Long userId) {
+        return ResponseEntity.ok(userJoinService.getJoinApplications(token, userId));
+    }
+
+    //가입신청내역 상세조회(사용자가 조회)
+    @GetMapping("user/{user_id}/join/apply")
+    public ResponseEntity<?> getJoinApplicationDetail(@PathVariable("user_id") Long userId,
+        @RequestHeader("Authorization") String token, @RequestParam Long joinApplyId) {
+
+        return ResponseEntity.ok(
+            userJoinService.getJoinApplicationDetail(token, userId, joinApplyId));
+    }
+
+    //아래 내용은 다음 PR에서 작성
+    //신청내역 수정
+    @PutMapping("user/{user_id}/join/apply")
+    public ResponseEntity<?> updateJoinRequest(@RequestParam Long crewId,
+        @RequestHeader("Authorization") String token,
+        @RequestBody UpdateJoinRequestDto updateJoinRequestDto) {
+        return null;
+    }
+
+    //크루 탈퇴
+    @DeleteMapping("/crew/{crew_id}/leave")
+    public ResponseEntity<?> leaveCrew(@PathVariable("crew_id") String crewId,
+        @RequestHeader("Authorization") String token) {
+        return null;
+    }
+}

--- a/src/main/java/com/example/runningservice/dto/JoinApplyDto.java
+++ b/src/main/java/com/example/runningservice/dto/JoinApplyDto.java
@@ -1,0 +1,65 @@
+package com.example.runningservice.dto;
+
+import com.example.runningservice.entity.JoinApplyEntity;
+import com.example.runningservice.enums.JoinStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+public class JoinApplyDto {
+
+    @Getter
+    @Builder
+    public static class Request {
+        @NotBlank
+        Long userId;
+        @Size(max = 100)
+        String message;
+    }
+
+    @Getter
+    @Builder
+    public static class SimpleResponse {
+        private String nickname;
+        private String crewName;
+        private JoinStatus status;
+        private LocalDateTime appliedAt;
+
+        public static SimpleResponse from(
+            JoinApplyEntity joinApplyEntity) {
+            return SimpleResponse.builder()
+                .nickname(joinApplyEntity.getMember().getNickName())
+                .crewName(joinApplyEntity.getCrew().getCrewName())
+                .status(joinApplyEntity.getStatus())
+                .appliedAt(joinApplyEntity.getCreatedAt())
+                .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class DetailResponse {
+        private String nickname;
+        private String crewName;
+        private JoinStatus status;
+        private String applyMessage;
+        private LocalDateTime appliedAt;
+
+        public static DetailResponse from(
+            JoinApplyEntity joinApplyEntity) {
+            return DetailResponse.builder()
+                .nickname(joinApplyEntity.getMember().getNickName())
+                .crewName(joinApplyEntity.getCrew().getCrewName())
+                .status(joinApplyEntity.getStatus())
+                .applyMessage(joinApplyEntity.getMessage())
+                .appliedAt(joinApplyEntity.getCreatedAt())
+                .build();
+        }
+    }
+
+
+
+}

--- a/src/main/java/com/example/runningservice/dto/crew/CrewResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/crew/CrewResponseDto.java
@@ -2,7 +2,6 @@ package com.example.runningservice.dto.crew;
 
 import com.example.runningservice.entity.CrewEntity;
 import com.example.runningservice.enums.Gender;
-import com.example.runningservice.enums.Region;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -40,7 +39,7 @@ public class CrewResponseDto {
         private String leader;
         private Integer crewCapacity;
         private Integer crewOccupancy;
-        private Region activityRegion;
+        private String activityRegion;
 
         public static CrewData fromEntityAndLeaderNameAndOccupancy(CrewEntity crewEntity,
             String nickname,
@@ -53,7 +52,7 @@ public class CrewResponseDto {
                 .crewImage(crewEntity.getCrewImage())
                 .crewCapacity(crewEntity.getCrewCapacity())
                 .crewOccupancy(occupancy)
-                .activityRegion(crewEntity.getActivityRegion())
+                .activityRegion(crewEntity.getActivityRegion().getRegionName())
                 .build();
         }
     }
@@ -75,7 +74,7 @@ public class CrewResponseDto {
                 .crewImage(crewEntity.getCrewImage())
                 .description(crewEntity.getDescription())
                 .crewCapacity(crewEntity.getCrewCapacity())
-                .activityRegion(crewEntity.getActivityRegion())
+                .activityRegion(crewEntity.getActivityRegion().getRegionName())
                 .limit(Limit.builder()
                     .gender(crewEntity.getGender())
                     .leaderRequired(crewEntity.getLeaderRequired())

--- a/src/main/java/com/example/runningservice/dto/crew/CrewResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/crew/CrewResponseDto.java
@@ -2,8 +2,10 @@ package com.example.runningservice.dto.crew;
 
 import com.example.runningservice.entity.CrewEntity;
 import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.Region;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -52,7 +54,9 @@ public class CrewResponseDto {
                 .crewImage(crewEntity.getCrewImage())
                 .crewCapacity(crewEntity.getCrewCapacity())
                 .crewOccupancy(occupancy)
-                .activityRegion(crewEntity.getActivityRegion().getRegionName())
+                .activityRegion(Optional.ofNullable(crewEntity.getActivityRegion())
+                    .map(Region::getRegionName)
+                    .orElse(null))
                 .build();
         }
     }
@@ -74,7 +78,9 @@ public class CrewResponseDto {
                 .crewImage(crewEntity.getCrewImage())
                 .description(crewEntity.getDescription())
                 .crewCapacity(crewEntity.getCrewCapacity())
-                .activityRegion(crewEntity.getActivityRegion().getRegionName())
+                .activityRegion(Optional.ofNullable(crewEntity.getActivityRegion())
+                    .map(Region::getRegionName)
+                    .orElse(null))
                 .limit(Limit.builder()
                     .gender(crewEntity.getGender())
                     .leaderRequired(crewEntity.getLeaderRequired())

--- a/src/main/java/com/example/runningservice/dto/regular_run/CrewRegularRunResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/regular_run/CrewRegularRunResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.runningservice.dto.regular_run;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CrewRegularRunResponseDto {
+
+    private Long crewId;
+    private List<RegularRunResponseDto> data;
+}

--- a/src/main/java/com/example/runningservice/dto/regular_run/RegularRunRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/regular_run/RegularRunRequestDto.java
@@ -1,0 +1,19 @@
+package com.example.runningservice.dto.regular_run;
+
+import com.example.runningservice.enums.Region;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class RegularRunRequestDto {
+
+    @NotNull
+    private int week;
+    @NotNull
+    private int count;
+    @NotNull
+    private List<String> dayOfWeek;
+    @NotNull
+    private Region activityRegion;
+}

--- a/src/main/java/com/example/runningservice/dto/regular_run/RegularRunResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/regular_run/RegularRunResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.runningservice.dto.regular_run;
 
+import com.example.runningservice.entity.RegularRunMeetingEntity;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,7 +16,7 @@ public class RegularRunResponseDto {
     private Long id;
     private Frequency frequency;
     private List<String> weekdays;
-    private String region;
+    private String location;
 
     @Builder
     @AllArgsConstructor
@@ -25,5 +26,19 @@ public class RegularRunResponseDto {
 
         private int weeks;
         private int times;
+    }
+
+    public static RegularRunResponseDto fromEntity(
+        RegularRunMeetingEntity regularRunMeetingEntity) {
+
+        return RegularRunResponseDto.builder()
+            .id(regularRunMeetingEntity.getId())
+            .frequency(Frequency.builder()
+                .weeks(regularRunMeetingEntity.getWeek())
+                .times(regularRunMeetingEntity.getCount())
+                .build())
+            .weekdays(regularRunMeetingEntity.getDayOfWeek())
+            .location(regularRunMeetingEntity.getActivityRegion().getRegionName())
+            .build();
     }
 }

--- a/src/main/java/com/example/runningservice/dto/regular_run/RegularRunResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/regular_run/RegularRunResponseDto.java
@@ -1,0 +1,29 @@
+package com.example.runningservice.dto.regular_run;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class RegularRunResponseDto {
+
+    private Long id;
+    private Frequency frequency;
+    private List<String> weekdays;
+    private String region;
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class Frequency {
+
+        private int weeks;
+        private int times;
+    }
+}

--- a/src/main/java/com/example/runningservice/entity/BaseEntity.java
+++ b/src/main/java/com/example/runningservice/entity/BaseEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @SuperBuilder
+@Getter
 public class BaseEntity {
 
     @CreatedDate

--- a/src/main/java/com/example/runningservice/entity/JoinApplyEntity.java
+++ b/src/main/java/com/example/runningservice/entity/JoinApplyEntity.java
@@ -1,9 +1,7 @@
 package com.example.runningservice.entity;
 
-import com.example.runningservice.enums.CrewRole;
 import com.example.runningservice.enums.JoinStatus;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -11,27 +9,20 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
-import java.time.LocalDateTime;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.envers.AuditOverride;
 
+@Entity(name = "join_request")
 @Getter
-@AllArgsConstructor
+@SuperBuilder
 @NoArgsConstructor
-@Builder
-@Entity
-@Table(name = "crew_member", uniqueConstraints = {
-    @UniqueConstraint(columnNames = {"member_id", "crew_id"})
-})
-@EntityListeners(AuditingEntityListener.class)
-public class CrewMemberEntity {
-
+@AllArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+public class JoinApplyEntity extends BaseEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -41,18 +32,19 @@ public class CrewMemberEntity {
     @ManyToOne
     @JoinColumn(name = "crew_id")
     private CrewEntity crew;
-    @Enumerated(EnumType.STRING)
-    private CrewRole role;
-    @CreatedDate
-    private LocalDateTime joinedAt;
+    @NotNull
     @Enumerated(EnumType.STRING)
     private JoinStatus status;
-
-    public static CrewMemberEntity memberOf(MemberEntity member, CrewEntity crew) {
-        return CrewMemberEntity.builder()
+    private String message;
+    public static JoinApplyEntity of(MemberEntity member, CrewEntity crew, String message) {
+        return JoinApplyEntity.builder()
             .member(member)
             .crew(crew)
-            .role(CrewRole.MEMBER)
+            .message(message)
             .build();
+    }
+
+    public void markStatus(JoinStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/example/runningservice/entity/RegularRunMeetingEntity.java
+++ b/src/main/java/com/example/runningservice/entity/RegularRunMeetingEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.Collections;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -42,4 +43,22 @@ public class RegularRunMeetingEntity extends BaseEntity {
     @Column(columnDefinition = "json")
     @JdbcTypeCode(SqlTypes.JSON)
     private List<String> dayOfWeek;
+
+    public List<String> getDayOfWeek() {
+        return Collections.unmodifiableList(this.dayOfWeek);
+    }
+
+    public void updateRegularRunInfo(int count, int week, Region activityRegion) {
+        this.count = count;
+        this.week = week;
+        this.activityRegion = activityRegion;
+    }
+
+    public void addDayOfWeek(String dayOfWeek) {
+        this.dayOfWeek.add(dayOfWeek);
+    }
+
+    public void clearDayOfWeek() {
+        this.dayOfWeek.clear();
+    }
 }

--- a/src/main/java/com/example/runningservice/entity/RegularRunMeetingEntity.java
+++ b/src/main/java/com/example/runningservice/entity/RegularRunMeetingEntity.java
@@ -1,0 +1,45 @@
+package com.example.runningservice.entity;
+
+import com.example.runningservice.enums.Region;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.envers.AuditOverride;
+import org.hibernate.type.SqlTypes;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@SuperBuilder
+@Entity
+@Table(name = "regular_run_meeting")
+@AuditOverride(forClass = BaseEntity.class)
+public class RegularRunMeetingEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    @JoinColumn(name = "crew_id")
+    private CrewEntity crew;
+    private int count;
+    private int week;
+    @Enumerated(EnumType.STRING)
+    private Region activityRegion;
+    @Column(columnDefinition = "json")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private List<String> dayOfWeek;
+}

--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     NOT_FOUND_CREW(HttpStatus.BAD_REQUEST, "크루를 찾을 수 없습니다."),
     NOT_FOUND_APPLY(HttpStatus.BAD_REQUEST, "해당 신청내역을 찾을 수 없습니다."),
     NOT_FOUND_REGULAR_RUN(HttpStatus.BAD_REQUEST, "정기러닝이 존재하지 않습니다."),
+    UNAUTHORIZED_CREW_ACCESS(HttpStatus.FORBIDDEN, "크루 접근 권한이 없습니다."),
 
     //크루가입
     RECORD_OPEN_REQUIRED(HttpStatus.FORBIDDEN, "러닝 기록을 공개해야 합니다."),

--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "인증되지 않은 이메일 입니다."),
     ENCRYPTION_ERROR(HttpStatus.BAD_REQUEST, ""),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    NOT_FOUND_CREW(HttpStatus.BAD_REQUEST, "크루를 찾을 수 없습니다.");
+    NOT_FOUND_CREW(HttpStatus.BAD_REQUEST, "크루를 찾을 수 없습니다."),
+    NOT_FOUND_REGULAR_RUN(HttpStatus.BAD_REQUEST, "정기러닝이 존재하지 않습니다.");
 
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -22,7 +22,18 @@ public enum ErrorCode {
     ENCRYPTION_ERROR(HttpStatus.BAD_REQUEST, ""),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     NOT_FOUND_CREW(HttpStatus.BAD_REQUEST, "크루를 찾을 수 없습니다."),
-    NOT_FOUND_REGULAR_RUN(HttpStatus.BAD_REQUEST, "정기러닝이 존재하지 않습니다.");
+    NOT_FOUND_APPLY(HttpStatus.BAD_REQUEST, "해당 신청내역을 찾을 수 없습니다."),
+    NOT_FOUND_REGULAR_RUN(HttpStatus.BAD_REQUEST, "정기러닝이 존재하지 않습니다."),
+
+    //크루가입
+    RECORD_OPEN_REQUIRED(HttpStatus.FORBIDDEN, "러닝 기록을 공개해야 합니다."),
+    GENDER_RESTRICTION_NOT_MET(HttpStatus.FORBIDDEN, "성별 제한을 충족하지 못했습니다."),
+    GENDER_REQUIRED(HttpStatus.FORBIDDEN, "가입을 위해 성별 정보가 필요합니다."),
+    AGE_RESTRICTION_NOT_MET(HttpStatus.FORBIDDEN, "나이 제한을 충족하지 못했습니다."),
+    AGE_REQUIRED(HttpStatus.FORBIDDEN, "가입을 위해 연령 정보가 필요합니다."),
+    //권한
+    UNAUTHORIZED_MY_APPLY_ACCESS(HttpStatus.FORBIDDEN, "잘못된 접근입니다. 자신의 가입 신청 내역만 조회할 수 있습니다.");
+
 
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/example/runningservice/repository/CrewMemberRepository.java
+++ b/src/main/java/com/example/runningservice/repository/CrewMemberRepository.java
@@ -3,6 +3,7 @@ package com.example.runningservice.repository;
 import com.example.runningservice.entity.CrewMemberEntity;
 import com.example.runningservice.enums.CrewRole;
 import com.example.runningservice.enums.JoinStatus;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +19,6 @@ public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Lo
     Page<CrewMemberEntity> findByMember_IdAndRole(Long memberId, CrewRole role, Pageable pageable);
 
     Page<CrewMemberEntity> findByMember_Id(Long memberId, Pageable pageable);
+
+    Optional<CrewMemberEntity> findByCrew_CrewIdAndMember_Id(Long crewId, Long memberId);
 }

--- a/src/main/java/com/example/runningservice/repository/JoinApplicationRepository.java
+++ b/src/main/java/com/example/runningservice/repository/JoinApplicationRepository.java
@@ -1,0 +1,14 @@
+package com.example.runningservice.repository;
+
+import com.example.runningservice.entity.JoinApplyEntity;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JoinApplicationRepository extends JpaRepository<JoinApplyEntity, Long> {
+    List<JoinApplyEntity> findAllByMember_Id(Long memberId);
+    Optional<JoinApplyEntity> findByIdAndMember_Email(Long id, String email);
+    Optional<JoinApplyEntity> findByIdAndMember_Id(Long id, Long memberId);
+}

--- a/src/main/java/com/example/runningservice/repository/RegularRunMeetingRepository.java
+++ b/src/main/java/com/example/runningservice/repository/RegularRunMeetingRepository.java
@@ -1,10 +1,19 @@
 package com.example.runningservice.repository;
 
 import com.example.runningservice.entity.RegularRunMeetingEntity;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RegularRunMeetingRepository extends JpaRepository<RegularRunMeetingEntity, Long> {
 
+    @Query("SELECT r FROM RegularRunMeetingEntity r WHERE r.crew.crewId IN :crewIdList")
+    List<RegularRunMeetingEntity> findByCrewIdIn(@Param("crewIdList") List<Long> crewIdList);
+
+    Page<RegularRunMeetingEntity> findByCrew_CrewId(Long crewId, Pageable pageable);
 }

--- a/src/main/java/com/example/runningservice/repository/RegularRunMeetingRepository.java
+++ b/src/main/java/com/example/runningservice/repository/RegularRunMeetingRepository.java
@@ -1,0 +1,10 @@
+package com.example.runningservice.repository;
+
+import com.example.runningservice.entity.RegularRunMeetingEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RegularRunMeetingRepository extends JpaRepository<RegularRunMeetingEntity, Long> {
+
+}

--- a/src/main/java/com/example/runningservice/security/CustomUserDetails.java
+++ b/src/main/java/com/example/runningservice/security/CustomUserDetails.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -17,6 +18,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class CustomUserDetails implements UserDetails {
 
+    @Getter
+    private Long id;
     private String email;
     private String password;
     private List<Role> roles;

--- a/src/main/java/com/example/runningservice/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/runningservice/security/CustomUserDetailsService.java
@@ -28,7 +28,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
         log.debug("User found: {}", email);
 
-        return new CustomUserDetails(memberEntity.getEmail(), memberEntity.getPassword(),
+        return new CustomUserDetails(memberEntity.getId(), memberEntity.getEmail(), memberEntity.getPassword(),
             memberEntity.getRoles());
     }
 }

--- a/src/main/java/com/example/runningservice/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/runningservice/security/JwtAuthenticationFilter.java
@@ -42,6 +42,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.info(String.format("[%s] -> %s ",
                     jwtUtil.extractEmail(accessJwt), request.getRequestURI())
             );
+            // LoginUserResolver에서 request를 통해 가져오기 위해 토큰에서 id를 가져와 저장한다.
+            request.setAttribute("loginId", jwtUtil.extractUserId(accessJwt));
         }
         log.info("Filtering request token: {}", accessJwt);
         log.info("authentication: {}", SecurityContextHolder.getContext().getAuthentication());

--- a/src/main/java/com/example/runningservice/security/LoginUserResolver.java
+++ b/src/main/java/com/example/runningservice/security/LoginUserResolver.java
@@ -1,0 +1,26 @@
+package com.example.runningservice.security;
+
+import com.example.runningservice.util.LoginUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginUserResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(LoginUser.class) != null;
+    }
+
+    @Override
+    public Long resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        return (Long) webRequest.getAttribute("loginId", RequestAttributes.SCOPE_REQUEST);
+    }
+}

--- a/src/main/java/com/example/runningservice/security/WebConfig.java
+++ b/src/main/java/com/example/runningservice/security/WebConfig.java
@@ -1,0 +1,15 @@
+package com.example.runningservice.security;
+
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginUserResolver());
+    }
+}

--- a/src/main/java/com/example/runningservice/service/RegularRunService.java
+++ b/src/main/java/com/example/runningservice/service/RegularRunService.java
@@ -74,4 +74,27 @@ public class RegularRunService {
             .weekdays(regularRunMeetingEntity.getDayOfWeek())
             .build();
     }
+
+    /**
+     * 크루 정기러닝 삭제
+     */
+    public RegularRunResponseDto deleteRegularRun(Long regularId) {
+        RegularRunMeetingEntity regularRunMeetingEntity = regularRunMeetingRepository
+            .findById(regularId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_REGULAR_RUN));
+
+        RegularRunResponseDto response = RegularRunResponseDto.builder()
+            .id(regularRunMeetingEntity.getId())
+            .frequency(Frequency.builder()
+                .times(regularRunMeetingEntity.getCount())
+                .weeks(regularRunMeetingEntity.getWeek())
+                .build())
+            .region(regularRunMeetingEntity.getActivityRegion().getRegionName())
+            .weekdays(regularRunMeetingEntity.getDayOfWeek())
+            .build();
+
+        regularRunMeetingRepository.delete(regularRunMeetingEntity);
+
+        return response;
+    }
 }

--- a/src/main/java/com/example/runningservice/service/RegularRunService.java
+++ b/src/main/java/com/example/runningservice/service/RegularRunService.java
@@ -52,6 +52,7 @@ public class RegularRunService {
     /**
      * 크루 정기러닝 수정
      */
+    @Transactional
     public RegularRunResponseDto updateRegularRun(Long regularId, RegularRunRequestDto request) {
         RegularRunMeetingEntity regularRunMeetingEntity = regularRunMeetingRepository
             .findById(regularId)

--- a/src/main/java/com/example/runningservice/service/RegularRunService.java
+++ b/src/main/java/com/example/runningservice/service/RegularRunService.java
@@ -48,4 +48,29 @@ public class RegularRunService {
             .weekdays(regularRunMeetingEntity.getDayOfWeek())
             .build();
     }
+
+    /**
+     * 크루 정기러닝 수정
+     */
+    public RegularRunResponseDto updateRegularRun(Long regularId, RegularRunRequestDto request) {
+        RegularRunMeetingEntity regularRunMeetingEntity = regularRunMeetingRepository
+            .findById(regularId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_REGULAR_RUN));
+
+        regularRunMeetingEntity.updateRegularRunInfo(request.getCount(), request.getWeek(),
+            request.getActivityRegion());
+
+        regularRunMeetingEntity.clearDayOfWeek();
+        request.getDayOfWeek().forEach(regularRunMeetingEntity::addDayOfWeek);
+
+        return RegularRunResponseDto.builder()
+            .id(regularRunMeetingEntity.getId())
+            .frequency(Frequency.builder()
+                .times(regularRunMeetingEntity.getCount())
+                .weeks(regularRunMeetingEntity.getWeek())
+                .build())
+            .region(regularRunMeetingEntity.getActivityRegion().getRegionName())
+            .weekdays(regularRunMeetingEntity.getDayOfWeek())
+            .build();
+    }
 }

--- a/src/main/java/com/example/runningservice/service/RegularRunService.java
+++ b/src/main/java/com/example/runningservice/service/RegularRunService.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -112,15 +111,14 @@ public class RegularRunService {
      */
     @Transactional
     public List<CrewRegularRunResponseDto> getRegularRunList(Pageable pageable) {
-        Page<CrewEntity> crewEntities = crewRepository.findAll(PageRequest.of(
-            pageable.getPageNumber(), pageable.getPageSize()));
-
         // 갯수만큼 크루 ID를 조회하고, 크루 ID에 해당하는 모든 정기러닝 조회
-        List<Long> crewIdList = crewEntities.stream().map(CrewEntity::getCrewId).toList();
-        List<RegularRunMeetingEntity> regularRunEntityList = regularRunMeetingRepository.findByCrewIdIn(
-            crewIdList);
+        Page<CrewEntity> crewEntities = crewRepository.findAll(pageable);
 
-        // 크루별로 합쳐서 보여주기 위해 크루 id를 key로 하는 Map 저장
+        List<Long> crewIdList = crewEntities.stream().map(CrewEntity::getCrewId).toList();
+        List<RegularRunMeetingEntity> regularRunEntityList = regularRunMeetingRepository
+            .findByCrewIdIn(crewIdList);
+
+        // 크루별로 그룹화해서 보여주기 위해 크루 id를 key로 하는 Map 저장
         Map<Long, List<RegularRunResponseDto>> crewRegularMap = new HashMap<>();
 
         for (RegularRunMeetingEntity regularRunMeeting : regularRunEntityList) {

--- a/src/main/java/com/example/runningservice/service/RegularRunService.java
+++ b/src/main/java/com/example/runningservice/service/RegularRunService.java
@@ -1,0 +1,51 @@
+package com.example.runningservice.service;
+
+import com.example.runningservice.dto.regular_run.RegularRunRequestDto;
+import com.example.runningservice.dto.regular_run.RegularRunResponseDto;
+import com.example.runningservice.dto.regular_run.RegularRunResponseDto.Frequency;
+import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.RegularRunMeetingEntity;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.CrewRepository;
+import com.example.runningservice.repository.RegularRunMeetingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RegularRunService {
+
+    private final CrewRepository crewRepository;
+    private final RegularRunMeetingRepository regularRunMeetingRepository;
+
+    /**
+     * 크루의 정기러닝 생성
+     */
+    @Transactional
+    public RegularRunResponseDto createRegularRun(Long crewId, RegularRunRequestDto regularRunDto) {
+        CrewEntity crewEntity = crewRepository.findById(crewId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW));
+
+        RegularRunMeetingEntity regularRunMeetingEntity = RegularRunMeetingEntity.builder()
+            .count(regularRunDto.getCount())
+            .crew(crewEntity)
+            .activityRegion(regularRunDto.getActivityRegion())
+            .dayOfWeek(regularRunDto.getDayOfWeek())
+            .week(regularRunDto.getWeek())
+            .build();
+
+        regularRunMeetingRepository.save(regularRunMeetingEntity);
+
+        return RegularRunResponseDto.builder()
+            .id(regularRunMeetingEntity.getId())
+            .frequency(Frequency.builder()
+                .times(regularRunMeetingEntity.getCount())
+                .weeks(regularRunMeetingEntity.getWeek())
+                .build())
+            .region(regularRunMeetingEntity.getActivityRegion().getRegionName())
+            .weekdays(regularRunMeetingEntity.getDayOfWeek())
+            .build();
+    }
+}

--- a/src/main/java/com/example/runningservice/service/RegularRunService.java
+++ b/src/main/java/com/example/runningservice/service/RegularRunService.java
@@ -1,5 +1,6 @@
 package com.example.runningservice.service;
 
+import com.example.runningservice.dto.regular_run.CrewRegularRunResponseDto;
 import com.example.runningservice.dto.regular_run.RegularRunRequestDto;
 import com.example.runningservice.dto.regular_run.RegularRunResponseDto;
 import com.example.runningservice.dto.regular_run.RegularRunResponseDto.Frequency;
@@ -9,7 +10,14 @@ import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.CrewRepository;
 import com.example.runningservice.repository.RegularRunMeetingRepository;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,7 +52,7 @@ public class RegularRunService {
                 .times(regularRunMeetingEntity.getCount())
                 .weeks(regularRunMeetingEntity.getWeek())
                 .build())
-            .region(regularRunMeetingEntity.getActivityRegion().getRegionName())
+            .location(regularRunMeetingEntity.getActivityRegion().getRegionName())
             .weekdays(regularRunMeetingEntity.getDayOfWeek())
             .build();
     }
@@ -70,7 +78,7 @@ public class RegularRunService {
                 .times(regularRunMeetingEntity.getCount())
                 .weeks(regularRunMeetingEntity.getWeek())
                 .build())
-            .region(regularRunMeetingEntity.getActivityRegion().getRegionName())
+            .location(regularRunMeetingEntity.getActivityRegion().getRegionName())
             .weekdays(regularRunMeetingEntity.getDayOfWeek())
             .build();
     }
@@ -78,6 +86,7 @@ public class RegularRunService {
     /**
      * 크루 정기러닝 삭제
      */
+    @Transactional
     public RegularRunResponseDto deleteRegularRun(Long regularId) {
         RegularRunMeetingEntity regularRunMeetingEntity = regularRunMeetingRepository
             .findById(regularId)
@@ -89,12 +98,70 @@ public class RegularRunService {
                 .times(regularRunMeetingEntity.getCount())
                 .weeks(regularRunMeetingEntity.getWeek())
                 .build())
-            .region(regularRunMeetingEntity.getActivityRegion().getRegionName())
+            .location(regularRunMeetingEntity.getActivityRegion().getRegionName())
             .weekdays(regularRunMeetingEntity.getDayOfWeek())
             .build();
 
         regularRunMeetingRepository.delete(regularRunMeetingEntity);
 
         return response;
+    }
+
+    /**
+     * 크루별 정기러닝 정보 조회
+     */
+    @Transactional
+    public List<CrewRegularRunResponseDto> getRegularRunList(Pageable pageable) {
+        Page<CrewEntity> crewEntities = crewRepository.findAll(PageRequest.of(
+            pageable.getPageNumber(), pageable.getPageSize()));
+
+        // 갯수만큼 크루 ID를 조회하고, 크루 ID에 해당하는 모든 정기러닝 조회
+        List<Long> crewIdList = crewEntities.stream().map(CrewEntity::getCrewId).toList();
+        List<RegularRunMeetingEntity> regularRunEntityList = regularRunMeetingRepository.findByCrewIdIn(
+            crewIdList);
+
+        // 크루별로 합쳐서 보여주기 위해 크루 id를 key로 하는 Map 저장
+        Map<Long, List<RegularRunResponseDto>> crewRegularMap = new HashMap<>();
+
+        for (RegularRunMeetingEntity regularRunMeeting : regularRunEntityList) {
+            List<RegularRunResponseDto> crewRegularList = crewRegularMap.getOrDefault(
+                regularRunMeeting.getCrew().getCrewId(), new ArrayList<>());
+
+            crewRegularList.add(RegularRunResponseDto.fromEntity(regularRunMeeting));
+            crewRegularMap.put(regularRunMeeting.getCrew().getCrewId(), crewRegularList);
+        }
+
+        List<CrewRegularRunResponseDto> response = new ArrayList<>();
+        for (Long crewId : crewRegularMap.keySet()) {
+            response.add(CrewRegularRunResponseDto.builder()
+                .crewId(crewId)
+                .data(crewRegularMap.get(crewId))
+                .build());
+        }
+
+        return response;
+    }
+
+    /**
+     * 특정 크루의 정기러닝 정보 조회
+     */
+    public CrewRegularRunResponseDto getCrewRegularRunList(Long crewId, Pageable pageable) {
+        Page<RegularRunMeetingEntity> crewEntities = regularRunMeetingRepository.findByCrew_CrewId(
+            crewId, pageable);
+
+        return CrewRegularRunResponseDto.builder()
+            .crewId(crewId)
+            .data(crewEntities.stream().map(RegularRunResponseDto::fromEntity).toList())
+            .build();
+    }
+
+    /**
+     * 특정 정기러닝 정보 조회
+     */
+    public RegularRunResponseDto getRegularRun(Long regularId) {
+        RegularRunMeetingEntity regularRunMeetingEntity = regularRunMeetingRepository.findById(
+            regularId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_REGULAR_RUN));
+
+        return RegularRunResponseDto.fromEntity(regularRunMeetingEntity);
     }
 }

--- a/src/main/java/com/example/runningservice/service/UserJoinService.java
+++ b/src/main/java/com/example/runningservice/service/UserJoinService.java
@@ -1,0 +1,151 @@
+package com.example.runningservice.service;
+
+import com.example.runningservice.dto.JoinApplyDto;
+import com.example.runningservice.dto.JoinApplyDto.SimpleResponse;
+import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.entity.JoinApplyEntity;
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.JoinStatus;
+import com.example.runningservice.enums.Visibility;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.CrewMemberRepository;
+import com.example.runningservice.repository.CrewRepository;
+import com.example.runningservice.repository.JoinApplicationRepository;
+import com.example.runningservice.repository.MemberRepository;
+import com.example.runningservice.util.JwtUtil;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserJoinService {
+
+    private final JoinApplicationRepository joinApplicationRepository;
+    private final MemberRepository memberRepository;
+    private final CrewRepository crewRepository;
+    private final CrewMemberRepository crewMemberRepository;
+    private final JwtUtil jwtUtil;
+
+    //가입 승인 Off 일 시, 자동 가입되도록 구현해야 함. 가입상태 표시 & 크루원repository에 저장
+    @Transactional
+    public JoinApplyDto.DetailResponse saveJoinApply(Long crewId,
+        JoinApplyDto.Request joinRequestForm) {
+        MemberEntity memberEntity = memberRepository.findById(joinRequestForm.getUserId())
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        CrewEntity crewEntity = crewRepository.findById(crewId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW));
+
+        //멤버제한 조건 검증 : 성별(선택), 최소연령(선택), 최대연령(선택), 러닝기록 오픈여부
+        isJoinPossible(memberEntity, crewEntity);
+
+        //crew의 가입승인 필수여부 확인 & 가입승인 필수 아닐 시, 자동으로 가입
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.of(memberEntity, crewEntity,
+            joinRequestForm.getMessage());
+
+        if (!crewEntity.getLeaderRequired()) { // 가입 승인이 필요 없는 경우
+            // 가입 상태를 승인으로 설정
+            joinApplyEntity.markStatus(JoinStatus.APPROVED);
+
+            // 크루원으로 자동 가입 처리
+            CrewMemberEntity crewMemberEntity = CrewMemberEntity.memberOf(memberEntity, crewEntity);
+            crewMemberRepository.save(crewMemberEntity);
+        } else {
+            // 가입 승인이 필요한 경우
+            joinApplyEntity.markStatus(JoinStatus.PENDING);
+        }
+        // 엔티티 저장
+        JoinApplyEntity savedJoinApplyEntity = joinApplicationRepository.save(joinApplyEntity);
+
+        return JoinApplyDto.DetailResponse.from(savedJoinApplyEntity);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SimpleResponse> getJoinApplications(String token, Long memberId) {
+        token = token.substring("Bearer ".length());
+        if (!jwtUtil.validateToken(memberId, token)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_MY_APPLY_ACCESS);
+        }
+        // memberId 기준 가입신청 리스트 조회
+        return joinApplicationRepository.findAllByMember_Id(memberId).stream()
+            .map(SimpleResponse::from).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public JoinApplyDto.DetailResponse getJoinApplicationDetail(String token, Long userId,
+        Long joinApplyId) {
+        token = token.substring("Bearer ".length());
+        if (!jwtUtil.validateToken(userId, token)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_MY_APPLY_ACCESS);
+        }
+
+        // JoinApplyEntity 조회 시, joinRequestId가 잘못된 경우 (존재하지 않는 경우)
+        JoinApplyEntity joinApplyEntity = joinApplicationRepository.findByIdAndMember_Id(
+            joinApplyId, userId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_APPLY));
+
+        return JoinApplyDto.DetailResponse.from(joinApplyEntity);
+    }
+
+    private void isJoinPossible(MemberEntity memberEntity, CrewEntity crewEntity) {
+        Gender requiredGender = crewEntity.getGender();
+        Integer minAge = crewEntity.getMinAge();
+        Integer maxAge = crewEntity.getMaxAge();
+
+        // 나이 제한 있으면 검증
+        if (minAge != null || maxAge != null) {
+            //나이 검증
+            validateAge(memberEntity, crewEntity, minAge, maxAge);
+        }
+        // 성별 제한 있으면 검증
+        if (requiredGender != null) {
+            // 성별 검증
+            validateGender(memberEntity, crewEntity, requiredGender);
+        }
+        // Todo 기록 공개 여부 검증
+//        Boolean requireRecordOpen = crewEntity.getRunRecordOpen();
+//        if (requireRecordOpen && memberEntity.getRunRecordOpen().equals(Visibility.PUBLIC)) {
+//            throw new CustomException("가입 자격이 없습니다. 달리기 기록을 공개해야 합니다.");
+//        }
+    }
+
+    private void validateAge(MemberEntity memberEntity, CrewEntity crewEntity, Integer minAge,
+        Integer maxAge) {
+
+        if (minAge != null || maxAge != null) {
+            if (memberEntity.getBirthYear() == null || memberEntity.getBirthYearVisibility()
+                .equals(Visibility.PRIVATE)) {
+                throw new CustomException(ErrorCode.AGE_REQUIRED);
+            }
+
+            int memberAge = LocalDate.now().getYear() - memberEntity.getBirthYear() + 1;
+            if (minAge != null && memberAge < minAge) {
+                throw new CustomException(ErrorCode.AGE_RESTRICTION_NOT_MET);
+            }
+
+            if (maxAge != null && memberAge > maxAge) {
+                throw new CustomException(ErrorCode.AGE_RESTRICTION_NOT_MET);
+            }
+        }
+    }
+
+    private void validateGender(MemberEntity memberEntity, CrewEntity crewEntity,
+        Gender requiredGender) {
+        Gender memberGender = memberEntity.getGender();
+        Visibility memberGenderVisibility = memberEntity.getGenderVisibility();
+
+        if (requiredGender != null) {
+            if (memberGender == null || memberGenderVisibility.equals(Visibility.PRIVATE)) {
+                throw new CustomException(ErrorCode.GENDER_REQUIRED);
+            }
+            if (!memberGender.equals(requiredGender)) {
+                throw new CustomException(ErrorCode.GENDER_RESTRICTION_NOT_MET);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/runningservice/util/JwtUtil.java
+++ b/src/main/java/com/example/runningservice/util/JwtUtil.java
@@ -43,19 +43,20 @@ public class JwtUtil {
         SECRET_KEY = new SecretKeySpec(decodedKey, 0, decodedKey.length, "HmacSHA256");
     }
 
-    public String generateToken(String email, List<GrantedAuthority> authorities) {
-        return createToken(email, authorities, ACCESS_TOKEN_EXPIRATION);
+    public String generateToken(String email, Long userId, List<GrantedAuthority> authorities) {
+        return createToken(email, userId, authorities, ACCESS_TOKEN_EXPIRATION);
     }
 
-    public String generateRefreshToken(String email, List<GrantedAuthority> authorities) {
-        return createToken(email, authorities, REFRESH_TOKEN_EXPIRATION); // 7 days
+    public String generateRefreshToken(String email, Long userId,List<GrantedAuthority> authorities) {
+        return createToken(email, userId, authorities, REFRESH_TOKEN_EXPIRATION); // 7 days
     }
 
-    private String createToken(String username, List<GrantedAuthority> authorities,
+    private String createToken(String username, Long userId, List<GrantedAuthority> authorities,
         long expirationTime) {
         Map<String, Object> claims = new HashMap<>();
         claims.put("roles",
             authorities.stream().map(GrantedAuthority::getAuthority).collect(Collectors.toList()));
+        claims.put("userId", userId);
         return Jwts.builder().claims(claims).subject(username)
             .issuedAt(new Date(System.currentTimeMillis()))
             .expiration(new Date(System.currentTimeMillis() + expirationTime))
@@ -66,10 +67,7 @@ public class JwtUtil {
         log.debug("extract token: {}", token);
         try {
             log.debug("token: {}", token);
-            return Jwts.parser()
-                .verifyWith(SECRET_KEY)
-                .build()
-                .parseSignedClaims(token)
+            return Jwts.parser().verifyWith(SECRET_KEY).build().parseSignedClaims(token)
                 .getPayload();
         } catch (SignatureException e) {
             log.error("Invalid JWT signature: {}", e.getMessage());
@@ -93,6 +91,10 @@ public class JwtUtil {
         return extractAllClaims(token).getSubject();
     }
 
+    public Long extractUserId(String token) {
+        return extractAllClaims(token).get("userId", Long.class);
+    }
+
     public List<Role> extractRoles(String token) {
         List<String> roles = extractAllClaims(token).get("roles", List.class);
         return roles.stream().map(Role::valueOf).collect(Collectors.toList());
@@ -102,6 +104,10 @@ public class JwtUtil {
         boolean equals = extractEmail(token).equals(email);
         log.debug("user email equals token owner email: {}", equals);
         return equals && !isTokenExpired(token);
+    }
+
+    public boolean validateToken(Long id, String token) {
+        return extractUserId(token).equals(id) && !isTokenExpired(token);
     }
 
     public Authentication getAuthentication(String jwt) {

--- a/src/main/java/com/example/runningservice/util/LoginUser.java
+++ b/src/main/java/com/example/runningservice/util/LoginUser.java
@@ -1,0 +1,12 @@
+package com.example.runningservice.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+
+}

--- a/src/test/java/com/example/runningservice/service/AuthServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/AuthServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -87,8 +88,8 @@ class AuthServiceTest {
             userDetails);
         when(userDetails.getUsername()).thenReturn("test@example.com");
         when(userDetails.getAuthorities()).thenAnswer(invocation -> authorities);
-        when(jwtUtil.generateToken("test@example.com", authorities)).thenReturn("access-token");
-        when(jwtUtil.generateRefreshToken("test@example.com", authorities)).thenReturn(
+        when(jwtUtil.generateToken("test@example.com", userDetails.getId(), authorities)).thenReturn("access-token");
+        when(jwtUtil.generateRefreshToken("test@example.com", userDetails.getId(), authorities)).thenReturn(
             "refresh-token");
 
         // When
@@ -101,8 +102,8 @@ class AuthServiceTest {
 
         verify(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
         verify(customUserDetailsService).loadUserByUsername(anyString());
-        verify(jwtUtil).generateToken(anyString(), anyList());
-        verify(jwtUtil).generateRefreshToken(anyString(), anyList());
+        verify(jwtUtil).generateToken(anyString(), anyLong(), anyList());
+        verify(jwtUtil).generateRefreshToken(anyString(), anyLong(), anyList());
     }
 
     @Test
@@ -180,9 +181,11 @@ class AuthServiceTest {
         when(jwtUtil.extractEmail(refreshToken)).thenReturn("test@example.com");
         when(customUserDetailsService.loadUserByUsername("test@example.com")).thenReturn(userDetails);
         List<GrantedAuthority> authorities = new ArrayList<>();
-        when(jwtUtil.generateToken("test@example.com", authorities)).thenReturn("access-token");
-        when(jwtUtil.generateRefreshToken("test@example.com", authorities)).thenReturn("refresh-token");
+        when(jwtUtil.generateToken("test@example.com", userDetails.getId(), authorities)).thenReturn("access-token");
+        when(jwtUtil.generateRefreshToken("test@example.com", userDetails.getId(), authorities)).thenReturn("refresh-token");
         when(principal.getName()).thenReturn(principalEmail);
+        when(jwtUtil.validateToken(principalEmail, refreshToken)).thenCallRealMethod();
+        when(jwtUtil.isTokenExpired(refreshToken)).thenReturn(false);
         //when
         JwtResponse jwtResponse = authService.refreshToken(refreshToken, principal);
         //then

--- a/src/test/java/com/example/runningservice/service/RegularRunServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/RegularRunServiceTest.java
@@ -1,0 +1,203 @@
+package com.example.runningservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.runningservice.dto.regular_run.CrewRegularRunResponseDto;
+import com.example.runningservice.dto.regular_run.RegularRunRequestDto;
+import com.example.runningservice.dto.regular_run.RegularRunResponseDto;
+import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.RegularRunMeetingEntity;
+import com.example.runningservice.enums.Region;
+import com.example.runningservice.repository.CrewRepository;
+import com.example.runningservice.repository.RegularRunMeetingRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+
+@ExtendWith(MockitoExtension.class)
+class RegularRunServiceTest {
+
+    @Mock
+    private CrewRepository crewRepository;
+    @Mock
+    private RegularRunMeetingRepository regularRunMeetingRepository;
+    @Mock
+    private RegularRunRequestDto regularRunDto;
+    @InjectMocks
+    private RegularRunService regularRunService;
+
+    @Test
+    @DisplayName("정기러닝 생성")
+    void createRegularRun() {
+        Long crewId = 1L;
+
+        when(regularRunDto.getCount()).thenReturn(2);
+        when(regularRunDto.getWeek()).thenReturn(3);
+        when(regularRunDto.getDayOfWeek()).thenReturn(List.of("월요일", "화요일"));
+        when(regularRunDto.getActivityRegion()).thenReturn(Region.SEOUL);
+        CrewEntity mockCrewEntity = new CrewEntity();
+        given(crewRepository.findById(crewId)).willReturn(Optional.of(mockCrewEntity));
+
+        // When
+        RegularRunResponseDto response = regularRunService.createRegularRun(crewId, regularRunDto);
+
+        // Then
+        verify(regularRunMeetingRepository).save(any(RegularRunMeetingEntity.class));
+        assertNotNull(response);
+        assertEquals(2, response.getFrequency().getTimes());
+        assertEquals(3, response.getFrequency().getWeeks());
+        assertEquals(Region.SEOUL.getRegionName(), response.getLocation());
+        assertEquals(2, response.getWeekdays().size());
+    }
+
+    @Test
+    @DisplayName("정기러닝 수정")
+    void updateRegularRun() {
+        Long regularId = 1L;
+
+        when(regularRunDto.getCount()).thenReturn(2);
+        when(regularRunDto.getWeek()).thenReturn(3);
+        when(regularRunDto.getDayOfWeek()).thenReturn(List.of("월요일", "화요일"));
+        when(regularRunDto.getActivityRegion()).thenReturn(Region.SEOUL);
+
+        RegularRunMeetingEntity regularEntity = new RegularRunMeetingEntity();
+        ReflectionTestUtils.setField(regularEntity, "dayOfWeek",
+            new ArrayList<>(List.of("월요일", "화요일")));
+
+        when(regularRunMeetingRepository.findById(regularId)).thenReturn(
+            Optional.of(regularEntity));
+
+        // When
+        RegularRunResponseDto response = regularRunService.updateRegularRun(regularId,
+            regularRunDto);
+
+        // Then
+        assertNotNull(response);
+        assertEquals(regularRunDto.getActivityRegion().getRegionName(), response.getLocation());
+        assertEquals(List.of("월요일", "화요일"), response.getWeekdays());
+    }
+
+    @Test
+    @DisplayName("정기러닝 삭제")
+    void deleteRegularRun() {
+        Long regularId = 1L;
+
+        RegularRunMeetingEntity mockRegularRunMeetingEntity = mock(RegularRunMeetingEntity.class);
+        when(mockRegularRunMeetingEntity.getActivityRegion()).thenReturn(Region.SEOUL);
+        when(mockRegularRunMeetingEntity.getId()).thenReturn(regularId);
+
+        when(regularRunMeetingRepository.findById(regularId)).thenReturn(
+            Optional.of(mockRegularRunMeetingEntity));
+
+        // When
+        RegularRunResponseDto response = regularRunService.deleteRegularRun(regularId);
+
+        // Then
+        verify(regularRunMeetingRepository).delete(mockRegularRunMeetingEntity);
+        assertNotNull(response);
+        assertEquals(regularId, response.getId());
+        assertEquals(mockRegularRunMeetingEntity.getActivityRegion().getRegionName(),
+            response.getLocation());
+    }
+
+    @Test
+    @DisplayName("크루별 정기러닝 정보 조회")
+    void getRegularRunList() {
+        Pageable pageable = PageRequest.of(0, 2);
+
+        List<Long> crewIdList = List.of(1L, 2L);
+        List<CrewEntity> crewList = List.of(CrewEntity.builder().crewId(crewIdList.get(0)).build(),
+            CrewEntity.builder().crewId(crewIdList.get(1)).build());
+        Page<CrewEntity> crewPage = new PageImpl<>(crewList);
+
+        given(crewRepository.findAll(pageable)).willReturn(crewPage);
+
+        RegularRunMeetingEntity mockRegular1 = mock(RegularRunMeetingEntity.class);
+        when(mockRegular1.getActivityRegion()).thenReturn(Region.SEOUL);
+        when(mockRegular1.getCrew()).thenReturn(crewList.get(0));
+
+        RegularRunMeetingEntity mockRegular2 = mock(RegularRunMeetingEntity.class);
+        when(mockRegular2.getActivityRegion()).thenReturn(Region.BUSAN);
+        when(mockRegular2.getCrew()).thenReturn(crewList.get(1));
+
+        List<RegularRunMeetingEntity> regularList = List.of(mockRegular1, mockRegular2);
+
+        given(regularRunMeetingRepository.findByCrewIdIn(crewIdList)).willReturn(regularList);
+
+        // When
+        List<CrewRegularRunResponseDto> response = regularRunService.getRegularRunList(pageable);
+
+        // Then
+        assertNotNull(response);
+        assertEquals(2, response.size());
+        assertEquals(crewIdList.get(0), response.get(0).getCrewId());
+        assertEquals(1, response.get(0).getData().size());
+        assertEquals(Region.SEOUL.getRegionName(), response.get(0).getData().get(0).getLocation());
+    }
+
+    @Test
+    @DisplayName("특정 크루의 정기러닝 정보 조회")
+    void getCrewRegularRunList() {
+        // given
+        Long crewId = 1L;
+        RegularRunMeetingEntity entity = RegularRunMeetingEntity.builder()
+            .activityRegion(Region.BUSAN)
+            .dayOfWeek(List.of())
+            .build();
+        Page<RegularRunMeetingEntity> page = new PageImpl<>(List.of(entity));
+
+        given(regularRunMeetingRepository.findByCrew_CrewId(crewId, Pageable.unpaged()))
+            .willReturn(page);
+
+        // when
+        CrewRegularRunResponseDto result = regularRunService.getCrewRegularRunList(crewId,
+            Pageable.unpaged());
+
+        // then
+        assertNotNull(result);
+        assertEquals(crewId, result.getCrewId());
+        assertEquals(1, result.getData().size());
+        verify(regularRunMeetingRepository).findByCrew_CrewId(crewId, Pageable.unpaged());
+    }
+
+    @Test
+    @DisplayName("특정 정기러닝 정보 조회")
+    void getRegularRun() {
+        // Given
+        Long regularId = 1L;
+        RegularRunMeetingEntity entity = RegularRunMeetingEntity.builder()
+            .activityRegion(Region.BUSAN)
+            .dayOfWeek(List.of())
+            .build();
+        RegularRunResponseDto expectedDto = RegularRunResponseDto.fromEntity(entity);
+
+        given(regularRunMeetingRepository.findById(regularId)).willReturn(Optional.of(entity));
+
+        // When
+        RegularRunResponseDto result = regularRunService.getRegularRun(regularId);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(expectedDto.getLocation(), result.getLocation());
+        assertEquals(expectedDto.getWeekdays(), result.getWeekdays());
+        verify(regularRunMeetingRepository).findById(regularId);
+    }
+}

--- a/src/test/java/com/example/runningservice/service/UserJoinServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/UserJoinServiceTest.java
@@ -1,0 +1,620 @@
+package com.example.runningservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.runningservice.dto.JoinApplyDto;
+import com.example.runningservice.dto.JoinApplyDto.Request;
+import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.entity.JoinApplyEntity;
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.JoinStatus;
+import com.example.runningservice.enums.Visibility;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.CrewMemberRepository;
+import com.example.runningservice.repository.CrewRepository;
+import com.example.runningservice.repository.JoinApplicationRepository;
+import com.example.runningservice.repository.MemberRepository;
+import com.example.runningservice.util.JwtUtil;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserJoinServiceTest {
+
+    @InjectMocks
+    private UserJoinService userJoinService;
+
+    @Mock
+    private JoinApplicationRepository joinApplicationRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private CrewRepository crewRepository;
+
+    @Mock
+    private CrewMemberRepository crewMemberRepository;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Test
+    @DisplayName("승인없이 자동 가입")
+    void saveJoinApply_whenJoinPossible_thenSuccess() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1996)
+            .gender(Gender.MALE)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .leaderRequired(false)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            JoinApplyDto.Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+        // then
+        assertEquals(JoinStatus.APPROVED, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+        verify(crewMemberRepository, times(1)).save(any(CrewMemberEntity.class));
+    }
+
+    @Test
+    @DisplayName("승인 필요 시 승인대기상태로 저장")
+    void saveJoinApply_whenJoinPossible_thenSuccess_withPending() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1996)
+            .gender(Gender.MALE)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            JoinApplyDto.Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+
+    @Test
+    @DisplayName("나이제한 없음(성공)")
+    void saveJoinApply_whenJoinPossible_NoAgeLimit_thenSuccess() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1996)
+            .gender(Gender.MALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .gender(Gender.MALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            JoinApplyDto.Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+
+    @Test
+    @DisplayName("나이제한 하한만 있음(성공)")
+    void saveJoinApply_whenJoinPossible_OnlyMinAgeLimit_thenSuccess() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(2005)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .gender(Gender.MALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .minAge(20)
+            .gender(Gender.MALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            JoinApplyDto.Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+
+    @Test
+    @DisplayName("나이제한 상한만 있음")
+    void saveJoinApply_whenJoinPossible_OnlyMaxAgeLimit_thenSuccess() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1995)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .gender(Gender.MALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .maxAge(30)
+            .gender(Gender.MALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            JoinApplyDto.Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+
+    @Test
+    @DisplayName("성별제한 없음")
+    void saveJoinApply_whenJoinPossible_NoGenderLimit_thenSuccess() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1995)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .gender(Gender.FEMALE)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .maxAge(30)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            JoinApplyDto.Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+
+    @Test
+    @DisplayName("어떠한 제한도 없음")
+    void saveJoinApply_whenJoinPossible_NoLimit_thenSuccess() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            JoinApplyDto.Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+
+    @Test
+    @DisplayName("성별 불일치(실패)")
+    void saveJoinApply_whenJoinPossible_GenderLimit_Fail() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1995)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .gender(Gender.MALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .maxAge(30)
+            .gender(Gender.FEMALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> userJoinService.saveJoinApply(1L,
+                Request.builder()
+                    .userId(1L)
+                    .message("test")
+                    .build()));
+
+        // then
+        assertEquals(ErrorCode.GENDER_RESTRICTION_NOT_MET, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("나이제한 미충족(실패)")
+    void saveJoinApply_whenJoinPossible_AgeLimit_Fail() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1994)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .gender(Gender.FEMALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .maxAge(30)
+            .gender(Gender.FEMALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> userJoinService.saveJoinApply(1L,
+                Request.builder()
+                    .userId(1L)
+                    .message("test")
+                    .build()));
+
+        // then
+        assertEquals(ErrorCode.AGE_RESTRICTION_NOT_MET, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("회원나이 null(실패)")
+    void saveJoinApply_whenJoinPossible_MemberAgeNull_Fail() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(null)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .gender(Gender.FEMALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .maxAge(30)
+            .gender(Gender.FEMALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> userJoinService.saveJoinApply(1L,
+                Request.builder()
+                    .userId(1L)
+                    .message("test")
+                    .build()));
+
+        // then
+        assertEquals(ErrorCode.AGE_REQUIRED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("회원나이 비공개(실패)")
+    void saveJoinApply_whenJoinPossible_MemberPrivate_Fail() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1994)
+            .birthYearVisibility(Visibility.PRIVATE)
+            .gender(Gender.FEMALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .maxAge(30)
+            .gender(Gender.FEMALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> userJoinService.saveJoinApply(1L,
+                Request.builder()
+                    .userId(1L)
+                    .message("test")
+                    .build()));
+
+        // then
+        assertEquals(ErrorCode.AGE_REQUIRED, exception.getErrorCode());
+    }
+    @Test
+    @DisplayName("회원나이 비공개 & 나이제한 없음(성공)")
+    void saveJoinApply_whenJoinPossible_MemberAgePrivate_Success() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(1994)
+            .birthYearVisibility(Visibility.PRIVATE)
+            .gender(Gender.FEMALE)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+
+    @Test
+    @DisplayName("회원나이 null 성공(나이제한 없음)")
+    void saveJoinApply_whenJoinPossible_MemberAgeNull_Success() {
+        // given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .email("testEmail")
+            .nickName("testNickName")
+            .birthYear(null)
+            .birthYearVisibility(Visibility.PRIVATE)
+            .gender(Gender.FEMALE)
+            .genderVisibility(Visibility.PUBLIC)
+            .build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .crewId(1L)
+            .crewName("testCrewName")
+            .gender(Gender.FEMALE)
+            .leaderRequired(true)
+            .build(); // 필드들 초기화
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build(); // 필드들 초기화
+
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(joinApplyEntity);
+
+        // when
+        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
+            Request.builder()
+                .userId(1L)
+                .message("test")
+                .build());
+
+        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
+        verify(joinApplicationRepository).save(captor.capture());
+
+        // then
+        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
+        assertEquals("testNickName", response.getNickname());
+        assertEquals("testCrewName", response.getCrewName());
+        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
+    }
+}


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 정기러닝 기능 추가
- Region 리턴 시, NullPointerException 방지

### 이 PR에서 변경된 사항
- 정기러닝(RegularRunMeeting) 엔티티/리포지토리 생성
- 정기러닝 생성, 수정, 삭제, 조회 API/Service 구현
- 엔티티에 수정 메서드 추가
  - List는 set없이도 수정될 수 있으므로 직접 접근 막기
- 크루 id와 사용자 id를 이용해 사용자의 크루 권한을 구하는 코드가 반복돼서 어노테이션으로 체크할 수 있도록 aop 사용
  - 컨트롤러에서 loginId, crewId가 각각 1,2번째 파라미터로 들어올때 @CrewRoleCheck로 체크하고 role에 해당하는 권한이 없으면  UNAUTHORIZED_CREW_ACCESS를 리턴
 - 서비스 테스트 코드 작성

### 기타
- 미리 필요해서 pr 브랜치에서 pull 해온 코드들이 포함돼있습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
