### PR TITLE
fix : Signup&Login-001 : 회원가입 & oauth2 연결 및 수정

### DIFF
--- a/src/main/java/com/example/runningservice/controller/AuthController.java
+++ b/src/main/java/com/example/runningservice/controller/AuthController.java
@@ -23,14 +23,14 @@ public class AuthController {
     public ResponseEntity<JwtResponse> login(@RequestBody LoginRequestDto loginRequestDto)
         throws Exception {
         JwtResponse jwtResponse = authService.authenticate(loginRequestDto);
-        log.info("{} 님이 로그인에 성공하셨습니다", loginRequestDto.getEmail());
+
         return ResponseEntity.ok(jwtResponse);
     }
 
     @PostMapping("/token/refresh")
     public ResponseEntity<JwtResponse> refreshToken(
-        @RequestHeader(name = "Authorization") String refreshToken, Principal principal)
-        throws Exception {
+        @RequestHeader(name = "Authorization") String refreshToken, Principal principal) {
+
         refreshToken = refreshToken.replace("Bearer ", "");
         return ResponseEntity.ok(authService.refreshToken(refreshToken, principal));
     }

--- a/src/main/java/com/example/runningservice/controller/LogoutController.java
+++ b/src/main/java/com/example/runningservice/controller/LogoutController.java
@@ -18,7 +18,7 @@ public class LogoutController {
     private final LogoutService logoutService;
 
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(@RequestHeader("Authorization") String refreshToken,
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String refreshToken,
         Authentication authentication,
         HttpServletRequest request) {
 

--- a/src/main/java/com/example/runningservice/controller/SignupController.java
+++ b/src/main/java/com/example/runningservice/controller/SignupController.java
@@ -1,15 +1,21 @@
 package com.example.runningservice.controller;
 
-import com.example.runningservice.dto.member.MemberResponseDto;
+import com.example.runningservice.dto.Oauth2DataDto;
 import com.example.runningservice.dto.SignupRequestDto;
+import com.example.runningservice.dto.member.MemberResponseDto;
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.MemberRepository;
 import com.example.runningservice.service.SignupService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -19,22 +25,55 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class SignupController {
 
     private final SignupService signupService;
+    private final MemberRepository memberRepository;
 
     @PostMapping("/signup")
     public ResponseEntity<MemberResponseDto> signup(
-        @RequestBody @Valid SignupRequestDto signupRequestDto) throws Exception {
+        @ModelAttribute @Valid SignupRequestDto signupRequestDto) throws Exception {
         // 사용자 정보 저장
         return ResponseEntity.ok(signupService.signup(signupRequestDto));
     }
 
     @PostMapping("/signup/email-send")
-    ResponseEntity<?> sendVerifyEmail(@RequestParam String email) {
+    ResponseEntity<Void> sendVerifyEmail(@RequestParam String email) {
         signupService.sendEmail(email);
         return ResponseEntity.ok().build();
     }
 
     @PutMapping("/signup/email-verify")
-    ResponseEntity<Boolean> verifyUser(@RequestParam String email, @RequestParam String code) {
-        return ResponseEntity.ok(signupService.verifyUser(email, code));
+    ResponseEntity<Void> verifyUser(@RequestParam String email, @RequestParam String code) {
+        signupService.verifyUser(email, code);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/user/signup/nickname-verify")
+    ResponseEntity<?> verifyNickname(@RequestParam String nickname) {
+
+        signupService.verifyNickName(nickname);
+        return ResponseEntity.ok().build();
+    }
+
+    //필수정보 확인
+    //채워지지 않은 필수정보 입력하도록 함
+    @GetMapping("/additional-info")
+    public ResponseEntity<Oauth2DataDto> showAdditionalInfoForm(@RequestParam("email") String email) {
+        // 이메일을 통해 기존 회원 정보를 가져옴
+        MemberEntity memberEntity = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        // DTO 초기화 및 기본 값 설정
+        Oauth2DataDto form = Oauth2DataDto.builder()
+            .email(email)
+            .name(memberEntity.getName())
+            .image(memberEntity.getProfileImageUrl())
+            .build();
+
+        return ResponseEntity.ok(form);
+    }
+
+    @PostMapping("/additional-info")
+    public ResponseEntity<?> processAdditionalInfo(@ModelAttribute @Valid SignupRequestDto form) {
+
+        return ResponseEntity.ok(signupService.saveAdditionalInfo(form));
     }
 }

--- a/src/main/java/com/example/runningservice/dto/Oauth2DataDto.java
+++ b/src/main/java/com/example/runningservice/dto/Oauth2DataDto.java
@@ -1,0 +1,10 @@
+package com.example.runningservice.dto;
+
+import lombok.Builder;
+
+@Builder
+public class Oauth2DataDto {
+    String email;
+    String name;
+    String image;
+}

--- a/src/main/java/com/example/runningservice/dto/SignupRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/SignupRequestDto.java
@@ -4,18 +4,22 @@ import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Region;
 import com.example.runningservice.enums.Role;
+import com.example.runningservice.enums.Visibility;
 import com.example.runningservice.util.AESUtil;
 import com.example.runningservice.util.validator.PasswordMatches;
 import com.example.runningservice.util.validator.ValidYear;
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
-
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -63,6 +67,15 @@ public class SignupRequestDto {
     private Region activityRegion;
     private MultipartFile profileImage; // 프로필 이미지 추가
 
+    @NotNull
+    private Visibility nameVisibility = Visibility.PRIVATE;
+    @NotNull
+    private Visibility phoneNumberVisibility = Visibility.PRIVATE;
+    @NotNull
+    private Visibility genderVisibility = Visibility.PRIVATE;
+    @NotNull
+    private Visibility birthYearVisibility = Visibility.PRIVATE;
+
     public MemberEntity toEntity(PasswordEncoder passwordEncoder, AESUtil aesUtil) throws Exception {
         return MemberEntity.builder()
             .email(email)
@@ -75,6 +88,10 @@ public class SignupRequestDto {
             .gender(gender)
             .activityRegion(activityRegion)
             .roles(new ArrayList<>(List.of(Role.ROLE_USER)))
+            .nameVisibility(nameVisibility)
+            .phoneNumberVisibility(phoneNumberVisibility)
+            .genderVisibility(genderVisibility)
+            .birthYearVisibility(birthYearVisibility)
             .build();
     }
 }

--- a/src/main/java/com/example/runningservice/dto/member/MemberResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/member/MemberResponseDto.java
@@ -4,10 +4,14 @@ import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Region;
 import com.example.runningservice.enums.Role;
+import com.example.runningservice.enums.Visibility;
 import com.example.runningservice.util.AESUtil;
-import lombok.*;
-
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -28,7 +32,12 @@ public class MemberResponseDto {
     private Region activityRegion;
     private String imageUrl;
 
-    public static MemberResponseDto of(MemberEntity memberEntity, AESUtil aesUtil) throws Exception {
+    private Visibility nameVisibility;
+    private Visibility phoneNumberVisibility;
+    private Visibility genderVisibility;
+    private Visibility birthYearVisibility;
+
+    public static MemberResponseDto of(MemberEntity memberEntity, AESUtil aesUtil) {
 
         return MemberResponseDto.builder()
                     .id(memberEntity.getId())
@@ -41,6 +50,10 @@ public class MemberResponseDto {
                     .roles(memberEntity.getRoles())
                     .activityRegion(memberEntity.getActivityRegion())
                     .imageUrl(memberEntity.getProfileImageUrl())
+                    .nameVisibility(memberEntity.getNameVisibility())
+                    .phoneNumberVisibility(memberEntity.getPhoneNumberVisibility())
+                    .genderVisibility(memberEntity.getGenderVisibility())
+                    .birthYearVisibility(memberEntity.getBirthYearVisibility())
                     .build();
     }
 }

--- a/src/main/java/com/example/runningservice/entity/MemberEntity.java
+++ b/src/main/java/com/example/runningservice/entity/MemberEntity.java
@@ -1,5 +1,6 @@
 package com.example.runningservice.entity;
 
+import com.example.runningservice.dto.SignupRequestDto;
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Notification;
 import com.example.runningservice.enums.Region;
@@ -115,5 +116,17 @@ public class MemberEntity extends BaseEntity {
         this.phoneNumberVisibility = phoneNumberVisibility;
         this.genderVisibility = genderVisibility;
         this.birthYearVisibility = birthYearVisibility;
+    }
+
+    public void updateAdditionalInfo(SignupRequestDto form) {
+        this.name = form.getName();
+        this.phoneNumber = form.getPhoneNumber();
+        this.gender = form.getGender();
+        this.birthYear = form.getBirthYear();
+        this.activityRegion = form.getActivityRegion();
+        this.nameVisibility = form.getNameVisibility();
+        this.genderVisibility = form.getGenderVisibility();
+        this.birthYearVisibility = form.getBirthYearVisibility();
+        this.phoneNumberVisibility = form.getPhoneNumberVisibility();
     }
 }

--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -33,6 +33,10 @@ public enum ErrorCode {
     UNAUTHORIZED_ACTIVITY(HttpStatus.FORBIDDEN, "활동 접근 권한이 없습니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작 날짜가 종료 날짜보다 빨라야 합니다."),
     NOT_FOUND_CHATROOM(HttpStatus.BAD_REQUEST, "채팅방을 찾을 수 없습니다."),
+    GOOGLE_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "Google 로그인에 실패했습니다."),
+    ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다."),
+    MISSING_REQUIRED_INFORMATION(HttpStatus.BAD_REQUEST, "필수 정보가 누락되었습니다."),
 
     //크루가입
     ALREADY_EXIST_PENDING_JOIN_APPLY(HttpStatus.BAD_REQUEST, "이미 거압 숭안 대기중입니다."),

--- a/src/main/java/com/example/runningservice/repository/CrewMemberRepository.java
+++ b/src/main/java/com/example/runningservice/repository/CrewMemberRepository.java
@@ -18,7 +18,7 @@ public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Lo
 
     Page<CrewMemberEntity> findByMember_IdOrderByJoinedAt(Long memberId, Pageable pageable);
 
-    Optional<CrewMemberEntity> findByMember_IdAndCrew_CrewId(Long memberId, Long crewId);
+    Optional<CrewMemberEntity> findByMember_IdAndCrew_Id(Long memberId, Long crewId);
 
     Boolean existsByMember_Id(Long memberId);
 

--- a/src/main/java/com/example/runningservice/repository/MemberRepository.java
+++ b/src/main/java/com/example/runningservice/repository/MemberRepository.java
@@ -3,10 +3,9 @@ package com.example.runningservice.repository;
 import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
@@ -20,4 +19,6 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
         return findById(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
     }
+
+    Boolean existsByNickName(String nickName);
 }

--- a/src/main/java/com/example/runningservice/repository/chat/ChatRoomRepository.java
+++ b/src/main/java/com/example/runningservice/repository/chat/ChatRoomRepository.java
@@ -15,6 +15,4 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> 
         return findById(roomId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CHATROOM));
     }
-
-    void deleteAllByCrewMember_Id(Long crewMemberId);
 }

--- a/src/main/java/com/example/runningservice/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/runningservice/security/JwtAuthenticationFilter.java
@@ -27,9 +27,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     // 토큰이 없거나 유효하지 않은 경우 필터 체인으로 넘김
     @Override
     protected void doFilterInternal(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain chain
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain chain
     ) throws ServletException, IOException {
         String accessJwt = resolveToken(request, ACCESS_TOKEN_HEADER);
         log.debug("request path: {}", request.getRequestURI());

--- a/src/main/java/com/example/runningservice/service/CrewMemberService.java
+++ b/src/main/java/com/example/runningservice/service/CrewMemberService.java
@@ -208,7 +208,7 @@ public class CrewMemberService {
         CrewMemberEntity newLeader = crewMemberRepository.findById(crewMemberId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW_MEMBER));
 
-        CrewMemberEntity oldLeader = crewMemberRepository.findByMember_IdAndCrew_CrewId(
+        CrewMemberEntity oldLeader = crewMemberRepository.findByMember_IdAndCrew_Id(
             userId, crewId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW_MEMBER));
 
         newLeader.acceptLeaderRole();

--- a/src/main/java/com/example/runningservice/service/LogoutService.java
+++ b/src/main/java/com/example/runningservice/service/LogoutService.java
@@ -2,8 +2,6 @@ package com.example.runningservice.service;
 
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
-import com.example.runningservice.security.CustomUserDetails;
-import com.example.runningservice.util.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,11 +17,14 @@ import org.springframework.stereotype.Service;
 public class LogoutService implements LogoutHandler {
 
     private final TokenBlackList tokenBlackList;
-    private final JwtUtil jwtUtil;
 
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response,
         Authentication authentication) {
+
+        if (authentication == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
         String authHeader = request.getHeader("Authorization");
 
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
@@ -31,11 +32,6 @@ public class LogoutService implements LogoutHandler {
         }
 
         String refreshToken = authHeader.substring("Bearer ".length());
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-
-        if (!jwtUtil.validateToken(userDetails.getUsername(), refreshToken)) {
-            throw new CustomException(ErrorCode.INVALID_TOKEN);
-        }
 
         if (tokenBlackList.isListed(refreshToken)) {
             throw new CustomException(ErrorCode.INVALID_TOKEN);

--- a/src/main/java/com/example/runningservice/service/OAuth2Service.java
+++ b/src/main/java/com/example/runningservice/service/OAuth2Service.java
@@ -4,6 +4,8 @@ package com.example.runningservice.service;
 import com.example.runningservice.dto.googleToken.GoogleAccessTokenRequestDto;
 import com.example.runningservice.dto.googleToken.GoogleAccessTokenResponseDto;
 import com.example.runningservice.dto.googleToken.GoogleAccountProfileResponseDto;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.util.AESUtil;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -37,31 +39,35 @@ public class OAuth2Service {
     private final RestTemplate restTemplate;
     private final AESUtil aesUtil;
 
-    public GoogleAccountProfileResponseDto getGoogleAccountProfile(final String code) throws LoginException, Exception {
+    public GoogleAccountProfileResponseDto getGoogleAccountProfile(final String code) {
         final String accessToken = requestGoogleAccessToken(code);
         return requestGoogleAccountProfile(accessToken);
     }
 
-    private String requestGoogleAccessToken(final String code) throws LoginException, Exception {
-        final String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
-        final HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
-        final HttpEntity<GoogleAccessTokenRequestDto> httpEntity = new HttpEntity<>(
-            GoogleAccessTokenRequestDto.builder()
-                .client_id(aesUtil.decrypt(clientId))
-                .client_secret(aesUtil.decrypt(clientSecret))
-                .code(decodedCode)
-                .redirect_uri(redirectUri)
-                .grant_type(authorizationCode)
-                .build(),
-            headers
-        );
-        final GoogleAccessTokenResponseDto response = restTemplate.exchange(
-            accessTokenUrl, HttpMethod.POST, httpEntity, GoogleAccessTokenResponseDto.class
-        ).getBody();
-        return Optional.ofNullable(response)
-            .orElseThrow(() -> new LoginException("구글로그인을 찾을 수 없습니다."))
-            .getAccess_token();
+    private String requestGoogleAccessToken(final String code) {
+        try {
+            final String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+            final HttpHeaders headers = new HttpHeaders();
+            headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+            final HttpEntity<GoogleAccessTokenRequestDto> httpEntity = new HttpEntity<>(
+                GoogleAccessTokenRequestDto.builder()
+                    .client_id(aesUtil.decrypt(clientId))
+                    .client_secret(aesUtil.decrypt(clientSecret))
+                    .code(decodedCode)
+                    .redirect_uri(redirectUri)
+                    .grant_type(authorizationCode)
+                    .build(),
+                headers
+            );
+            final GoogleAccessTokenResponseDto response = restTemplate.exchange(
+                accessTokenUrl, HttpMethod.POST, httpEntity, GoogleAccessTokenResponseDto.class
+            ).getBody();
+            return Optional.ofNullable(response)
+                .orElseThrow(() -> new LoginException("구글로그인을 찾을 수 없습니다."))
+                .getAccess_token();
+        } catch (LoginException e) {
+            throw new CustomException(ErrorCode.GOOGLE_LOGIN_FAILED);
+        }
     }
 
     private GoogleAccountProfileResponseDto requestGoogleAccountProfile(final String accessToken) {

--- a/src/main/java/com/example/runningservice/service/Oauth2CustomSuccessHandler.java
+++ b/src/main/java/com/example/runningservice/service/Oauth2CustomSuccessHandler.java
@@ -1,0 +1,105 @@
+package com.example.runningservice.service;
+
+import com.example.runningservice.dto.JwtResponse;
+import com.example.runningservice.dto.googleToken.GoogleAccountProfileResponseDto;
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.enums.Role;
+import com.example.runningservice.repository.MemberRepository;
+import com.example.runningservice.util.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class Oauth2CustomSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final MemberRepository memberRepository;
+    private final JwtUtil jwtUtil;
+    private final OAuth2Service oAuth2Service;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException, ServletException {
+        OAuth2User oauthUser = (OAuth2User) authentication.getPrincipal();
+        String code = oauthUser.getAttribute("code");
+
+        // OAuth2Service를 사용하여 Google 프로필 정보를 가져옴
+        GoogleAccountProfileResponseDto profile = oAuth2Service.getGoogleAccountProfile(code);
+        //email, name, 이미지 받기
+        String email = profile.getEmail();
+        String name = profile.getName();
+        String image = profile.getPicture();
+
+        MemberEntity memberEntity = memberRepository.findByEmail(profile.getEmail())
+            .orElseGet(
+                () -> memberRepository.save(memberRepository.save(MemberEntity.builder()
+                    .email(email)
+                    .name(name)
+                    .profileImageUrl(image)
+                    .roles(new ArrayList<>(List.of(Role.ROLE_USER)))
+                    .build())));
+
+        // 추가 정보 입력이 필요한 경우 리디렉션
+        if (!isInfoComplete(memberEntity)) {
+            response.sendRedirect("/additional-info?email=" + email);
+            return;
+        }
+        // 필수정보가 모두 있을 시, 토큰 발행(로그인 완료)
+        List<GrantedAuthority> authorities = memberEntity.getRoles().stream()
+            .map(role -> new SimpleGrantedAuthority(role.name()))
+            .collect(Collectors.toList());
+
+        String accessToken = jwtUtil.generateToken(memberEntity.getEmail(), memberEntity.getId(),
+            authorities);
+
+        String refreshToken = jwtUtil.generateRefreshToken(memberEntity.getEmail(),
+            memberEntity.getId(), authorities);
+
+        JwtResponse jwtResponse = JwtResponse.builder().accessJwt(accessToken)
+            .refreshJwt(refreshToken).build();
+
+        // 응답 타입을 JSON으로 설정
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        // 응답으로 토큰 전송
+        response.getWriter().write(objectMapper.writeValueAsString(jwtResponse));
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+        FilterChain chain, Authentication authentication) throws IOException, ServletException {
+
+        // 이 메서드에서 위의 onAuthenticationSuccess 메서드를 호출하고 체인을 통해 다음 필터로 넘김
+        this.onAuthenticationSuccess(request, response, authentication);
+        chain.doFilter(request, response);
+    }
+
+    private boolean isInfoComplete(MemberEntity member) {
+        // 필수 정보가 모두 있는지 검증
+        return member.getName() != null &&
+            member.getPhoneNumber() != null &&
+            member.getBirthYear() != null &&
+            member.getActivityRegion() != null &&
+            member.getNickName() != null &&
+            member.getPhoneNumberVisibility() != null &&
+            member.getBirthYearVisibility() != null &&
+            member.getGenderVisibility() != null &&
+            member.getNameVisibility() != null;
+    }
+}

--- a/src/main/java/com/example/runningservice/service/SignupService.java
+++ b/src/main/java/com/example/runningservice/service/SignupService.java
@@ -52,7 +52,7 @@ public class SignupService {
         memberEntity.saveVerificationCode(code);
 
         //이메일 전송
-        String from = "wadadak@example.com";
+        String from = "simzoo93@naver.com";
         String to = email;
         String subject = "Email 인증메일입니다.";
         String text = getBody(email, memberEntity.getName(), code);
@@ -60,7 +60,7 @@ public class SignupService {
     }
 
     @Transactional
-    public boolean verifyUser(String email, String code) {
+    public void verifyUser(String email, String code) {
         // 이메일로 사용자 찾기
         MemberEntity memberEntity = memberRepository.findByEmail(email)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
@@ -72,9 +72,6 @@ public class SignupService {
 
         // 이메일을 인증된 상태로 표시
         memberEntity.markEmailVerified();
-
-        // 이메일이 인증되었는지를 반환
-        return memberEntity.isEmailVerified();
     }
 
     private void validateRegisterForm(SignupRequestDto registerForm) throws Exception {
@@ -115,5 +112,23 @@ public class SignupService {
         } else { // 크루 이미지가 없으면 기본 이미지로 사용
             return s3FileUtil.getImgUrl("user-default");
         }
+    }
+
+    @Transactional
+    public void verifyNickName(String nickname) {
+        if (memberRepository.existsByNickName(nickname)) {
+            throw new CustomException(ErrorCode.ALREADY_EXIST_NICKNAME);
+        }
+    }
+
+    @Transactional
+    public MemberResponseDto saveAdditionalInfo(SignupRequestDto form) {
+        // 기존 회원 정보 업데이트
+        MemberEntity memberEntity = memberRepository.findByEmail(form.getEmail())
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        memberEntity.updateAdditionalInfo(form);
+
+        return MemberResponseDto.of(memberRepository.save(memberEntity), aesUtil);
     }
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>My Application</title>
+</head>
+<body>
+<h1>Welcome to My Application</h1>
+<p>This is the home page.</p>
+</body>
+</html>

--- a/src/test/java/com/example/runningservice/controller/CrewApplicantControllerTest.java
+++ b/src/test/java/com/example/runningservice/controller/CrewApplicantControllerTest.java
@@ -1,0 +1,127 @@
+package com.example.runningservice.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.runningservice.dto.join.CrewApplicantDetailResponseDto;
+import com.example.runningservice.dto.join.CrewApplicantResponseDto;
+import com.example.runningservice.dto.join.GetApplicantsRequestDto;
+import com.example.runningservice.enums.JoinStatus;
+import com.example.runningservice.repository.CrewMemberRepository;
+import com.example.runningservice.security.JwtAuthenticationFilter;
+import com.example.runningservice.service.CrewApplicantService;
+import com.example.runningservice.util.JwtUtil;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+@WebMvcTest(CrewApplicantController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+//@Import({CrewRoleCheckAspect.class})  // AOP 설정을 테스트에 포함시킵니다.
+class CrewApplicantControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CrewApplicantService crewApplicantService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @MockBean
+    private CrewMemberRepository crewMemberRepository;
+
+    @Test
+    @DisplayName("모든 가입신청자 리스트 조회")
+    @WithMockUser("USER")
+    void getAllApplicants_success() throws Exception {
+        //given
+        Long userId = 1L;
+        Long crewId = 2L;
+
+//        // CrewMemberEntity를 모킹하여 LEADER 권한을 반환하도록 설정
+//        when(crewMemberRepository.findByCrew_CrewIdAndMember_Id(eq(crewId), eq(userId)))
+//            .thenReturn(Optional.of(CrewMemberEntity.builder()
+//                .role(CrewRole.LEADER)
+//                .build()));
+
+        GetApplicantsRequestDto requestDto = GetApplicantsRequestDto.builder()
+            .status(JoinStatus.PENDING)
+            .pageable(PageRequest.of(0, 5))
+            .build();
+
+        CrewApplicantResponseDto crewApplicantResponseDto1 = CrewApplicantDetailResponseDto
+            .builder()
+            .nickName("testNick1")
+            .profileImage("testImage1")
+            .message("testMessage1")
+            .appliedAt(LocalDateTime.of(2024, 1, 1, 1, 1))
+            .build();
+
+        CrewApplicantResponseDto crewApplicantResponseDto2 = CrewApplicantDetailResponseDto
+            .builder()
+            .nickName("testNick2")
+            .profileImage("testImage2")
+            .message("testMessage2")
+            .appliedAt(LocalDateTime.of(2024, 1, 1, 1, 2))
+            .build();
+
+        Page<CrewApplicantResponseDto> responsePage = new PageImpl<>(
+            List.of(crewApplicantResponseDto1, crewApplicantResponseDto2));
+
+        when(jwtUtil.validateToken(1L, "mockToken")).thenReturn(true);
+        when(jwtUtil.getAuthentication("mockToken")).thenReturn(
+            new UsernamePasswordAuthenticationToken("user", null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+        when(crewApplicantService.getAllJoinApplications(eq(crewId), eq(requestDto))).thenReturn(
+            responsePage);
+        //when
+        //then
+        mockMvc.perform(get("/crew/2/join/list")
+                .param("status", JoinStatus.PENDING.name())
+                .param("page", "0")
+                .param("size", "5")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(request -> {
+                    request.addHeader("Authorization", "Bearer mockToken");
+                    request.setAttribute("loginId", 1L);
+                    return request;
+                }))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].nickName").value("testNick1"))
+                .andExpect(jsonPath("$.content[1].nickName").value("testNick2"));
+    }
+
+    private RequestPostProcessor mockJwtToken() {
+        return request -> {
+            request.addHeader("Authorization", "Bearer mockToken");
+            request.setAttribute("loginId", 1L);  // Manually setting loginId
+            return request;
+        };
+    }
+}

--- a/src/test/java/com/example/runningservice/service/CrewMemberServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/CrewMemberServiceTest.java
@@ -445,7 +445,7 @@ class CrewMemberServiceTest {
         Long crewMemberId = 2L;
 
         when(crewMemberRepository.findById(crewMemberId)).thenReturn(Optional.of(newLeader));
-        when(crewMemberRepository.findByMember_IdAndCrew_CrewId(userId, crewId)).thenReturn(
+        when(crewMemberRepository.findByMember_IdAndCrew_Id(userId, crewId)).thenReturn(
             Optional.of(oldLeader));
 
         // when
@@ -459,7 +459,7 @@ class CrewMemberServiceTest {
         assertEquals("NewLeader", result.getNewLeaderNickName());
         assertEquals(CrewRole.LEADER, result.getNewLeaderRole());
         verify(crewMemberRepository, times(1)).findById(crewMemberId);
-        verify(crewMemberRepository, times(1)).findByMember_IdAndCrew_CrewId(userId, crewId);
+        verify(crewMemberRepository, times(1)).findByMember_IdAndCrew_Id(userId, crewId);
 
         // Verify that roles were changed
         assertEquals(CrewRole.MEMBER, oldLeader.getRole());
@@ -496,7 +496,7 @@ class CrewMemberServiceTest {
         // then
         assertEquals(ErrorCode.NOT_FOUND_CREW_MEMBER, exception.getErrorCode());
         verify(crewMemberRepository, times(1)).findById(crewMemberId);
-        verify(crewMemberRepository, never()).findByMember_IdAndCrew_CrewId(anyLong(), anyLong());
+        verify(crewMemberRepository, never()).findByMember_IdAndCrew_Id(anyLong(), anyLong());
     }
 
     @Test
@@ -520,7 +520,7 @@ class CrewMemberServiceTest {
         Long crewMemberId = 2L;
 
         when(crewMemberRepository.findById(crewMemberId)).thenReturn(Optional.of(newLeader));
-        when(crewMemberRepository.findByMember_IdAndCrew_CrewId(userId, crewId)).thenReturn(
+        when(crewMemberRepository.findByMember_IdAndCrew_Id(userId, crewId)).thenReturn(
             Optional.empty());
 
         // when
@@ -532,7 +532,7 @@ class CrewMemberServiceTest {
         assertEquals(ErrorCode.NOT_FOUND_CREW_MEMBER, exception.getErrorCode());
 
         verify(crewMemberRepository, times(1)).findById(crewMemberId);
-        verify(crewMemberRepository, times(1)).findByMember_IdAndCrew_CrewId(userId, crewId);
+        verify(crewMemberRepository, times(1)).findByMember_IdAndCrew_Id(userId, crewId);
 
         // not changed
         assertEquals(CrewRole.LEADER, oldLeader.getRole());

--- a/src/test/java/com/example/runningservice/service/SignupServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/SignupServiceTest.java
@@ -1,10 +1,12 @@
 package com.example.runningservice.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -12,8 +14,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.example.runningservice.client.MailgunClient;
-import com.example.runningservice.dto.member.MemberResponseDto;
 import com.example.runningservice.dto.SignupRequestDto;
+import com.example.runningservice.dto.member.MemberResponseDto;
 import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Region;
@@ -29,7 +31,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -246,11 +247,11 @@ class SignupServiceTest {
         when(memberRepository.findByEmail(anyString())).thenReturn(Optional.of(memberEntity));
 
         // When
-        boolean result = signupService.verifyUser("test@example.com", "valid-code");
+        signupService.verifyUser("test@example.com", "valid-code");
 
         // Then
-        assertTrue(result);
         verify(memberRepository, times(1)).findByEmail(anyString());
+        assertEquals(true, memberEntity.isEmailVerified());
     }
 
     @Test


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 회원가입 api에서 이미지 파일을 다룰 수 있도록 파라미터 변경
- oauth2 로그인과 자체서비스 로그인 기능 연결
- 소셜계정으로 로그인 했을 시, 부족한 필수 정보는 추가로 받아 저장한다. 

### 이 PR에서 변경된 사항
추가된 api
- 닉네임 중복인증 요청 api
- oauth2에서 받아온 정보 조회 api (GET /additional-info)
- oauth2에서 받아온 정보 외 필수 정보 추가 저장 (POST /additional-info)

security 설정 수정
- oauth2 연결에 맞게 수정 
- Oauth2CustomSuccessHandler 주입하여 사용
- Oauth2CustomSuccessHandler : 구글로부터 받아온 데이터확인 후 토큰 발행 (필수 정보 부족할 시 redirect)

기타
- LogoutService : jwtAuthenticationFilter와 중복되지 않게 토큰 검증 부분 삭제
- SignupController POST "/user/signup" 파라미터를 RequestBody Valid -> ModelAttribute Valid 수정

### 참고 스크린샷

### 기타
- Oauth2 테스트의 경우 테스트 계정 등록이 필요하여 진행하지 못함
- Mailgun 테스트 시 wadadak@example.com으로 진행하였으나 DMARC 정책에 걸려 실제 사용하는 이메일 사용


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [x] API 테스트
