### PR TITLE
feat : Join-Crew-002 크루원 관리(조회, 일반퇴장, 강제퇴장, 권한변경, 리더 위임), 가입신청 제한 조건 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,12 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:sts'
 
+    //queryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 }
 
 

--- a/src/main/java/com/example/runningservice/config/QueryDslConfig.java
+++ b/src/main/java/com/example/runningservice/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.example.runningservice.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/runningservice/controller/CrewApplicantController.java
+++ b/src/main/java/com/example/runningservice/controller/CrewApplicantController.java
@@ -30,6 +30,7 @@ public class CrewApplicantController {
     private final CrewApplicantService crewApplicantService;
 
     @GetMapping("/{crew_id}/join/list")
+    @CrewRoleCheck(role = {"LEADER", "STAFF"})
     public ResponseEntity<Page<CrewApplicantResponseDto>> getJoinApplications(
         @LoginUser Long userId,
         @PathVariable("crew_id") Long crewId,

--- a/src/main/java/com/example/runningservice/controller/CrewMemberController.java
+++ b/src/main/java/com/example/runningservice/controller/CrewMemberController.java
@@ -1,0 +1,116 @@
+package com.example.runningservice.controller;
+
+import com.example.runningservice.aop.CrewRoleCheck;
+import com.example.runningservice.dto.crewMember.ChangeCrewRoleRequestDto;
+import com.example.runningservice.dto.crewMember.ChangeCrewRoleResponseDto;
+import com.example.runningservice.dto.crewMember.ChangedLeaderResponseDto;
+import com.example.runningservice.dto.crewMember.CrewMemberBlackListResponseDto;
+import com.example.runningservice.dto.crewMember.GetCrewMemberRequestDto;
+import com.example.runningservice.dto.crewMember.CrewMemberResponseDto;
+import com.example.runningservice.service.CrewMemberService;
+import com.example.runningservice.util.AESUtil;
+import com.example.runningservice.util.LoginUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("crew")
+public class CrewMemberController {
+
+    private final CrewMemberService crewMemberService;
+    private final AESUtil aesUtil;
+
+    /**
+     * 크루원 리스트 조회
+     */
+    @GetMapping("/{crew_id}/member/list")
+    @CrewRoleCheck(role = {"LEADER", "STAFF"})
+    public ResponseEntity<Page<CrewMemberResponseDto>> getCrewMembers(@LoginUser Long userId,
+        @PathVariable Long crewId,
+        @Valid GetCrewMemberRequestDto.Filter filterDto,
+        Pageable pageable) {
+
+        Page<CrewMemberResponseDto> pageDto = crewMemberService.getCrewMembers(crewId, filterDto,
+            pageable).map(e -> CrewMemberResponseDto.of(e, aesUtil));
+
+        return ResponseEntity.ok(pageDto);
+    }
+
+    /**
+     * 크루원 개별 상세조회
+     */
+    @GetMapping("/{crew_id}/member")
+    @CrewRoleCheck(role = {"LEADER", "STAFF"})
+    public ResponseEntity<CrewMemberResponseDto> getCrewMember(@LoginUser Long userID,
+        @PathVariable("crew_id") Long crewId, @RequestParam Long crewMemberId) {
+
+        CrewMemberResponseDto crewMemberDto = CrewMemberResponseDto.of(
+            crewMemberService.getCrewMember(crewMemberId), aesUtil);
+
+        return ResponseEntity.ok(crewMemberDto);
+    }
+
+    /**
+     * 리더 권한 위임
+     */
+    @PatchMapping("/{crew_id}/transfer-leader")
+    @CrewRoleCheck(role = {"LEADER"})
+    public ResponseEntity<ChangedLeaderResponseDto> transferLeaderRole(@LoginUser Long userId,
+        @PathVariable("crew_id") Long crewId,
+        @RequestParam Long crewMemberId) {
+
+        return ResponseEntity.ok(
+            crewMemberService.transferLeaderRole(userId, crewId, crewMemberId));
+    }
+
+    /**
+     * 크루원 권한 변경
+     */
+    @PatchMapping("/{crew_id}/change-role")
+    @CrewRoleCheck(role = {"LEADER", "STAFF"})
+    public ResponseEntity<ChangeCrewRoleResponseDto> changeRole(@LoginUser Long userID,
+        @PathVariable("crew_id") Long crewId,
+        @RequestBody @Valid ChangeCrewRoleRequestDto requestDto) {
+
+        return ResponseEntity.ok(
+            ChangeCrewRoleResponseDto.of(crewMemberService.changeRole(requestDto)));
+    }
+
+    /**
+     * 강제 퇴장
+     */
+    @DeleteMapping("/{crew_id}/remove-member")
+    @CrewRoleCheck(role = {"LEADER", "STAFF"})
+    public ResponseEntity<CrewMemberBlackListResponseDto> removeMember(@LoginUser Long userId,
+        @PathVariable("crew_id") Long crewId, @RequestParam Long crewMemberId) {
+
+        return ResponseEntity.ok(CrewMemberBlackListResponseDto.of(
+            crewMemberService.removeCrewMember(crewId, crewMemberId)));
+    }
+
+    /**
+     * 크루 퇴장
+     */
+    @DeleteMapping("/{crew_id}/leave")
+    @CrewRoleCheck(role = {"MEMBER", "STAFF"}) //Leader는 자발적 퇴장 불가
+    public ResponseEntity<Void> leaveCrew(@LoginUser Long userId,
+        @PathVariable("crew_id") Long crewId) {
+
+        crewMemberService.leaveCrew(crewId, userId);
+
+        return ResponseEntity.noContent().build();
+    }
+}
+

--- a/src/main/java/com/example/runningservice/dto/crewMember/ChangeCrewRoleRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/crewMember/ChangeCrewRoleRequestDto.java
@@ -1,0 +1,18 @@
+package com.example.runningservice.dto.crewMember;
+
+import com.example.runningservice.enums.CrewRole;
+import com.example.runningservice.util.validator.CrewRoleValid;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChangeCrewRoleRequestDto {
+
+    private Long crewMemberId;
+    @NotNull
+    @CrewRoleValid(roles = {"STAFF", "MEMBER"})
+    private CrewRole newRole;
+
+}

--- a/src/main/java/com/example/runningservice/dto/crewMember/ChangeCrewRoleResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/crewMember/ChangeCrewRoleResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.runningservice.dto.crewMember;
+
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.enums.CrewRole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChangeCrewRoleResponseDto {
+    private String nickName;
+    private String crewName;
+    private CrewRole crewRole;
+
+    public static ChangeCrewRoleResponseDto of(CrewMemberEntity crewMemberEntity) {
+        return ChangeCrewRoleResponseDto.builder()
+            .nickName(crewMemberEntity.getMember().getNickName())
+            .crewName(crewMemberEntity.getCrew().getCrewName())
+            .crewRole(crewMemberEntity.getRole())
+            .build();
+    }
+}

--- a/src/main/java/com/example/runningservice/dto/crewMember/ChangedLeaderResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/crewMember/ChangedLeaderResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.runningservice.dto.crewMember;
+
+import com.example.runningservice.enums.CrewRole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ChangedLeaderResponseDto {
+
+    private String oldLeaderNickName;
+    private CrewRole oldLeaderRole;
+    private String newLeaderNickName;
+    private CrewRole newLeaderRole;
+}

--- a/src/main/java/com/example/runningservice/dto/crewMember/CrewMemberBlackListResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/crewMember/CrewMemberBlackListResponseDto.java
@@ -1,0 +1,26 @@
+package com.example.runningservice.dto.crewMember;
+
+import com.example.runningservice.entity.CrewMemberBlackListEntity;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CrewMemberBlackListResponseDto {
+    private Long blackListId;
+    private String memberNickName;
+    private String memberEmail;
+    private String crewName;
+    private LocalDateTime bannedAt;
+
+    public static CrewMemberBlackListResponseDto of(CrewMemberBlackListEntity crewMemberBlackListEntity) {
+        return CrewMemberBlackListResponseDto.builder()
+            .blackListId(crewMemberBlackListEntity.getId())
+            .memberNickName(crewMemberBlackListEntity.getMember().getNickName())
+            .memberEmail(crewMemberBlackListEntity.getMember().getEmail())
+            .crewName(crewMemberBlackListEntity.getCrew().getCrewName())
+            .bannedAt(crewMemberBlackListEntity.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/example/runningservice/dto/crewMember/CrewMemberResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/crewMember/CrewMemberResponseDto.java
@@ -1,0 +1,67 @@
+package com.example.runningservice.dto.crewMember;
+
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.enums.CrewRole;
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.Region;
+import com.example.runningservice.enums.Visibility;
+import com.example.runningservice.util.AESUtil;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CrewMemberResponseDto {
+
+    private String memberNickName;
+    private String name;
+    private String phoneNumber;
+    private Integer birthYear;
+    private Gender memberGender;
+    private Region memberActivityRegion;
+    private String memberProfileImage;
+    private String crewName;
+    private CrewRole role;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime joinedAt;
+
+    public static CrewMemberResponseDto of(CrewMemberEntity crewMemberEntity, AESUtil aesUtil) {
+        MemberEntity member = crewMemberEntity.getMember();
+        // 기본적으로 모든 필드를 공개하지 않도록 설정
+        CrewMemberResponseDto.CrewMemberResponseDtoBuilder dtoBuilder = CrewMemberResponseDto.builder()
+            .memberNickName(member.getNickName())
+            .crewName(crewMemberEntity.getCrew().getCrewName())
+            .role(crewMemberEntity.getRole())
+            .joinedAt(crewMemberEntity.getJoinedAt());
+
+        // 공개 설정에 따라 필드를 추가 (이름, 연령, 성별, 전화번호, 활동지역, 프로필 이미지)
+        if (member.getNameVisibility() == Visibility.PUBLIC) {
+            dtoBuilder.name(member.getName());
+        }
+
+        if (member.getBirthYearVisibility() == Visibility.PUBLIC) {
+            dtoBuilder.birthYear(member.getBirthYear());
+        }
+
+        if (member.getGenderVisibility() == Visibility.PUBLIC) {
+            dtoBuilder.memberGender(member.getGender());
+        }
+
+        if (member.getPhoneNumberVisibility() == Visibility.PUBLIC) {
+            dtoBuilder.phoneNumber(aesUtil.decrypt(member.getPhoneNumber()));
+        }
+
+        if (member.getActivityRegion() != null) {
+            dtoBuilder.memberActivityRegion(member.getActivityRegion());
+        }
+
+        if (member.getProfileImageUrl() != null) {
+            dtoBuilder.memberProfileImage(member.getProfileImageUrl());
+        }
+
+        return dtoBuilder.build();
+    }
+}

--- a/src/main/java/com/example/runningservice/dto/crewMember/GetCrewMemberRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/crewMember/GetCrewMemberRequestDto.java
@@ -1,0 +1,20 @@
+package com.example.runningservice.dto.crewMember;
+
+import com.example.runningservice.enums.CrewRole;
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.util.validator.YearRange;
+import lombok.Builder;
+import lombok.Getter;
+
+public class GetCrewMemberRequestDto {
+
+    @Getter
+    @Builder
+    @YearRange(minYear = "minAge", maxYear = "maxAge")
+    public static class Filter {
+        private Gender gender;
+        private Integer minAge;
+        private Integer maxAge;
+        private CrewRole crewRole;
+    }
+}

--- a/src/main/java/com/example/runningservice/entity/CrewMemberBlackListEntity.java
+++ b/src/main/java/com/example/runningservice/entity/CrewMemberBlackListEntity.java
@@ -1,0 +1,34 @@
+package com.example.runningservice.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.envers.AuditOverride;
+
+@Entity(name = "crew_black_list")
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+public class CrewMemberBlackListEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "crew_id")
+    private CrewEntity crew;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private MemberEntity member;
+}

--- a/src/main/java/com/example/runningservice/entity/CrewMemberEntity.java
+++ b/src/main/java/com/example/runningservice/entity/CrewMemberEntity.java
@@ -2,6 +2,8 @@ package com.example.runningservice.entity;
 
 import com.example.runningservice.enums.CrewRole;
 import com.example.runningservice.enums.JoinStatus;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
@@ -45,14 +47,26 @@ public class CrewMemberEntity {
     private CrewRole role;
     @CreatedDate
     private LocalDateTime joinedAt;
+    //Todo 삭제 논의
     @Enumerated(EnumType.STRING)
     private JoinStatus status;
 
-    public static CrewMemberEntity memberOf(MemberEntity member, CrewEntity crew) {
+    public static CrewMemberEntity of(MemberEntity member, CrewEntity crew) {
         return CrewMemberEntity.builder()
             .member(member)
             .crew(crew)
             .role(CrewRole.MEMBER)
             .build();
+    }
+
+    public void changeRoleTo(CrewRole newRole) {
+        if (newRole == this.role) {
+            throw new CustomException(ErrorCode.ROLE_NOT_CHANGED);
+        }
+            this.role = newRole;
+    }
+
+    public void acceptLeaderRole() {
+        this.role = CrewRole.LEADER;
     }
 }

--- a/src/main/java/com/example/runningservice/entity/JoinApplyEntity.java
+++ b/src/main/java/com/example/runningservice/entity/JoinApplyEntity.java
@@ -47,11 +47,22 @@ public class JoinApplyEntity extends BaseEntity{
     public void initializeStatusAsPending() {
         this.status = JoinStatus.PENDING;
     }
-    public void approveJoin() {
+
+    public void markAsJoinApproved() {
         this.status = JoinStatus.APPROVED;
     }
-    public void rejectJoin() {
+
+    public void markAsRejected() {
         this.status = JoinStatus.REJECTED;
     }
+
+    public void markAsWithdrawn() {
+        this.status = JoinStatus.WITHDRAWN;
+    }
+
+    public void markAsForceWithdrawn() {
+        this.status = JoinStatus.FORCE_WITHDRAWN;
+    }
+
     public void updateMessage(String message) { this.message = message; }
 }

--- a/src/main/java/com/example/runningservice/enums/JoinStatus.java
+++ b/src/main/java/com/example/runningservice/enums/JoinStatus.java
@@ -1,5 +1,5 @@
 package com.example.runningservice.enums;
 
 public enum JoinStatus {
-    PENDING, APPROVED, REJECTED
+    PENDING, APPROVED, REJECTED, WITHDRAWN, FORCE_WITHDRAWN, UNBLOCKED
 }

--- a/src/main/java/com/example/runningservice/enums/OccupancyStatus.java
+++ b/src/main/java/com/example/runningservice/enums/OccupancyStatus.java
@@ -2,7 +2,7 @@ package com.example.runningservice.enums;
 
 import com.example.runningservice.dto.crew.CrewFilterDto;
 import com.example.runningservice.entity.CrewEntity;
-import com.example.runningservice.repository.CrewRepository;
+import com.example.runningservice.repository.crew.CrewRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -26,6 +26,8 @@ public enum ErrorCode {
     NOT_FOUND_REGULAR_RUN(HttpStatus.BAD_REQUEST, "정기러닝이 존재하지 않습니다."),
     UNAUTHORIZED_CREW_ACCESS(HttpStatus.FORBIDDEN, "크루 접근 권한이 없습니다."),
     DECRYPTION_ERROR(HttpStatus.BAD_REQUEST, "복호화 과정 중 에러가 발생하였습니다."),
+    NOT_FOUND_CREW_MEMBER(HttpStatus.BAD_REQUEST, "해당 크루원을 찾을 수 없습니다."),
+    ROLE_NOT_CHANGED(HttpStatus.BAD_REQUEST, "새로운 역할이 현재 역할과 동일합니다."),
     UNAUTHORIZED_REGULAR_ACCESS(HttpStatus.FORBIDDEN, "정기러닝 접근 권한이 없습니다."),
     NOT_FOUND_ACTIVITY(HttpStatus.BAD_REQUEST, "활동이 존재하지 않습니다."),
     UNAUTHORIZED_ACTIVITY(HttpStatus.FORBIDDEN, "활동 접근 권한이 없습니다."),
@@ -33,13 +35,14 @@ public enum ErrorCode {
     NOT_FOUND_CHATROOM(HttpStatus.BAD_REQUEST, "채팅방을 찾을 수 없습니다."),
 
     //크루가입
-    ALREADY_EXIST_JOIN_APPLY(HttpStatus.BAD_REQUEST, "이미 가입신청 기록이 있습니다."),
+    ALREADY_EXIST_PENDING_JOIN_APPLY(HttpStatus.BAD_REQUEST, "이미 거압 숭안 대기중입니다."),
     ALREADY_CREWMEMBER(HttpStatus.BAD_REQUEST, "이미 크루에 가입된 회원입니다."),
     RECORD_OPEN_REQUIRED(HttpStatus.FORBIDDEN, "러닝 기록을 공개해야 합니다."),
     GENDER_RESTRICTION_NOT_MET(HttpStatus.FORBIDDEN, "성별 제한을 충족하지 못했습니다."),
     GENDER_REQUIRED(HttpStatus.FORBIDDEN, "가입을 위해 성별 정보가 필요합니다."),
     AGE_RESTRICTION_NOT_MET(HttpStatus.FORBIDDEN, "나이 제한을 충족하지 못했습니다."),
     AGE_REQUIRED(HttpStatus.FORBIDDEN, "가입을 위해 연령 정보가 필요합니다."),
+    JOIN_NOT_ALLOWED_FOR_FORCE_WITHDRAWN(HttpStatus.FORBIDDEN, "강제퇴장된 멤버는 재가입할 수 없습니다."),
     //권한
     UNAUTHORIZED_MY_APPLY_ACCESS(HttpStatus.FORBIDDEN, "잘못된 접근입니다. 자신의 가입 신청 내역만 조회할 수 있습니다.");
 

--- a/src/main/java/com/example/runningservice/repository/CrewMemberBlackListRepository.java
+++ b/src/main/java/com/example/runningservice/repository/CrewMemberBlackListRepository.java
@@ -1,0 +1,10 @@
+package com.example.runningservice.repository;
+
+import com.example.runningservice.entity.CrewMemberBlackListEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CrewMemberBlackListRepository extends JpaRepository<CrewMemberBlackListEntity, Long> {
+
+}

--- a/src/main/java/com/example/runningservice/repository/CrewMemberRepository.java
+++ b/src/main/java/com/example/runningservice/repository/CrewMemberRepository.java
@@ -4,15 +4,12 @@ import com.example.runningservice.entity.CrewEntity;
 import com.example.runningservice.entity.CrewMemberEntity;
 import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.enums.CrewRole;
-import com.example.runningservice.enums.JoinStatus;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Long> {
@@ -20,6 +17,8 @@ public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Lo
     void deleteAllByCrew_Id(Long crewId);
 
     Page<CrewMemberEntity> findByMember_IdOrderByJoinedAt(Long memberId, Pageable pageable);
+
+    Optional<CrewMemberEntity> findByMember_IdAndCrew_CrewId(Long memberId, Long crewId);
 
     Boolean existsByMember_Id(Long memberId);
 

--- a/src/main/java/com/example/runningservice/repository/JoinApplicationRepository.java
+++ b/src/main/java/com/example/runningservice/repository/JoinApplicationRepository.java
@@ -12,14 +12,15 @@ import org.springframework.stereotype.Repository;
 public interface JoinApplicationRepository extends JpaRepository<JoinApplyEntity, Long> {
     Optional<JoinApplyEntity> findByIdAndMember_Id(Long id, Long memberId);
     Optional<JoinApplyEntity> findByIdAndStatus(Long id, JoinStatus status);
-    Boolean existsByMember_IdAndCrew_Id(Long memberId, Long crewId);
     Optional<JoinApplyEntity> findByIdAndStatusAndCrew_Id(Long memberId, JoinStatus status, Long crewId);
     Page<JoinApplyEntity> findAllByMember_Id(Long memberId, Pageable pageable);
 
     Page<JoinApplyEntity> findAllByMember_IdAndStatus(Long memberId, JoinStatus status, Pageable pageable);
-    Page<JoinApplyEntity> findAllByCrew_CrewIdAndStatus(Long crewId, JoinStatus status, Pageable pageable);
+    Page<JoinApplyEntity> findAllByCrew_IdAndStatus(Long crewId, JoinStatus status, Pageable pageable);
 
-    Page<JoinApplyEntity> findAllByCrew_CrewId(Long crewId, Pageable pageable);
+    Page<JoinApplyEntity> findAllByCrew_Id(Long crewId, Pageable pageable);
 
-    Optional<JoinApplyEntity> findByIdAndCrew_CrewId(Long joinApplyId, Long crewId);
+    Optional<JoinApplyEntity> findByIdAndCrew_Id(Long joinApplyId, Long crewId);
+
+    Optional<JoinApplyEntity> findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(Long userId, Long crewId);
 }

--- a/src/main/java/com/example/runningservice/repository/chat/ChatJoinRepository.java
+++ b/src/main/java/com/example/runningservice/repository/chat/ChatJoinRepository.java
@@ -12,7 +12,8 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ChatJoinRepository extends JpaRepository<ChatJoinEntity, Long> {
+public interface ChatJoinRepository extends JpaRepository<ChatJoinEntity, Long>,
+    ChatJoinRepositoryCustom {
     // 중복참여 확인
     boolean existsByChatRoomAndMember(ChatRoomEntity chatRoom, MemberEntity member);
 

--- a/src/main/java/com/example/runningservice/repository/chat/ChatJoinRepositoryCustom.java
+++ b/src/main/java/com/example/runningservice/repository/chat/ChatJoinRepositoryCustom.java
@@ -1,0 +1,5 @@
+package com.example.runningservice.repository.chat;
+
+public interface ChatJoinRepositoryCustom {
+    void deleteAllByMemberIdAndCrewId(Long memberId, Long crewId);
+}

--- a/src/main/java/com/example/runningservice/repository/chat/ChatJoinRepositoryCustomImpl.java
+++ b/src/main/java/com/example/runningservice/repository/chat/ChatJoinRepositoryCustomImpl.java
@@ -1,0 +1,28 @@
+package com.example.runningservice.repository.chat;
+
+import static com.example.runningservice.entity.chat.QChatJoinEntity.chatJoinEntity;
+
+import com.querydsl.jpa.impl.JPADeleteClause;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatJoinRepositoryCustomImpl implements ChatJoinRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public void deleteAllByMemberIdAndCrewId(Long memberId, Long crewId) {
+        new JPADeleteClause(entityManager, chatJoinEntity)
+            .where(chatJoinEntity.member.id.eq(memberId)
+                .and(chatJoinEntity.chatRoom.crew.id.eq(crewId)))
+            .execute();
+    }
+}

--- a/src/main/java/com/example/runningservice/repository/chat/ChatRoomRepository.java
+++ b/src/main/java/com/example/runningservice/repository/chat/ChatRoomRepository.java
@@ -1,13 +1,10 @@
 package com.example.runningservice.repository.chat;
 
-import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.entity.chat.ChatRoomEntity;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
@@ -18,4 +15,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> 
         return findById(roomId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CHATROOM));
     }
+
+    void deleteAllByCrewMember_Id(Long crewMemberId);
 }

--- a/src/main/java/com/example/runningservice/repository/crew/CrewRepository.java
+++ b/src/main/java/com/example/runningservice/repository/crew/CrewRepository.java
@@ -1,4 +1,4 @@
-package com.example.runningservice.repository;
+package com.example.runningservice.repository.crew;
 
 import com.example.runningservice.entity.CrewEntity;
 import com.example.runningservice.enums.Gender;
@@ -13,7 +13,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CrewRepository extends JpaRepository<CrewEntity, Long> {
+public interface CrewRepository extends JpaRepository<CrewEntity, Long>, CrewRepositoryCustom {
 
     boolean existsByCrewName(String crewName);
 

--- a/src/main/java/com/example/runningservice/repository/crew/CrewRepositoryCustom.java
+++ b/src/main/java/com/example/runningservice/repository/crew/CrewRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.example.runningservice.repository.crew;
+
+
+import com.example.runningservice.entity.CrewEntity;
+import java.util.Optional;
+
+public interface CrewRepositoryCustom {
+    Optional<CrewEntity> findByIdAndMemberCountLessThanCapacity(Long crewId);
+}

--- a/src/main/java/com/example/runningservice/repository/crew/CrewRepositoryCustomImpl.java
+++ b/src/main/java/com/example/runningservice/repository/crew/CrewRepositoryCustomImpl.java
@@ -1,0 +1,25 @@
+package com.example.runningservice.repository.crew;
+
+import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.QCrewEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CrewRepositoryCustomImpl implements CrewRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<CrewEntity> findByIdAndMemberCountLessThanCapacity(Long crewId) {
+        QCrewEntity crew = QCrewEntity.crewEntity;
+
+        CrewEntity foundCrew = queryFactory.selectFrom(crew)
+            .where(crew.id.eq(crewId)
+                .and(crew.crewMember.size().lt(crew.crewCapacity)))
+            .fetchOne();
+
+        return Optional.ofNullable(foundCrew);
+    }
+}

--- a/src/main/java/com/example/runningservice/service/AuthService.java
+++ b/src/main/java/com/example/runningservice/service/AuthService.java
@@ -27,7 +27,7 @@ public class AuthService {
     private final AuthenticationManager authenticationManager;
     private final CustomUserDetailsService customUserDetailsService;
     private final JwtUtil jwtUtil;
-    private final BlackList blackList;
+    private final TokenBlackList tokenBlackList;
 
     public JwtResponse authenticate(LoginRequestDto loginRequestDto) throws Exception {
         //loginId와 비밀번호 일치여부 확인 (불일치 시 예외 발생)
@@ -58,7 +58,7 @@ public class AuthService {
 
     public JwtResponse refreshToken(String refreshToken, Principal principal) {
         //refresh token 이 블랙리스트에 있는지 확인
-        if (blackList.isListed(refreshToken)) {
+        if (tokenBlackList.isListed(refreshToken)) {
             throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
         //토큰 유효성 검사(올바른 서명 & 유효기간)
@@ -74,7 +74,7 @@ public class AuthService {
         final String newRefreshToken = jwtUtil.generateRefreshToken(email, userDetails.getId(), authorities);
 
         //기존 refreshToken을 blackList에 추가
-        blackList.add(refreshToken);
+        tokenBlackList.add(refreshToken);
 
         return new JwtResponse(newAccessToken, newRefreshToken);
     }

--- a/src/main/java/com/example/runningservice/service/CrewMemberService.java
+++ b/src/main/java/com/example/runningservice/service/CrewMemberService.java
@@ -1,0 +1,225 @@
+package com.example.runningservice.service;
+
+import com.example.runningservice.dto.crewMember.ChangeCrewRoleRequestDto;
+import com.example.runningservice.dto.crewMember.ChangedLeaderResponseDto;
+import com.example.runningservice.dto.crewMember.GetCrewMemberRequestDto;
+import com.example.runningservice.entity.CrewMemberBlackListEntity;
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.entity.JoinApplyEntity;
+import com.example.runningservice.entity.QCrewMemberEntity;
+import com.example.runningservice.enums.CrewRole;
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.CrewMemberBlackListRepository;
+import com.example.runningservice.repository.CrewMemberRepository;
+import com.example.runningservice.repository.JoinApplicationRepository;
+import com.example.runningservice.repository.chat.ChatJoinRepository;
+import com.example.runningservice.util.PageUtil;
+import com.example.runningservice.util.QueryDslUtil;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CrewMemberService {
+
+    private final CrewMemberRepository crewMemberRepository;
+    private final JoinApplicationRepository joinApplicationRepository;
+    private final CrewMemberBlackListRepository crewMemberBlackListRepository;
+    private final ChatJoinRepository chatJoinRepository;
+    private final JPAQueryFactory queryFactory;
+
+
+    /**
+     * 크루원 조회
+     */
+    @Transactional
+    public Page<CrewMemberEntity> getCrewMembers(Long crewId, GetCrewMemberRequestDto.Filter filterDto,
+        Pageable pageable) {
+
+        String defaultSortBy = "joinedAt";
+        int defaultPageNumber = 0;
+        int defaultPageSize = 10;
+        Pageable sortedPageable = PageUtil.getSortedPageable(pageable, defaultSortBy, Direction.ASC,
+            defaultPageNumber, defaultPageSize);
+
+        QCrewMemberEntity crewMember = QCrewMemberEntity.crewMemberEntity;
+
+        // 쿼리 작성
+        List<CrewMemberEntity> crewMembers = queryFactory.selectFrom(crewMember)
+            .where(
+                crewIdEq(crewId),
+                genderEq(filterDto.getGender()),
+                roleEq(filterDto.getCrewRole()),
+                birthYearGoe(filterDto.getMinAge()),
+                birthYearLoe(filterDto.getMaxAge())
+            )
+            .orderBy(QueryDslUtil.getAllOrderSpecifiers(sortedPageable, "crewMemberEntity")
+                .toArray(new OrderSpecifier[0]))
+            .offset(sortedPageable.getOffset())
+            .limit(sortedPageable.getPageSize())
+            .fetch();
+
+        // 총 개수 계산
+        Long total = queryFactory.select(crewMember.count())
+            .from(crewMember)
+            .where(
+                crewIdEq(crewId),
+                genderEq(filterDto.getGender()),
+                roleEq(filterDto.getCrewRole()),
+                birthYearGoe(filterDto.getMinAge()),
+                birthYearLoe(filterDto.getMaxAge())
+            )
+            .fetchOne();
+
+        return new PageImpl<>(crewMembers, sortedPageable, total != null ? total : 0);
+    }
+
+    private BooleanExpression crewIdEq(Long crewId) {
+        return crewId != null ? QCrewMemberEntity.crewMemberEntity.crew.id.eq(crewId) : null;
+    }
+
+    private BooleanExpression genderEq(Gender gender) {
+        return gender != null ? QCrewMemberEntity.crewMemberEntity.member.gender.eq(gender) : null;
+    }
+
+    private BooleanExpression roleEq(CrewRole crewRole) {
+        return crewRole != null ? QCrewMemberEntity.crewMemberEntity.role.eq(crewRole) : null;
+    }
+
+    private BooleanExpression birthYearGoe(Integer minAge) {
+        if (minAge == null) {
+            return null;
+        }
+        int minBirthYear = LocalDate.now().getYear() - minAge + 1; //한국나이
+        return QCrewMemberEntity.crewMemberEntity.member.birthYear.loe(minBirthYear);
+    }
+
+    private BooleanExpression birthYearLoe(Integer maxAge) {
+        if (maxAge == null) {
+            return null;
+        }
+        int maxBirthYear = LocalDate.now().getYear() - maxAge + 1; //한국나이
+        return QCrewMemberEntity.crewMemberEntity.member.birthYear.goe(maxBirthYear);
+    }
+
+    /**
+     * 크루원 개별조회(상세조회)
+     */
+    @Transactional
+    public CrewMemberEntity getCrewMember(Long crewMemberId) {
+        return crewMemberRepository.findById(crewMemberId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW_MEMBER));
+    }
+
+    /**
+     * 크루 탈퇴(일반 탈퇴)
+     */
+    @Transactional
+    public void leaveCrew(Long crewId, Long userId) {
+        //crewId와 userId로 요청자 데이터 찾기
+        CrewMemberEntity crewMemberEntity = crewMemberRepository.findByCrew_IdAndMember_Id(
+            crewId, userId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW_MEMBER));
+
+        //퇴장 후 신청자 테이블에서 상태를 WITHDRAWN 으로 변경
+        JoinApplyEntity joinApplyEntity = joinApplicationRepository.findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(
+            userId, crewId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_APPLY));
+
+        joinApplyEntity.markAsWithdrawn();
+
+        //크루멤버 테이블에서 지우기
+        crewMemberRepository.delete(crewMemberEntity);
+
+        //가입해있던 크루 내 모든 채팅방에서 퇴장(삭제)
+        chatJoinRepository.deleteAllByMemberIdAndCrewId(crewMemberEntity.getMember().getId(), crewId);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(joinApplyEntity.getMember().getEmail())
+            .append(" 님이 ")
+            .append(joinApplyEntity.getCrew().getCrewName())
+            .append(" 크루를 탈퇴하셨습니다.");
+        log.info(new String(sb));
+    }
+
+    /**
+     * 강제퇴장
+     */
+    @Transactional
+    public CrewMemberBlackListEntity removeCrewMember(Long crewId, Long crewMemberId) {
+        //퇴장시킬 크루원 데이터 찾기
+        CrewMemberEntity crewMemberEntity = crewMemberRepository.findById(crewMemberId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW_MEMBER));
+
+        //퇴장 후 신청자 테이블에성 상태를 FORCE_WITHDRAWN 으로 변경
+        JoinApplyEntity joinApplyEntity = joinApplicationRepository.findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(
+                crewMemberEntity.getMember().getId(), crewId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_APPLY));
+
+        joinApplyEntity.markAsForceWithdrawn();
+
+        //크루멤버 테이블에서 지우기
+        crewMemberRepository.delete(crewMemberEntity);
+
+        //채팅방에서도 퇴장(해당 유저가 가입한 크루 내 모든 채팅방에서 퇴장)
+        chatJoinRepository.deleteAllByMemberIdAndCrewId(crewMemberEntity.getMember().getId(), crewId);
+
+        //블랙리스트에 멤버 추가
+        return crewMemberBlackListRepository.save(CrewMemberBlackListEntity.builder()
+                .member(crewMemberEntity.getMember())
+                .crew(crewMemberEntity.getCrew())
+                .build());
+    }
+
+    /**
+     * 크루원 권한 변경
+     */
+    @Transactional
+    public CrewMemberEntity changeRole(ChangeCrewRoleRequestDto requestDto) {
+        //크루원 데이터 가져오기
+        CrewMemberEntity crewMemberEntity = crewMemberRepository.findById(
+                requestDto.getCrewMemberId())
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW_MEMBER));
+
+        //크루원 권한 변경
+        crewMemberEntity.changeRoleTo(requestDto.getNewRole());
+
+        return crewMemberEntity;
+    }
+
+    /**
+     * 리더 권한 위임
+     */
+    @Transactional
+    public ChangedLeaderResponseDto transferLeaderRole(Long userId, Long crewId,
+        Long crewMemberId) {
+        CrewMemberEntity newLeader = crewMemberRepository.findById(crewMemberId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW_MEMBER));
+
+        CrewMemberEntity oldLeader = crewMemberRepository.findByMember_IdAndCrew_CrewId(
+            userId, crewId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW_MEMBER));
+
+        newLeader.acceptLeaderRole();
+
+        oldLeader.changeRoleTo(CrewRole.MEMBER);
+
+        return ChangedLeaderResponseDto.builder()
+            .oldLeaderNickName(oldLeader.getMember().getNickName())
+            .oldLeaderRole(oldLeader.getRole())
+            .newLeaderNickName(newLeader.getMember().getNickName())
+            .newLeaderRole(newLeader.getRole())
+            .build();
+    }
+}

--- a/src/main/java/com/example/runningservice/service/LogoutService.java
+++ b/src/main/java/com/example/runningservice/service/LogoutService.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class LogoutService implements LogoutHandler {
 
-    private final BlackList blackList;
+    private final TokenBlackList tokenBlackList;
     private final JwtUtil jwtUtil;
 
     @Override
@@ -37,11 +37,11 @@ public class LogoutService implements LogoutHandler {
             throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
 
-        if (blackList.isListed(refreshToken)) {
+        if (tokenBlackList.isListed(refreshToken)) {
             throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
 
-        blackList.add(refreshToken);
+        tokenBlackList.add(refreshToken);
         SecurityContextHolder.clearContext();
     }
 }

--- a/src/main/java/com/example/runningservice/service/TokenBlackList.java
+++ b/src/main/java/com/example/runningservice/service/TokenBlackList.java
@@ -15,7 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class BlackList {
+public class TokenBlackList {
     private final JwtUtil jwtUtil;
 
     private final Map<String, Date> blacklist = new ConcurrentHashMap<>();

--- a/src/main/java/com/example/runningservice/service/UserJoinService.java
+++ b/src/main/java/com/example/runningservice/service/UserJoinService.java
@@ -1,9 +1,9 @@
 package com.example.runningservice.service;
 
+import com.example.runningservice.dto.UpdateJoinApplyDto;
 import com.example.runningservice.dto.join.GetApplicantsRequestDto;
 import com.example.runningservice.dto.join.JoinApplyDto;
 import com.example.runningservice.dto.join.JoinApplyDto.SimpleResponse;
-import com.example.runningservice.dto.UpdateJoinApplyDto;
 import com.example.runningservice.entity.CrewEntity;
 import com.example.runningservice.entity.CrewMemberEntity;
 import com.example.runningservice.entity.JoinApplyEntity;
@@ -14,16 +14,16 @@ import com.example.runningservice.enums.Visibility;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.CrewMemberRepository;
-import com.example.runningservice.repository.CrewRepository;
 import com.example.runningservice.repository.JoinApplicationRepository;
 import com.example.runningservice.repository.MemberRepository;
+import com.example.runningservice.repository.crew.CrewRepository;
 import com.example.runningservice.util.JwtUtil;
+import com.example.runningservice.util.PageUtil;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,14 +37,14 @@ public class UserJoinService {
     private final CrewMemberRepository crewMemberRepository;
     private final JwtUtil jwtUtil;
 
-    //Todo OccupancyStatus 반영하여 필터링 추가
     @Transactional
     public JoinApplyDto.DetailResponse saveJoinApply(Long crewId,
         JoinApplyDto.Request joinApplyForm) {
         MemberEntity memberEntity = memberRepository.findById(joinApplyForm.getUserId())
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
-        CrewEntity crewEntity = crewRepository.findById(crewId)
+        //크루원 수가 크루 정원보다 작은 크루일 때만 가져오기
+        CrewEntity crewEntity = crewRepository.findByIdAndMemberCountLessThanCapacity(crewId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW));
 
         //멤버제한 조건 검증 : 성별(선택), 최소연령(선택), 최대연령(선택), 러닝기록 오픈여부
@@ -56,7 +56,7 @@ public class UserJoinService {
 
         if (!crewEntity.getLeaderRequired()) { // 가입 승인이 필요 없는 경우
             // 가입 상태를 승인으로 설정
-            joinApplyEntity.approveJoin();
+            joinApplyEntity.markAsJoinApproved();
 
             // 크루원으로 자동 가입 처리
             CrewMemberEntity crewMemberEntity = CrewMemberEntity.of(memberEntity, crewEntity);
@@ -84,17 +84,14 @@ public class UserJoinService {
 
         // 기본 정렬 기준 및 방향 설정 (기본값은 createdAt 기준 내림차순)
         String defaultSortBy = "createdAt";
-        Sort defaultSort = Sort.by(Sort.Order.asc(defaultSortBy));
-
-        // Pageable에서 sort 정보를 추출 (sort=정렬기준(ex.createdAt) 이 있으면 isSorted()==true)
+        Direction defaultDirection = Direction.ASC;
         Pageable pageable = request.getPageable();
-        int pageNumber = pageable != null ? pageable.getPageNumber() : 0; // 기본 페이지 번호 0
-        int pageSize = (pageable != null && pageable.getPageSize() > 0) ? pageable.getPageSize() : 10; // 기본 페이지 크기 10
-
-        Sort sortOrder = pageable == null || pageable.getSort().isUnsorted() ? defaultSort : pageable.getSort();
+        int defaultPageNumber =  0;
+        int defaultSize = 10;
 
         // 정렬 순서 설정
-        Pageable sortedPageable = PageRequest.of(pageNumber, pageSize, sortOrder);
+        Pageable sortedPageable = PageUtil.getSortedPageable(pageable, defaultSortBy, defaultDirection,
+            defaultPageNumber, defaultSize);
 
         // 신청결과 필터링
         JoinStatus status = request.getStatus();
@@ -140,19 +137,21 @@ public class UserJoinService {
             validateGender(memberEntity, crewEntity, requiredGender);
         }
         // Todo 기록 공개 여부 검증
-//        Boolean requireRecordOpen = crewEntity.getRunRecordOpen();
-//        if (requireRecordOpen && memberEntity.getRunRecordOpen().equals(Visibility.PUBLIC)) {
-//            throw new CustomException("가입 자격이 없습니다. 달리기 기록을 공개해야 합니다.");
-//        }
 
         //이미 회원이면 신청 불가
         if (crewMemberRepository.existsByMember_Id(memberId)) {
             throw new CustomException(ErrorCode.ALREADY_CREWMEMBER);
         }
-        //이미 신청기록 있다면 신청 불가
-        if (joinApplicationRepository.existsByMember_IdAndCrew_Id(memberId, crewId)) {
-            throw new CustomException(ErrorCode.ALREADY_EXIST_JOIN_APPLY);
-        }
+        //최근 신청내역이 대기상태이거나 강제퇴장된 상태면 신청불가
+        joinApplicationRepository.findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(memberId, crewId)
+            .ifPresent(application -> {
+                if (application.getStatus() == JoinStatus.PENDING) {
+                    throw new CustomException(ErrorCode.ALREADY_EXIST_PENDING_JOIN_APPLY);
+                }
+                if (application.getStatus() == JoinStatus.FORCE_WITHDRAWN) {
+                    throw new CustomException(ErrorCode.JOIN_NOT_ALLOWED_FOR_FORCE_WITHDRAWN);
+                }
+            });
     }
 
     private void validateAge(MemberEntity memberEntity, CrewEntity crewEntity, Integer minAge,
@@ -163,7 +162,7 @@ public class UserJoinService {
                 throw new CustomException(ErrorCode.AGE_REQUIRED);
             }
 
-            int memberAge = LocalDate.now().getYear() - memberEntity.getBirthYear() + 1;
+            int memberAge = LocalDate.now().getYear() - memberEntity.getBirthYear() + 1; //한국나이
             if (minAge != null && memberAge < minAge) {
                 throw new CustomException(ErrorCode.AGE_RESTRICTION_NOT_MET);
             }

--- a/src/main/java/com/example/runningservice/util/PageUtil.java
+++ b/src/main/java/com/example/runningservice/util/PageUtil.java
@@ -7,13 +7,19 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class PageUtil {
-    public Pageable getSortedPageable(Pageable pageable, String defaultSortBy, Sort.Direction sortDirection, int number, int size) {
+
+    public static Pageable getSortedPageable(Pageable pageable, String defaultSortBy,
+        Sort.Direction sortDirection, int defaultPageNumber, int defaultPageSize) {
+
         Sort defaultSort = Sort.by(sortDirection, defaultSortBy);
         // Pageable에서 sort 정보를 추출 (sort=정렬기준(ex.createdAt) 이 있으면 isSorted()==true)
-        int pageNumber = pageable != null ? pageable.getPageNumber() : number; // 기본 페이지 번호 0
-        int pageSize = (pageable != null && pageable.getPageSize() > 0) ? pageable.getPageSize() : size; // 기본 페이지 크기 10
+        int pageNumber =
+            pageable != null ? pageable.getPageNumber() : defaultPageNumber; // 기본 페이지 번호 0
+        int pageSize = (pageable != null && pageable.getPageSize() > 0) ? pageable.getPageSize()
+            : defaultPageSize; // 기본 페이지 크기 10
 
-        Sort sortOrder = pageable == null || pageable.getSort().isUnsorted() ? defaultSort : pageable.getSort();
+        Sort sortOrder =
+            pageable == null || pageable.getSort().isUnsorted() ? defaultSort : pageable.getSort();
 
         // 정렬 순서 설정
         return PageRequest.of(pageNumber, pageSize, sortOrder);

--- a/src/main/java/com/example/runningservice/util/QueryDslUtil.java
+++ b/src/main/java/com/example/runningservice/util/QueryDslUtil.java
@@ -1,0 +1,52 @@
+package com.example.runningservice.util;
+
+import com.example.runningservice.entity.QCrewMemberEntity;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.PathBuilder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QueryDslUtil {
+    //map으로 정렬할 entity 관리
+    private static final Map<String, PathBuilder<?>> ENTITY_PATH_MAP = new HashMap<>();
+
+    static {
+        ENTITY_PATH_MAP.put("crewMemberEntity", new PathBuilder<>(QCrewMemberEntity.class, "crewMemberEntity"));
+        // 새로운 엔티티가 추가될 때마다 여기에 추가
+    }
+
+    public static List<OrderSpecifier<?>> getAllOrderSpecifiers(Pageable pageable, String entityType) {
+
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        if (!isEmpty(pageable.getSort())) {
+            PathBuilder<?> entityPath = ENTITY_PATH_MAP.get(entityType);
+
+            if (entityPath == null) {
+                throw new IllegalArgumentException("Entity의 타입이 아닙니다.");
+            }
+
+            for (Sort.Order order : pageable.getSort()) {
+                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+                Expression fieldPath = Expressions.path(Object.class, entityPath, order.getProperty());
+                OrderSpecifier<?> orderSpecifier = new OrderSpecifier<>(direction, fieldPath);
+                orders.add(orderSpecifier);
+            }
+        }
+
+        return orders;
+    }
+
+    private static boolean isEmpty(Sort sort) {
+        return sort == null || !sort.iterator().hasNext();
+    }
+}

--- a/src/main/java/com/example/runningservice/util/validator/CrewRoleValid.java
+++ b/src/main/java/com/example/runningservice/util/validator/CrewRoleValid.java
@@ -1,0 +1,23 @@
+package com.example.runningservice.util.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = CrewRoleValidator.class)
+public @interface CrewRoleValid {
+
+    String message() default "Invalid role";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    String[] roles();  // 허용할 역할 리스트
+}

--- a/src/main/java/com/example/runningservice/util/validator/CrewRoleValidator.java
+++ b/src/main/java/com/example/runningservice/util/validator/CrewRoleValidator.java
@@ -1,0 +1,21 @@
+package com.example.runningservice.util.validator;
+
+import com.example.runningservice.enums.CrewRole;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Arrays;
+import java.util.List;
+
+public class CrewRoleValidator implements ConstraintValidator<CrewRoleValid,CrewRole> {
+    private List<String> acceptedRoles;
+
+    @Override
+    public void initialize(CrewRoleValid annotation) {
+        acceptedRoles = Arrays.asList(annotation.roles());
+    }
+
+    @Override
+    public boolean isValid(CrewRole role, ConstraintValidatorContext context) {
+        return role != null && acceptedRoles.contains(role.name());
+    }
+}

--- a/src/test/java/com/example/runningservice/service/AuthServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/AuthServiceTest.java
@@ -61,7 +61,7 @@ class AuthServiceTest {
     private Authentication authentication;
 
     @Mock
-    private BlackList blackList;
+    private TokenBlackList tokenBlackList;
 
     @Mock
     private CustomUserDetails userDetails;
@@ -176,7 +176,7 @@ class AuthServiceTest {
         String refreshToken = "refresh-token";
         String principalEmail = "test@example.com";
 
-        when(blackList.isListed(refreshToken)).thenReturn(false);
+        when(tokenBlackList.isListed(refreshToken)).thenReturn(false);
         when(jwtUtil.isTokenExpired(refreshToken)).thenReturn(false);
         when(jwtUtil.extractEmail(refreshToken)).thenReturn("test@example.com");
         when(customUserDetailsService.loadUserByUsername("test@example.com")).thenReturn(userDetails);
@@ -192,14 +192,14 @@ class AuthServiceTest {
         assertNotNull(jwtResponse);
         assertEquals("refresh-token", jwtResponse.getRefreshJwt());
         assertEquals("access-token", jwtResponse.getAccessJwt());
-        verify(blackList).isListed(refreshToken);
+        verify(tokenBlackList).isListed(refreshToken);
     }
 
     @Test
     void testRefreshToken_BlacklistedToken() {
         // Given
         String refreshToken = "blacklisted-refresh-token";
-        when(blackList.isListed(refreshToken)).thenReturn(true);
+        when(tokenBlackList.isListed(refreshToken)).thenReturn(true);
 
         // When & Then
         CustomException exception = assertThrows(CustomException.class, () -> {
@@ -207,7 +207,7 @@ class AuthServiceTest {
         });
 
         assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, exception.getErrorCode());
-        verify(blackList).isListed(refreshToken);
+        verify(tokenBlackList).isListed(refreshToken);
         verify(jwtUtil, never()).isTokenExpired(anyString());
     }
 
@@ -216,7 +216,7 @@ class AuthServiceTest {
         // Given
         String refreshToken = "expired-refresh-token";
         String principalEmail = "test@example.com";
-        when(blackList.isListed(refreshToken)).thenReturn(false);
+        when(tokenBlackList.isListed(refreshToken)).thenReturn(false);
         when(principal.getName()).thenReturn(principalEmail);
         when(jwtUtil.validateToken(principalEmail, refreshToken)).thenCallRealMethod();
         when(jwtUtil.extractEmail(refreshToken)).thenReturn(principalEmail);
@@ -236,7 +236,7 @@ class AuthServiceTest {
         // Given
         String refreshToken = "expired-refresh-token";
         String principalEmail = "test@example.com";
-        when(blackList.isListed(refreshToken)).thenReturn(false);
+        when(tokenBlackList.isListed(refreshToken)).thenReturn(false);
         when(principal.getName()).thenReturn(principalEmail);
         when(jwtUtil.validateToken(principalEmail, refreshToken)).thenCallRealMethod();
         when(jwtUtil.extractEmail(refreshToken)).thenReturn("diffrent-email");

--- a/src/test/java/com/example/runningservice/service/CrewApplicantServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/CrewApplicantServiceTest.java
@@ -89,7 +89,7 @@ class CrewApplicantServiceTest {
                 10))
             .thenReturn(request.getPageable());
 
-        when(joinApplicationRepository.findAllByCrew_CrewIdAndStatus(eq(crewId),
+        when(joinApplicationRepository.findAllByCrew_IdAndStatus(eq(crewId),
             eq(JoinStatus.PENDING), eq(request.getPageable())))
             .thenReturn(page);
 
@@ -116,7 +116,7 @@ class CrewApplicantServiceTest {
             .createdAt(LocalDateTime.now())
             .build();
 
-        when(joinApplicationRepository.findByIdAndCrew_CrewId(joinApplyId, crewId))
+        when(joinApplicationRepository.findByIdAndCrew_Id(joinApplyId, crewId))
             .thenReturn(Optional.of(joinApplyEntity));
 
         // when

--- a/src/test/java/com/example/runningservice/service/CrewMemberServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/CrewMemberServiceTest.java
@@ -1,0 +1,675 @@
+package com.example.runningservice.service;
+
+import static com.example.runningservice.entity.QCrewMemberEntity.crewMemberEntity;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.runningservice.dto.crewMember.ChangeCrewRoleRequestDto;
+import com.example.runningservice.dto.crewMember.ChangedLeaderResponseDto;
+import com.example.runningservice.dto.crewMember.GetCrewMemberRequestDto;
+import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.CrewMemberBlackListEntity;
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.entity.JoinApplyEntity;
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.entity.QCrewMemberEntity;
+import com.example.runningservice.enums.CrewRole;
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.JoinStatus;
+import com.example.runningservice.enums.Visibility;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.CrewMemberBlackListRepository;
+import com.example.runningservice.repository.CrewMemberRepository;
+import com.example.runningservice.repository.JoinApplicationRepository;
+import com.example.runningservice.repository.chat.ChatJoinRepository;
+import com.example.runningservice.util.AESUtil;
+import com.example.runningservice.util.PageUtil;
+import com.example.runningservice.util.QueryDslUtil;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+
+@ExtendWith(MockitoExtension.class)
+class CrewMemberServiceTest {
+
+    @Mock
+    private CrewMemberRepository crewMemberRepository;
+
+    @Mock
+    private JoinApplicationRepository joinApplicationRepository;
+
+    @Mock
+    private CrewMemberBlackListRepository crewMemberBlackListRepository;
+
+    @Mock
+    private ChatJoinRepository chatJoinRepository;
+
+    @Mock
+    private JPAQueryFactory queryFactory;
+
+    @Mock
+    private PageUtil pageUtil;
+
+    @Mock
+    private AESUtil aesUtil;
+
+    @InjectMocks
+    private CrewMemberService crewMemberService;
+
+    private BooleanExpression crewIdEq(Long crewId) {
+        return crewId != null ? crewMemberEntity.crew.id.eq(crewId) : null;
+    }
+
+    private BooleanExpression genderEq(Gender gender) {
+        return gender != null ? crewMemberEntity.member.gender.eq(gender) : null;
+    }
+
+    private BooleanExpression roleEq(CrewRole crewRole) {
+        return crewRole != null ? crewMemberEntity.role.eq(crewRole) : null;
+    }
+
+    private BooleanExpression birthYearGoe(Integer minAge) {
+        if (minAge == null) {
+            return null;
+        }
+        int minBirthYear = LocalDate.now().getYear() - minAge + 1; //한국나이
+        return crewMemberEntity.member.birthYear.loe(minBirthYear);
+    }
+
+    private BooleanExpression birthYearLoe(Integer maxAge) {
+        if (maxAge == null) {
+            return null;
+        }
+        int maxBirthYear = LocalDate.now().getYear() - maxAge + 1; //한국나이
+        return crewMemberEntity.member.birthYear.goe(maxBirthYear);
+    }
+
+    @Test
+    void testGetCrewMembers() {
+        // Given
+        Long crewId = 1L;
+        GetCrewMemberRequestDto.Filter filter = GetCrewMemberRequestDto.Filter.builder()
+            .crewRole(CrewRole.MEMBER)
+            .build();
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        CrewMemberEntity crewMember1 = CrewMemberEntity.builder()
+            .id(1L)
+            .member(MemberEntity.builder().nickName("nick1").build())
+            .crew(CrewEntity.builder().id(1L).crewName("crew1").build())
+            .role(CrewRole.MEMBER)
+            .joinedAt(LocalDateTime.of(2024, 1, 1, 1, 1))
+            .build();
+
+        CrewMemberEntity crewMember2 = CrewMemberEntity.builder()
+            .id(1L)
+            .member(MemberEntity.builder().nickName("nick2").build())
+            .crew(CrewEntity.builder().id(1L).crewName("crew1").build())
+            .role(CrewRole.LEADER)
+            .joinedAt(LocalDateTime.of(2024, 1, 1, 1, 2))
+            .build();
+
+        CrewMemberEntity crewMember3 = CrewMemberEntity.builder()
+            .id(1L)
+            .member(MemberEntity.builder().nickName("nick3").build())
+            .crew(CrewEntity.builder().id(1L).crewName("crew1").build())
+            .role(CrewRole.STAFF)
+            .joinedAt(LocalDateTime.of(2024, 1, 1, 1, 3))
+            .build();
+
+        List<CrewMemberEntity> crewMembers = List.of(crewMember1, crewMember2, crewMember3);
+
+        Page<CrewMemberEntity> expectedPage = new PageImpl<>(crewMembers, pageable, 3);
+
+        String defaultSortBy = "joinedAt";
+        int defaultPageNumber = 0;
+        int defaultPageSize = 10;
+        Direction defaultSortDirection = Direction.ASC;
+        Pageable sortedPageable = PageUtil.getSortedPageable(pageable, defaultSortBy,
+            defaultSortDirection,
+            defaultPageNumber, defaultPageSize);
+        QCrewMemberEntity crewMemberEntity = QCrewMemberEntity.crewMemberEntity;
+
+        // Mock the JPAQuery object
+        JPAQuery<CrewMemberEntity> jpaQuery = (JPAQuery<CrewMemberEntity>) mock(JPAQuery.class);
+
+        when(queryFactory.selectFrom(crewMemberEntity)).thenReturn(jpaQuery);
+
+        when(jpaQuery.where(
+            crewIdEq(crewId),
+            genderEq(filter.getGender()),
+            roleEq(filter.getCrewRole()),
+            birthYearGoe(filter.getMinAge()),
+            birthYearLoe(filter.getMaxAge()))
+        ).thenReturn(jpaQuery);
+
+        when(jpaQuery.orderBy(QueryDslUtil.getAllOrderSpecifiers(sortedPageable, "crewMemberEntity")
+            .toArray(new OrderSpecifier[0]))).thenReturn(jpaQuery);
+
+        when(jpaQuery.offset(sortedPageable.getOffset())).thenReturn(jpaQuery);
+        when(jpaQuery.limit(sortedPageable.getPageSize())).thenReturn(jpaQuery);
+
+        when(queryFactory.selectFrom(crewMemberEntity)
+            .where(
+                crewIdEq(crewId),
+                genderEq(filter.getGender()),
+                roleEq(filter.getCrewRole()),
+                birthYearGoe(filter.getMinAge()),
+                birthYearLoe(filter.getMaxAge())
+            )
+            .orderBy(QueryDslUtil.getAllOrderSpecifiers(sortedPageable, "crewMemberEntity")
+                .toArray(new OrderSpecifier[0]))
+            .offset(sortedPageable.getOffset())
+            .limit(sortedPageable.getPageSize())
+            .fetch()).thenReturn(crewMembers);
+
+        JPAQuery<Long> countQuery = mock(JPAQuery.class);
+
+        when(queryFactory.select(crewMemberEntity.count())).thenReturn(countQuery);
+        when(countQuery.from(crewMemberEntity)).thenReturn(countQuery);
+        when(countQuery.where(
+            crewIdEq(crewId),
+            genderEq(filter.getGender()),
+            roleEq(filter.getCrewRole()),
+            birthYearGoe(filter.getMinAge()),
+            birthYearLoe(filter.getMaxAge())
+        )).thenReturn(countQuery);
+
+        when(queryFactory.select(crewMemberEntity.count())
+            .from(crewMemberEntity)
+            .where(crewIdEq(crewId),
+                genderEq(filter.getGender()),
+                roleEq(filter.getCrewRole()),
+                birthYearGoe(filter.getMinAge()),
+                birthYearLoe(filter.getMaxAge()))
+            .fetchOne()).thenReturn(3L);
+
+        //when
+        Page<CrewMemberEntity> result = crewMemberService.getCrewMembers(crewId, filter, pageable);
+
+        //then
+        assertEquals(3, result.getTotalElements());
+        assertEquals(crewMembers, result.getContent());
+        assertEquals("nick1", result.getContent().get(0).getMember().getNickName());
+    }
+
+    @Test
+    void testGetCrewMember_Success() {
+        // given
+        CrewMemberEntity crewMember = CrewMemberEntity.builder()
+            .crew(CrewEntity.builder().id(1L).crewName("crew1").build())
+            .member(MemberEntity.builder().nickName("nick1").name("name1").nameVisibility(
+                Visibility.PRIVATE).build())
+            .role(CrewRole.MEMBER)
+            .build();
+
+        when(crewMemberRepository.findById(crewMember.getId())).thenReturn(Optional.of(crewMember));
+
+        // when
+        CrewMemberEntity result = crewMemberService.getCrewMember(crewMember.getId());
+
+        // then
+        assertNotNull(result);
+        assertEquals(crewMember.getId(), result.getId());
+        assertEquals("nick1", result.getMember().getNickName());
+    }
+
+    @Test
+    void testGetCrewMember_NotFound() {
+        // given
+        Long invalidId = 2L;
+        when(crewMemberRepository.findById(invalidId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            crewMemberService.getCrewMember(invalidId);
+        });
+
+        assertEquals(ErrorCode.NOT_FOUND_CREW_MEMBER, exception.getErrorCode());
+    }
+
+    @Test
+    void testLeaveCrew_Success() {
+        // given
+        Long crewId = 1L;
+        Long memberId = 2L;
+        CrewMemberEntity crewMember = CrewMemberEntity.builder()
+            .crew(CrewEntity.builder().id(1L).crewName("crew1").build())
+            .member(
+                MemberEntity.builder().id(memberId).nickName("nick1").name("name1").nameVisibility(
+                    Visibility.PRIVATE).build())
+            .role(CrewRole.MEMBER)
+            .build();
+
+        JoinApplyEntity joinEntity = JoinApplyEntity.builder()
+            .crew(CrewEntity.builder().id(1L).crewName("crew1").build())
+            .member(MemberEntity.builder().id(2L).nickName("nick1").email("email1").build())
+            .status(JoinStatus.APPROVED)
+            .build();
+
+        when(crewMemberRepository.findByCrew_IdAndMember_Id(crewId, memberId))
+            .thenReturn(Optional.of(crewMember));
+        doNothing().when(crewMemberRepository).delete(crewMember);
+        when(
+            joinApplicationRepository.findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(memberId,
+                crewId))
+            .thenReturn(Optional.of(joinEntity));
+
+        // when
+        crewMemberService.leaveCrew(crewId, memberId);
+
+        // Assert
+        assertEquals(JoinStatus.WITHDRAWN, joinEntity.getStatus());
+        verify(crewMemberRepository, times(1)).findByCrew_IdAndMember_Id(crewId, memberId);
+        verify(crewMemberRepository, times(1)).delete(crewMember);
+        verify(joinApplicationRepository,
+            times(1)).findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(memberId, crewId);
+        verify(chatJoinRepository, times(1)).deleteAllByMemberIdAndCrewId(memberId, crewId);
+    }
+
+    @Test
+    @DisplayName("잘못된 crewId & memberId")
+    void testLeaveCrew_CrewMemberNotFound() {
+        // given
+        CrewMemberEntity crewMember = CrewMemberEntity.builder()
+            .crew(CrewEntity.builder().id(1L).crewName("crew1").build())
+            .member(MemberEntity.builder().nickName("nick1").name("name1").nameVisibility(
+                Visibility.PRIVATE).build())
+            .role(CrewRole.MEMBER)
+            .build();
+
+        JoinApplyEntity joinEntity = JoinApplyEntity.builder()
+            .crew(CrewEntity.builder().id(1L).crewName("crew1").build())
+            .member(MemberEntity.builder().id(2L).nickName("nick1").email("email1").build())
+            .status(JoinStatus.APPROVED)
+            .build();
+
+        when(crewMemberRepository.findByCrew_IdAndMember_Id(2L, 1L))
+            .thenReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            crewMemberService.leaveCrew(2L, 1L);
+        });
+
+        assertEquals(ErrorCode.NOT_FOUND_CREW_MEMBER, exception.getErrorCode());
+        verify(crewMemberRepository, times(1)).findByCrew_IdAndMember_Id(2L, 1L);
+        verify(crewMemberRepository, never()).delete(crewMember);
+        verify(joinApplicationRepository,
+            never()).findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(2L, 1L);
+    }
+
+    @Test
+    void testLeaveCrew_JoinApplyNotFound() {
+        // given
+        Long crewId = 1L;
+        Long memberId = 2L;
+        Long JoinID = 3L;
+
+        CrewMemberEntity crewMember = CrewMemberEntity.builder()
+            .crew(CrewEntity.builder().id(crewId).crewName("crew1").build())
+            .member(
+                MemberEntity.builder().id(memberId).nickName("nick1").name("name1").nameVisibility(
+                    Visibility.PRIVATE).build())
+            .role(CrewRole.MEMBER)
+            .build();
+
+        when(crewMemberRepository.findByCrew_IdAndMember_Id(crewId, memberId))
+            .thenReturn(Optional.of(crewMember));
+        when(
+            joinApplicationRepository.findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(memberId,
+                crewId))
+            .thenReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            crewMemberService.leaveCrew(crewId, memberId);
+        });
+
+        assertEquals(ErrorCode.NOT_FOUND_APPLY, exception.getErrorCode());
+        verify(crewMemberRepository, times(1)).findByCrew_IdAndMember_Id(crewId, memberId);
+        verify(crewMemberRepository, never()).delete(crewMember);
+        verify(joinApplicationRepository,
+            times(1)).findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(memberId, crewId);
+    }
+
+    @Test
+    @DisplayName("권한 변경 성공")
+    void testChangeRole_Success() {
+        // given
+        Long crewMemberId = 1L;
+        CrewRole newRole = CrewRole.STAFF;
+        Long crewId = 2L;
+        Long memberId = 3L;
+        ChangeCrewRoleRequestDto requestDto = ChangeCrewRoleRequestDto.builder()
+            .crewMemberId(crewMemberId)
+            .newRole(newRole)
+            .build();
+
+        CrewMemberEntity crewMember = CrewMemberEntity.builder()
+            .crew(CrewEntity.builder().id(crewId).crewName("crew1").build())
+            .member(
+                MemberEntity.builder().id(memberId).nickName("nick1").name("name1").build())
+            .role(CrewRole.MEMBER)
+            .build();
+
+        when(crewMemberRepository.findById(crewMemberId)).thenReturn(Optional.of(crewMember));
+
+        // when
+        CrewMemberEntity result = crewMemberService.changeRole(requestDto);
+
+        // then
+        assertNotNull(result);
+        assertEquals(newRole, result.getRole());
+
+        verify(crewMemberRepository, times(1)).findById(crewMemberId);
+    }
+
+    @Test
+    @DisplayName("권한변경 실패_크루멤버를 찾을 수 없음")
+    void testChangeRole_CrewMemberNotFound() {
+        // given
+        Long crewMemberId = 1L;
+        CrewRole newRole = CrewRole.STAFF;
+        Long crewId = 2L;
+        Long memberId = 3L;
+        ChangeCrewRoleRequestDto requestDto = ChangeCrewRoleRequestDto.builder()
+            .crewMemberId(crewMemberId)
+            .newRole(newRole)
+            .build();
+
+        CrewMemberEntity crewMember = CrewMemberEntity.builder()
+            .crew(CrewEntity.builder().id(crewId).crewName("crew1").build())
+            .member(
+                MemberEntity.builder().id(memberId).nickName("nick1").name("name1").build())
+            .role(CrewRole.MEMBER)
+            .build();
+
+        when(crewMemberRepository.findById(crewMemberId)).thenReturn(Optional.empty());
+
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> crewMemberService.changeRole(requestDto));
+
+        // then
+        assertEquals(ErrorCode.NOT_FOUND_CREW_MEMBER, exception.getErrorCode());
+        assertEquals(null, crewMember.getStatus());
+    }
+
+
+    @Test
+    @DisplayName("리더권한 위임 성공")
+    void testTransferLeaderRole_Success() {
+        // given
+        CrewMemberEntity oldLeader = CrewMemberEntity.builder()
+            .id(1L)
+            .role(CrewRole.LEADER)
+            .member(MemberEntity.builder().id(1L).nickName("OldLeader").build())
+            .build();
+
+        CrewMemberEntity newLeader = CrewMemberEntity.builder()
+            .id(2L)
+            .role(CrewRole.MEMBER)
+            .member(MemberEntity.builder().id(2L).nickName("NewLeader").build())
+            .build();
+
+        Long userId = 1L;
+        Long crewId = 1L;
+        Long crewMemberId = 2L;
+
+        when(crewMemberRepository.findById(crewMemberId)).thenReturn(Optional.of(newLeader));
+        when(crewMemberRepository.findByMember_IdAndCrew_CrewId(userId, crewId)).thenReturn(
+            Optional.of(oldLeader));
+
+        // when
+        ChangedLeaderResponseDto result = crewMemberService.transferLeaderRole(userId, crewId,
+            crewMemberId);
+
+        // then
+        assertNotNull(result);
+        assertEquals("OldLeader", result.getOldLeaderNickName());
+        assertEquals(CrewRole.MEMBER, result.getOldLeaderRole());
+        assertEquals("NewLeader", result.getNewLeaderNickName());
+        assertEquals(CrewRole.LEADER, result.getNewLeaderRole());
+        verify(crewMemberRepository, times(1)).findById(crewMemberId);
+        verify(crewMemberRepository, times(1)).findByMember_IdAndCrew_CrewId(userId, crewId);
+
+        // Verify that roles were changed
+        assertEquals(CrewRole.MEMBER, oldLeader.getRole());
+        assertEquals(CrewRole.LEADER, newLeader.getRole());
+    }
+
+    @Test
+    @DisplayName("newLeader로 지정할 크루원을 찾을 수 없음")
+    void testTransferLeaderRole_NewLeaderNotFound() {
+        // given
+        CrewMemberEntity oldLeader = CrewMemberEntity.builder()
+            .id(1L)
+            .role(CrewRole.LEADER)
+            .member(MemberEntity.builder().id(1L).nickName("OldLeader").build())
+            .build();
+
+        CrewMemberEntity newLeader = CrewMemberEntity.builder()
+            .id(2L)
+            .role(CrewRole.MEMBER)
+            .member(MemberEntity.builder().id(2L).nickName("NewLeader").build())
+            .build();
+
+        Long userId = 1L;
+        Long crewId = 1L;
+        Long crewMemberId = 2L;
+
+        when(crewMemberRepository.findById(crewMemberId)).thenReturn(Optional.empty());
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            crewMemberService.transferLeaderRole(userId, crewId, crewMemberId);
+        });
+
+        // then
+        assertEquals(ErrorCode.NOT_FOUND_CREW_MEMBER, exception.getErrorCode());
+        verify(crewMemberRepository, times(1)).findById(crewMemberId);
+        verify(crewMemberRepository, never()).findByMember_IdAndCrew_CrewId(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("oldLeader를 찾을 수 없음")
+    void testTransferLeaderRole_OldLeaderNotFound() {
+        // given
+        CrewMemberEntity oldLeader = CrewMemberEntity.builder()
+            .id(1L)
+            .role(CrewRole.LEADER)
+            .member(MemberEntity.builder().id(1L).nickName("OldLeader").build())
+            .build();
+
+        CrewMemberEntity newLeader = CrewMemberEntity.builder()
+            .id(2L)
+            .role(CrewRole.MEMBER)
+            .member(MemberEntity.builder().id(2L).nickName("NewLeader").build())
+            .build();
+
+        Long userId = 1L;
+        Long crewId = 1L;
+        Long crewMemberId = 2L;
+
+        when(crewMemberRepository.findById(crewMemberId)).thenReturn(Optional.of(newLeader));
+        when(crewMemberRepository.findByMember_IdAndCrew_CrewId(userId, crewId)).thenReturn(
+            Optional.empty());
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            crewMemberService.transferLeaderRole(userId, crewId, crewMemberId);
+        });
+
+        //then
+        assertEquals(ErrorCode.NOT_FOUND_CREW_MEMBER, exception.getErrorCode());
+
+        verify(crewMemberRepository, times(1)).findById(crewMemberId);
+        verify(crewMemberRepository, times(1)).findByMember_IdAndCrew_CrewId(userId, crewId);
+
+        // not changed
+        assertEquals(CrewRole.LEADER, oldLeader.getRole());
+        assertEquals(CrewRole.MEMBER, newLeader.getRole());
+    }
+
+    @Test
+    void testRemoveCrewMember_Success() {
+        // given
+        MemberEntity member = MemberEntity.builder()
+            .id(2L)
+            .email("test@example.com")
+            .nickName("testNick")
+            .build();
+
+        CrewEntity crew = CrewEntity.builder()
+            .id(1L)
+            .crewName("TestCrew")
+            .build();
+
+        CrewMemberEntity crewMember = CrewMemberEntity.builder()
+            .id(3L)
+            .member(member)
+            .crew(crew)
+            .role(CrewRole.MEMBER)
+            .build();
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(4L)
+            .member(member)
+            .crew(crew)
+            .status(JoinStatus.APPROVED)
+            .build();
+        Long crewId = 1L;
+        Long crewMemberId = 3L;
+
+        CrewMemberBlackListEntity blackList = CrewMemberBlackListEntity.builder()
+            .id(1L)
+            .crew(crew)
+            .member(member)
+            .build();
+
+        when(crewMemberRepository.findById(crewMemberId)).thenReturn(Optional.of(crewMember));
+        when(joinApplicationRepository.findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(
+            crewMember.getMember().getId(), crewId))
+            .thenReturn(Optional.of(joinApplyEntity));
+        when(crewMemberBlackListRepository.save(any(CrewMemberBlackListEntity.class))).thenReturn(
+            blackList);
+
+        // when
+        CrewMemberBlackListEntity result = crewMemberService.removeCrewMember(crewId,
+            crewMemberId);
+
+        // then
+        assertEquals(JoinStatus.FORCE_WITHDRAWN, joinApplyEntity.getStatus());
+        assertEquals(1L, result.getId());
+        verify(crewMemberRepository, times(1)).findById(crewMemberId);
+        verify(joinApplicationRepository, times(1))
+            .findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(crewMember.getMember().getId(),
+                crewId);
+        verify(crewMemberRepository, times(1)).delete(crewMember);
+        verify(chatJoinRepository, times(1)).deleteAllByMemberIdAndCrewId(
+            crewMember.getMember().getId(), crewId);
+        verify(crewMemberBlackListRepository, times(1)).save(any(CrewMemberBlackListEntity.class));
+    }
+
+    @Test
+    @DisplayName("퇴장시킬 크루원을 찾을 수 없음")
+    void testRemoveCrewMember_CrewMemberNotFound() {
+        // given
+        Long crewId = 1L;
+        Long crewMemberId = 3L;
+
+        when(crewMemberRepository.findById(crewMemberId)).thenReturn(Optional.empty());
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            crewMemberService.removeCrewMember(crewId, crewMemberId);
+        });
+
+        // then
+        assertEquals(ErrorCode.NOT_FOUND_CREW_MEMBER, exception.getErrorCode());
+
+        verify(crewMemberRepository, times(1)).findById(crewMemberId);
+        verify(joinApplicationRepository, never())
+            .findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(anyLong(), anyLong());
+        verify(crewMemberRepository, never()).delete(any(CrewMemberEntity.class));
+    }
+
+    @Test
+    @DisplayName("퇴장시킬 크루원의 가입신청내역을 찾을 수 없음")
+    void testRemoveCrewMember_JoinApplyNotFound() {
+        // given
+        MemberEntity member = MemberEntity.builder()
+            .id(2L)
+            .email("test@example.com")
+            .nickName("testNick")
+            .build();
+
+        CrewEntity crew = CrewEntity.builder()
+            .id(1L)
+            .crewName("TestCrew")
+            .build();
+
+        CrewMemberEntity crewMember = CrewMemberEntity.builder()
+            .id(3L)
+            .member(member)
+            .crew(crew)
+            .role(CrewRole.MEMBER)
+            .build();
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(4L)
+            .member(member)
+            .crew(crew)
+            .status(JoinStatus.APPROVED)
+            .build();
+        Long crewId = 1L;
+        Long crewMemberId = 3L;
+
+        when(crewMemberRepository.findById(crewMemberId)).thenReturn(Optional.of(crewMember));
+        when(joinApplicationRepository.findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(
+            crewMember.getMember().getId(), crewId))
+            .thenReturn(Optional.empty());
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            crewMemberService.removeCrewMember(crewId, crewMemberId);
+        });
+
+        // then
+        assertEquals(ErrorCode.NOT_FOUND_APPLY, exception.getErrorCode());
+        assertEquals(JoinStatus.APPROVED, joinApplyEntity.getStatus());
+        verify(crewMemberRepository, times(1)).findById(crewMemberId);
+        verify(joinApplicationRepository, times(1))
+            .findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(crewMember.getMember().getId(),
+                crewId);
+        verify(crewMemberRepository, never()).delete(any(CrewMemberEntity.class));
+    }
+}

--- a/src/test/java/com/example/runningservice/service/LogoutServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/LogoutServiceTest.java
@@ -26,7 +26,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 class LogoutServiceTest {
 
     @Mock
-    private BlackList blackList;
+    private TokenBlackList tokenBlackList;
 
     @Mock
     private JwtUtil jwtUtil;
@@ -115,7 +115,7 @@ class LogoutServiceTest {
         when(authentication.getPrincipal()).thenReturn(customUserDetails);
         when(customUserDetails.getUsername()).thenReturn("username");
         when(jwtUtil.validateToken("username", "validRefreshToken")).thenReturn(true);
-        when(blackList.isListed("validRefreshToken")).thenReturn(true);
+        when(tokenBlackList.isListed("validRefreshToken")).thenReturn(true);
 
         //when
         CustomException exception = assertThrows(CustomException.class,
@@ -132,12 +132,12 @@ class LogoutServiceTest {
         when(authentication.getPrincipal()).thenReturn(customUserDetails);
         when(customUserDetails.getUsername()).thenReturn("username");
         when(jwtUtil.validateToken("username", "validRefreshToken")).thenReturn(true);
-        when(blackList.isListed("validRefreshToken")).thenReturn(false);
+        when(tokenBlackList.isListed("validRefreshToken")).thenReturn(false);
 
         //when
         logoutService.logout(request, response, authentication);
 
-        verify(blackList, times(1)).add("validRefreshToken");
+        verify(tokenBlackList, times(1)).add("validRefreshToken");
         assert (SecurityContextHolder.getContext().getAuthentication() == null);
     }
 }

--- a/src/test/java/com/example/runningservice/service/UserJoinServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/UserJoinServiceTest.java
@@ -27,7 +27,7 @@ import com.example.runningservice.enums.Visibility;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.CrewMemberRepository;
-import com.example.runningservice.repository.CrewRepository;
+import com.example.runningservice.repository.crew.CrewRepository;
 import com.example.runningservice.repository.JoinApplicationRepository;
 import com.example.runningservice.repository.MemberRepository;
 import com.example.runningservice.util.JwtUtil;
@@ -81,7 +81,8 @@ class UserJoinServiceTest {
             .crew(crewEntity).status(JoinStatus.PENDING).build(); // 필드들 초기화
 
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(crewEntity.getId())).thenReturn(
+            Optional.of(crewEntity));
         when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(
             joinApplyEntity);
 
@@ -112,7 +113,8 @@ class UserJoinServiceTest {
             .crew(crewEntity).status(JoinStatus.PENDING).build(); // 필드들 초기화
 
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(anyLong())).thenReturn(
+            Optional.of(crewEntity));
         when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(
             joinApplyEntity);
 
@@ -144,7 +146,8 @@ class UserJoinServiceTest {
             .crew(crewEntity).status(JoinStatus.PENDING).build(); // 필드들 초기화
 
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(crewEntity.getId())).thenReturn(
+            Optional.of(crewEntity));
         when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(
             joinApplyEntity);
 
@@ -176,7 +179,8 @@ class UserJoinServiceTest {
             .crew(crewEntity).status(JoinStatus.PENDING).build(); // 필드들 초기화
 
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(anyLong())).thenReturn(
+            Optional.of(crewEntity));
         when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(
             joinApplyEntity);
 
@@ -208,7 +212,8 @@ class UserJoinServiceTest {
             .crew(crewEntity).status(JoinStatus.PENDING).build(); // 필드들 초기화
 
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(anyLong())).thenReturn(
+            Optional.of(crewEntity));
         when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(
             joinApplyEntity);
 
@@ -240,7 +245,8 @@ class UserJoinServiceTest {
             .crew(crewEntity).status(JoinStatus.PENDING).build(); // 필드들 초기화
 
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(crewEntity.getId())).thenReturn(
+            Optional.of(crewEntity));
         when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(
             joinApplyEntity);
 
@@ -271,7 +277,8 @@ class UserJoinServiceTest {
             .crew(crewEntity).status(JoinStatus.PENDING).build(); // 필드들 초기화
 
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(crewEntity.getId())).thenReturn(
+            Optional.of(crewEntity));
         when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(
             joinApplyEntity);
 
@@ -300,7 +307,8 @@ class UserJoinServiceTest {
             .gender(Gender.FEMALE).leaderRequired(true).build(); // 필드들 초기화
 
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(crewEntity.getId())).thenReturn(
+            Optional.of(crewEntity));
 
         // when
         CustomException exception = assertThrows(CustomException.class,
@@ -322,7 +330,8 @@ class UserJoinServiceTest {
             .gender(Gender.FEMALE).leaderRequired(true).build(); // 필드들 초기화
 
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(crewEntity.getId())).thenReturn(
+            Optional.of(crewEntity));
 
         // when
         CustomException exception = assertThrows(CustomException.class,
@@ -344,82 +353,8 @@ class UserJoinServiceTest {
             .gender(Gender.FEMALE).leaderRequired(true).build(); // 필드들 초기화
 
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
-
-        // when
-        CustomException exception = assertThrows(CustomException.class,
-            () -> userJoinService.saveJoinApply(1L,
-                Request.builder().userId(1L).message("test").build()));
-
-        // then
-        assertEquals(ErrorCode.AGE_REQUIRED, exception.getErrorCode());
-    }
-
-//    @Test
-//    @DisplayName("회원나이 비공개(실패)")
-//    void saveJoinApply_whenJoinPossible_MemberPrivate_Fail() {
-//        // given
-//        MemberEntity memberEntity = MemberEntity.builder().id(1L).email("testEmail")
-//            .nickName("testNickName").birthYear(1994).birthYearVisibility(Visibility.PRIVATE)
-//            .gender(Gender.FEMALE).genderVisibility(Visibility.PUBLIC).build();
-//        CrewEntity crewEntity = CrewEntity.builder().crewId(1L).crewName("testCrewName").maxAge(30)
-//            .gender(Gender.FEMALE).leaderRequired(true).build(); // 필드들 초기화
-//
-//        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-//        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
-//
-//        // when
-//        CustomException exception = assertThrows(CustomException.class,
-//            () -> userJoinService.saveJoinApply(1L,
-//                Request.builder().userId(1L).message("test").build()));
-//
-//        // then
-//        assertEquals(ErrorCode.AGE_REQUIRED, exception.getErrorCode());
-//    }
-//
-//    @Test
-//    @DisplayName("회원나이 비공개 & 나이제한 없음(성공)")
-//    void saveJoinApply_whenJoinPossible_MemberAgePrivate_Success() {
-//        // given
-//        MemberEntity memberEntity = MemberEntity.builder().id(1L).email("testEmail")
-//            .nickName("testNickName").birthYear(1994).birthYearVisibility(Visibility.PRIVATE)
-//            .gender(Gender.FEMALE).build();
-//        CrewEntity crewEntity = CrewEntity.builder().crewId(1L).crewName("testCrewName")
-//            .leaderRequired(true).build(); // 필드들 초기화
-//
-//        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder().id(1L).member(memberEntity)
-//            .crew(crewEntity).status(JoinStatus.PENDING).build(); // 필드들 초기화
-//
-//        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-//        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
-//        when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(
-//            joinApplyEntity);
-//
-//        // when
-//        JoinApplyDto.DetailResponse response = userJoinService.saveJoinApply(1L,
-//            Request.builder().userId(1L).message("test").build());
-//
-//        ArgumentCaptor<JoinApplyEntity> captor = forClass(JoinApplyEntity.class);
-//        verify(joinApplicationRepository).save(captor.capture());
-//
-//        // then
-//        assertEquals(JoinStatus.PENDING, captor.getValue().getStatus());
-//        assertEquals("testNickName", response.getNickname());
-//        assertEquals("testCrewName", response.getCrewName());
-//        verify(joinApplicationRepository, times(1)).save(any(JoinApplyEntity.class));
-//    }
-    @Test
-    @DisplayName("회원나이 비공개(실패)")
-    void saveJoinApply_whenJoinPossible_MemberPrivate_Fail() {
-        // given
-        MemberEntity memberEntity = MemberEntity.builder().id(1L).email("testEmail")
-            .nickName("testNickName").birthYear(1994).birthYearVisibility(Visibility.PRIVATE)
-            .gender(Gender.FEMALE).genderVisibility(Visibility.PUBLIC).build();
-        CrewEntity crewEntity = CrewEntity.builder().id(1L).crewName("testCrewName").maxAge(30)
-            .gender(Gender.FEMALE).leaderRequired(true).build(); // 필드들 초기화
-
-        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(crewEntity.getId())).thenReturn(
+            Optional.of(crewEntity));
 
         // when
         CustomException exception = assertThrows(CustomException.class,
@@ -444,7 +379,8 @@ class UserJoinServiceTest {
             .crew(crewEntity).status(JoinStatus.PENDING).build(); // 필드들 초기화
 
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(crewEntity.getId())).thenReturn(
+            Optional.of(crewEntity));
         when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(
             joinApplyEntity);
 
@@ -476,7 +412,8 @@ class UserJoinServiceTest {
             .crew(crewEntity).status(JoinStatus.PENDING).build(); // 필드들 초기화
 
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(anyLong())).thenReturn(Optional.of(crewEntity));
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(anyLong())).thenReturn(
+            Optional.of(crewEntity));
         when(joinApplicationRepository.save(any(JoinApplyEntity.class))).thenReturn(
             joinApplyEntity);
 
@@ -550,7 +487,7 @@ class UserJoinServiceTest {
         Pageable capturedPageable = pageableCaptor.getValue();
         assertEquals(0, capturedPageable.getPageNumber());
         assertEquals(10, capturedPageable.getPageSize());
-        assertEquals(Sort.by(Sort.Order.desc("createdAt")), capturedPageable.getSort());
+        assertEquals(Sort.by(Sort.Order.asc("createdAt")), capturedPageable.getSort());
     }
 
     @Test
@@ -613,7 +550,8 @@ class UserJoinServiceTest {
         // Given
         String token = "Bearer validToken";
         Long memberId = 1L;
-        GetApplicantsRequestDto request = GetApplicantsRequestDto.builder().status(JoinStatus.PENDING)
+        GetApplicantsRequestDto request = GetApplicantsRequestDto.builder()
+            .status(JoinStatus.PENDING)
             .pageable(PageRequest.of(0, 10, Sort.by(Sort.Order.asc("createdAt")))).build();
 
         JoinApplyEntity entity1 = JoinApplyEntity.builder()
@@ -692,22 +630,29 @@ class UserJoinServiceTest {
             .gender(Gender.FEMALE).build();
         CrewEntity crewEntity = CrewEntity.builder().id(2L).crewName("testCrewName").maxAge(30)
             .leaderRequired(true).build(); // 필드들 초기화
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.PENDING)
+            .build();
 
         JoinApplyDto.Request joinApplyDto = JoinApplyDto.Request.builder().userId(userId)
             .message("testMessage").build();
 
         when(memberRepository.findById(1L)).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(2L)).thenReturn(Optional.of(crewEntity));
-        when(joinApplicationRepository.existsByMember_IdAndCrew_Id(userId, crewId)).thenReturn(
-            true);
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(2L)).thenReturn(
+            Optional.of(crewEntity));
+        when(joinApplicationRepository.findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(userId,
+            crewId)).thenReturn(Optional.of(joinApplyEntity));
 
         // When
         CustomException exception = assertThrows(CustomException.class,
             () -> userJoinService.saveJoinApply(crewId, joinApplyDto));
 
         //then
-        assertEquals(ErrorCode.ALREADY_EXIST_JOIN_APPLY, exception.getErrorCode());
-        verify(joinApplicationRepository, times(1)).existsByMember_IdAndCrew_Id(userId, crewId);
+        assertEquals(ErrorCode.ALREADY_EXIST_PENDING_JOIN_APPLY, exception.getErrorCode());
+        verify(joinApplicationRepository,
+            times(1)).findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(userId, crewId);
     }
 
     @Test
@@ -727,7 +672,8 @@ class UserJoinServiceTest {
             .message("testMessage").build();
 
         when(memberRepository.findById(1L)).thenReturn(Optional.of(memberEntity));
-        when(crewRepository.findById(2L)).thenReturn(Optional.of(crewEntity));
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(2L)).thenReturn(
+            Optional.of(crewEntity));
         when(crewMemberRepository.existsByMember_Id(userId)).thenReturn(true);
 
         // When
@@ -849,5 +795,42 @@ class UserJoinServiceTest {
         CustomException thrownException = assertThrows(CustomException.class,
             () -> userJoinService.removeJoinApply(token, 1L));
         assertEquals(ErrorCode.UNAUTHORIZED_MY_APPLY_ACCESS, thrownException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("강제퇴장된 회원일 경우 재가입 불가_실패")
+    void testSaveJoinApply_BlackListed_fail() {
+        // Given
+        Long userId = 1L;
+        Long crewId = 2L;
+
+        MemberEntity memberEntity = MemberEntity.builder().id(userId).email("testEmail")
+            .nickName("testNickName").birthYear(1995).birthYearVisibility(Visibility.PUBLIC)
+            .gender(Gender.FEMALE).build();
+        CrewEntity crewEntity = CrewEntity.builder().id(crewId).crewName("testCrewName").maxAge(30)
+            .leaderRequired(true).build(); // 필드들 초기화
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .member(memberEntity)
+            .crew(crewEntity)
+            .status(JoinStatus.FORCE_WITHDRAWN)
+            .build();
+
+        JoinApplyDto.Request joinApplyDto = JoinApplyDto.Request.builder().userId(userId)
+            .message("testMessage").build();
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(memberEntity));
+        when(crewRepository.findByIdAndMemberCountLessThanCapacity(2L)).thenReturn(
+            Optional.of(crewEntity));
+        when(joinApplicationRepository.findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(userId,
+            crewId)).thenReturn(Optional.of(joinApplyEntity));
+
+        // When
+        CustomException exception = assertThrows(CustomException.class,
+            () -> userJoinService.saveJoinApply(crewId, joinApplyDto));
+
+        //then
+        assertEquals(ErrorCode.JOIN_NOT_ALLOWED_FOR_FORCE_WITHDRAWN, exception.getErrorCode());
+        verify(joinApplicationRepository,
+            times(1)).findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(userId, crewId);
     }
 }


### PR DESCRIPTION


### 이 PR을 통해 해결하려는 문제
- 가입한 크루원 정보를 조회(리스트 조회, 상세조회)
- 가입한 크루의 권한을 수정(Member -> Staff / Staff -> Member)
- 리더 권한 위임(OldLeader : Leader -> Member / NewLeader : Staff or Member -> Leader)
- 크루 나가기(퇴장)
- 크루 내보내기(강제퇴장)
- 강제퇴장 당한 회원의 경우 해당 크루에 재가입 불가

### 이 PR에서 변경된 사항
크루원 관리 기능(CrewMemberController, CrewMemberService)

- 크루원 조회 (GET "/crew/{crew_id}/member/list")
  - Leader, Staff 권한
  - getCrewMembers(Long crewId, CrewMemberRequestDto.Filter filter, Pageable pageable)
  - QueryDsl 사용하여 구현
  - 필터 조건에 따라 해당 크루의 크루원 조회 (성별, 나이(~이상, ~미만), 권한
  - repostiory 구현하여 리팩토링 필요
- 크루원 개별조회
  - GET "/crew/{crew_id}/member"
  - Leader, Staff 권한
  - getCreMember(crewMemberId)
  - crewMemberId로 조회한 후 컨트롤러에서 dto 변환하여 응답갑 전달
- 리더 권한 위임
  - PATCH "/crew/{crew_id}/transfer-leader"
  - Leader 권한
  - transferLeaderRole(Long userId, Long crewId, Long crewMemberId)
  - CrewEntity에 acceptLeaderRole() 생성하여 해당 객체에 leader권한 저장
  - CrewEntity의 changeRoleTo(CrewRole role) 사용하여 롤 변경(기존 리더는 MEMBER 권한 갖게 로직 구현) / changeRoleTo메서드 파라미터는 기존 객체의 role과 다른 값만 입력 가능
  - 변경 전, 후 리더정도를 dto로 반환
- 크루원 권한 변경
  - PATCH "/crew/{crew_id}/change-role"
  - Leader, Staff 권한
  - changeRole(ChangeCrewRoleRequestDto requestDto)
  - requestDto에서 변경할 권한으로 LEADER를 입력하지 못하게 설정함(@Valid, @CrewRoleValid validator 추가)
  - 컨트롤러에서 권한변경 내용 dto로 변환
- 강제퇴장
  - DELETE "/crew/{crew_id}/remove-member"
  - removeCrewMember(Long crewId, Long crewMemberId)
  - crewMember 테이블에서 삭제
  - joinApply 테이블에서 상태값 변경(Approved -> Force-Withdrawn)
  - blackList 테이블에 회원 정보 저장
  - 회원이 포함되어 있던 모든 chatJoin 테이블에서 회원 정보 삭제 (QueryDsl 통해 구현 ChatJoinRepositoryCustomImpl deleteAllByMemberIdAndCrewId(Long memberId, Long crewID)
  - blackList 정보를 컨트롤러에서 dto로 변환하여 응답
- 크루 퇴장
  - Delete "/crew/{crew_id}/leave"
  - Member, Staff 권한 (Leader는 퇴장 불가)
  - leaveCrew(Long crewId, Long userId)
  - crewMember 테이블에서 삭제
  - joinApply 테이블에서 상태 변경(Approved -> Withdrawn)
  - 가입했던 크루 내 모든 채팅방에서 삭제 크루원 블랙리스트 도메인 추가
    - CrewMemberBlackListEntity
    - CrewMemberBlackListRepository
    - CrewMemberBlackListResponseDto

수정
- UserJoinService
  - repostiory 메서드 변경(crewRepository.findById -> findByIdAndMemberCountLessThanCapacity(Long crewId) : 크루원 수가 정원보다 작은 크루의 데이터 가져오도록 수정
  - 신청내역 있으면 가입신청 제한 -> 최근 신청내역 상태가 PENDING이거나 FORCE_WITHDRAWN이면 가입 신청 제한

기타
- crewId -> id 변경에 따른 메서드명칭 수정 : CrewApplicantService, CrewApplicantServiceTestt
- QueryDsl : CrewRepositoryCustom, ChatJoinRepositoryCustom
- PageUtil : static 메서드로 변경(인스턴스 메서드 사용 시, 매번 의존성 추가해줘야하여 의존성이 커짐)
- JoinStatus에 Withdrawn, force_withdrawn 추가
- 리포지토리 패키지 수정(crew 패키지 생성,
- BlackList 네이밍 변경 -> TokenBlackList
### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [ ] API 테스트
