### PR TITLE
fix : Join-User-001 가입신청 관련 사용자 기능 부분 수정

### DIFF
--- a/src/main/java/com/example/runningservice/controller/UserJoinController.java
+++ b/src/main/java/com/example/runningservice/controller/UserJoinController.java
@@ -1,16 +1,18 @@
 package com.example.runningservice.controller;
 
+import com.example.runningservice.dto.UpdateJoinApplyDto;
 import com.example.runningservice.dto.join.GetApplicantsRequestDto;
 import com.example.runningservice.dto.join.JoinApplyDto;
 import com.example.runningservice.dto.join.JoinApplyDto.SimpleResponse;
-import com.example.runningservice.dto.UpdateJoinApplyDto;
 import com.example.runningservice.enums.JoinStatus;
 import com.example.runningservice.service.UserJoinService;
-import com.example.runningservice.util.JwtUtil;
+import com.example.runningservice.util.LoginUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,7 +20,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,60 +29,66 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserJoinController {
 
     private final UserJoinService userJoinService;
-    private final JwtUtil jwtUtil;
 
-    //가입신청
-    @PostMapping("crew/join/apply")
+    /**
+     * 가입신청
+     */
+    @PostMapping("crew/{crew_id}/join/apply")
     public ResponseEntity<JoinApplyDto.DetailResponse> createJoinApplication(
-        @PathVariable("crew_id") Long crewId, @RequestHeader("Authorization") String token,
+        @LoginUser Long userId, @PathVariable("crew_id") Long crewId,
         @RequestBody JoinApplyDto.Request joinRequestForm) {
-        return ResponseEntity.ok(userJoinService.saveJoinApply(crewId, joinRequestForm));
+        return ResponseEntity.ok(userJoinService.saveJoinApply(crewId, userId, joinRequestForm));
     }
 
-    //가입신청내역 조회(사용자가 조회)
-    @GetMapping("user/{user_id}/join/apply/list")
-    public ResponseEntity<Page<SimpleResponse>> getJoinApplicaations(
-        @RequestHeader("Authorization") String token, @PathVariable("user_id") Long userId,
-        @RequestParam JoinStatus status, Pageable pageable) {
+    /**
+     * 사용자가 자신의 가입신청 리스트 조회
+     */
+    @GetMapping("user/join/apply/list")
+    public ResponseEntity<Page<SimpleResponse>> getJoinApplications(
+        @LoginUser Long userId, @RequestParam(required = false) JoinStatus status,
+        @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable) {
 
         GetApplicantsRequestDto joinApplicationsDto = GetApplicantsRequestDto.builder()
-            .status(status)
-            .pageable(pageable)
-            .build();
+                .status(status)
+                .pageable(pageable)
+                .build();
 
-        return ResponseEntity.ok(
-            userJoinService.getJoinApplications(token, userId, joinApplicationsDto));
+            return ResponseEntity.ok(
+                userJoinService.getJoinApplications(userId, joinApplicationsDto));
+        }
+
+        /**
+         *  사용자가 자신의 가입신청내역 상세 조회
+         */
+        @GetMapping("user/join/apply")
+        public ResponseEntity<JoinApplyDto.DetailResponse> getJoinApplicationDetail (
+            @LoginUser Long userId, @RequestParam Long joinApplyId){
+
+            return ResponseEntity.ok(
+                userJoinService.getJoinApplicationDetail(userId, joinApplyId));
+        }
+
+        /**
+         * 가입신청 수정
+         */
+        //신청내역 수정
+        @PutMapping("crew/join/apply")
+        public ResponseEntity<JoinApplyDto.DetailResponse> updateJoinApply (
+            @LoginUser Long userId,
+            @RequestBody UpdateJoinApplyDto updateJoinApplyDto){
+            return ResponseEntity.ok(
+                userJoinService.updateJoinApply(userId, updateJoinApplyDto));
+        }
+
+        /**
+         * 가입신청 취소
+         */
+        //크루 가입신청 취소
+        @DeleteMapping("/crew/join/apply")
+        public ResponseEntity<Void> cancelJoinApply (
+            @LoginUser Long userId, @RequestParam Long joinApplyId){
+
+            userJoinService.removeJoinApply(userId, joinApplyId);
+            return ResponseEntity.ok().build();
+        }
     }
-
-    //가입신청내역 상세조회(사용자가 조회)
-    @GetMapping("user/{user_id}/join/apply")
-    public ResponseEntity<JoinApplyDto.DetailResponse> getJoinApplicationDetail(
-        @PathVariable("user_id") Long userId, @RequestHeader("Authorization") String token,
-        @RequestParam Long joinApplyId) {
-
-        return ResponseEntity.ok(
-            userJoinService.getJoinApplicationDetail(token, userId, joinApplyId));
-    }
-
-    //신청내역 수정
-    @PutMapping("crew/join/apply")
-    public ResponseEntity<JoinApplyDto.DetailResponse> updateJoinApply(
-        @RequestHeader("Authorization") String token,
-        @RequestBody UpdateJoinApplyDto updateJoinApplyDto) {
-        return ResponseEntity.ok(
-            userJoinService.updateJoinApply(token, updateJoinApplyDto));
-    }
-
-    //크루 가입신청 취소
-    @DeleteMapping("/crew/join/apply")
-    public ResponseEntity<String> cancelJoinApply(
-        @RequestHeader("Authorization") String token, @RequestParam Long joinApplyId) {
-
-        userJoinService.removeJoinApply(token, joinApplyId);
-
-        String message = String.format("{} 님이 크루 가입 신청을 취소하였습니다.",
-            jwtUtil.extractEmail(token.substring("Bearer ".length())));
-
-        return ResponseEntity.ok(message);
-    }
-}

--- a/src/main/java/com/example/runningservice/dto/join/JoinApplyDto.java
+++ b/src/main/java/com/example/runningservice/dto/join/JoinApplyDto.java
@@ -2,20 +2,22 @@ package com.example.runningservice.dto.join;
 
 import com.example.runningservice.entity.JoinApplyEntity;
 import com.example.runningservice.enums.JoinStatus;
-import jakarta.validation.constraints.NotBlank;
+import com.example.runningservice.enums.Region;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 public class JoinApplyDto {
 
     @Getter
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Request {
-        @NotBlank
-        Long userId;
         @Size(max = 100)
         String message;
     }
@@ -23,18 +25,23 @@ public class JoinApplyDto {
     @Getter
     @Builder
     public static class SimpleResponse {
-        private String nickname;
+        private Long joinApplyId;
         private String crewName;
+        private String crewImage;
         private JoinStatus status;
+        private Integer capacity;
+        private Integer currentMemberCount;
         private LocalDateTime appliedAt;
         private LocalDateTime updatedAt;
 
-        public static SimpleResponse from(
-            JoinApplyEntity joinApplyEntity) {
+        public static SimpleResponse from(JoinApplyEntity joinApplyEntity) {
             return SimpleResponse.builder()
-                .nickname(joinApplyEntity.getMember().getNickName())
+                .joinApplyId(joinApplyEntity.getId())
                 .crewName(joinApplyEntity.getCrew().getCrewName())
+                .crewImage(joinApplyEntity.getCrew().getCrewImage())
                 .status(joinApplyEntity.getStatus())
+                .capacity(joinApplyEntity.getCrew().getCrewCapacity())
+                .currentMemberCount(joinApplyEntity.getCrew().getCrewMember().size())
                 .appliedAt(joinApplyEntity.getCreatedAt())
                 .updatedAt(joinApplyEntity.getUpdatedAt())
                 .build();
@@ -44,20 +51,30 @@ public class JoinApplyDto {
     @Getter
     @Builder
     public static class DetailResponse {
-        private String nickname;
+        private Long joinApplyId;
         private String crewName;
+        private String crewImage;
         private JoinStatus status;
+        private Integer capacity;
+        private Integer currentMemberCount;
         private String applyMessage;
+        private String description;
+        private Region activityRegion;
         private LocalDateTime appliedAt;
         private LocalDateTime updatedAt;
 
         public static DetailResponse from(
             JoinApplyEntity joinApplyEntity) {
             return DetailResponse.builder()
-                .nickname(joinApplyEntity.getMember().getNickName())
+                .joinApplyId(joinApplyEntity.getId())
                 .crewName(joinApplyEntity.getCrew().getCrewName())
+                .crewImage(joinApplyEntity.getCrew().getCrewImage())
                 .status(joinApplyEntity.getStatus())
+                .capacity(joinApplyEntity.getCrew().getCrewCapacity())
+                .currentMemberCount(joinApplyEntity.getCrew().getCrewMember().size())
                 .applyMessage(joinApplyEntity.getMessage())
+                .description(joinApplyEntity.getMessage())
+                .activityRegion(joinApplyEntity.getCrew().getActivityRegion())
                 .appliedAt(joinApplyEntity.getCreatedAt())
                 .updatedAt(joinApplyEntity.getUpdatedAt())
                 .build();

--- a/src/main/java/com/example/runningservice/entity/JoinApplyEntity.java
+++ b/src/main/java/com/example/runningservice/entity/JoinApplyEntity.java
@@ -36,6 +36,7 @@ public class JoinApplyEntity extends BaseEntity{
     @Enumerated(EnumType.STRING)
     private JoinStatus status;
     private String message;
+
     public static JoinApplyEntity of(MemberEntity member, CrewEntity crew, String message) {
         return JoinApplyEntity.builder()
             .member(member)

--- a/src/main/java/com/example/runningservice/entity/MemberEntity.java
+++ b/src/main/java/com/example/runningservice/entity/MemberEntity.java
@@ -18,7 +18,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -73,6 +76,8 @@ public class MemberEntity extends BaseEntity {
     private Visibility genderVisibility;
     @Column(name = "birth_year_visibility")
     private Visibility birthYearVisibility;
+    @Column(name = "run_record_visibility")
+    private Visibility runRecordVisibility;
 
     // 알림 설정
     @Column(name = "post_noti")
@@ -83,6 +88,15 @@ public class MemberEntity extends BaseEntity {
     private Notification mentionNoti;
     @Column(name = "chatting_noti")
     private Notification chattingNoti;
+
+    //러닝 프로필
+    @OneToMany
+    @JoinColumn(name = "run_record_id")
+    private List<RunRecordEntity> runRecordEntities = new ArrayList<>();
+    @OneToOne
+    @JoinColumn(name = "run_goal_id")
+    private RunGoalEntity runGoalEntity;
+
 
     public void markEmailVerified() {
         this.emailVerified = true;

--- a/src/main/java/com/example/runningservice/entity/RunGoalEntity.java
+++ b/src/main/java/com/example/runningservice/entity/RunGoalEntity.java
@@ -1,5 +1,7 @@
 package com.example.runningservice.entity;
 
+import com.example.runningservice.util.converter.BooleanToIntegerConverter;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
@@ -26,7 +28,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class RunGoalEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-
     @Setter
     private Long id;
 
@@ -43,6 +44,7 @@ public class RunGoalEntity {
     private LocalDateTime updatedAt;
 
     private String averagePace;
+    @Convert(converter = BooleanToIntegerConverter.class)
     private Integer isPublic;
     private Integer runCount;
 }

--- a/src/main/java/com/example/runningservice/entity/RunRecordEntity.java
+++ b/src/main/java/com/example/runningservice/entity/RunRecordEntity.java
@@ -1,5 +1,7 @@
 package com.example.runningservice.entity;
 
+import com.example.runningservice.util.converter.BooleanToIntegerConverter;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
@@ -45,5 +47,6 @@ public class RunRecordEntity {
     private LocalDateTime createdAt;
     @LastModifiedDate
     private LocalDateTime updatedAt;
+    @Convert(converter = BooleanToIntegerConverter.class)
     private Integer isPublic;
 }

--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     UNAUTHORIZED_ACTIVITY(HttpStatus.FORBIDDEN, "활동 접근 권한이 없습니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작 날짜가 종료 날짜보다 빨라야 합니다."),
     NOT_FOUND_CHATROOM(HttpStatus.BAD_REQUEST, "채팅방을 찾을 수 없습니다."),
+    INVALID_SORT(HttpStatus.BAD_REQUEST, "유효한 정렬기준이 아닙니다."),
 
     //크루가입
     ALREADY_EXIST_PENDING_JOIN_APPLY(HttpStatus.BAD_REQUEST, "이미 거압 숭안 대기중입니다."),
@@ -43,6 +44,7 @@ public enum ErrorCode {
     AGE_RESTRICTION_NOT_MET(HttpStatus.FORBIDDEN, "나이 제한을 충족하지 못했습니다."),
     AGE_REQUIRED(HttpStatus.FORBIDDEN, "가입을 위해 연령 정보가 필요합니다."),
     JOIN_NOT_ALLOWED_FOR_FORCE_WITHDRAWN(HttpStatus.FORBIDDEN, "강제퇴장된 멤버는 재가입할 수 없습니다."),
+
     //권한
     UNAUTHORIZED_MY_APPLY_ACCESS(HttpStatus.FORBIDDEN, "잘못된 접근입니다. 자신의 가입 신청 내역만 조회할 수 있습니다.");
 

--- a/src/main/java/com/example/runningservice/repository/chat/ChatRoomRepository.java
+++ b/src/main/java/com/example/runningservice/repository/chat/ChatRoomRepository.java
@@ -9,12 +9,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
 
-    // List<ChatRoomEntity> findByCrewId(Long crewId);
+//     List<ChatRoomEntity> findByCrewId(Long crewId);
 
     default ChatRoomEntity findChatRoomById(Long roomId) {
         return findById(roomId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CHATROOM));
     }
-
-    void deleteAllByCrewMember_Id(Long crewMemberId);
 }

--- a/src/main/java/com/example/runningservice/util/converter/BooleanToIntegerConverter.java
+++ b/src/main/java/com/example/runningservice/util/converter/BooleanToIntegerConverter.java
@@ -1,0 +1,25 @@
+package com.example.runningservice.util.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class BooleanToIntegerConverter implements AttributeConverter<Boolean, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(Boolean attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute ? 1 : 0;
+    }
+
+    @Override
+    public Boolean convertToEntityAttribute(Integer dbData) {
+
+        if (dbData == null) {
+            return null;
+        }
+        return dbData == 1;
+    }
+}


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 프론트엔드 요청사항에 맞게 로직 및 응답값 수정
- ArgumentResolver 활용하여 코드 리팩토링
- 사용자 가입신청 기능 관련하여 develop 브랜치에서 에러 발생할 수 있는 부분 해결

### 이 PR에서 변경된 사항
가입신청
- 공통 수정 내용
  - UserJoinController : LoginUser 어노테이션 사용
  - UserJoinService
    - saveJoinApply(): 매개변수에 Long userId 추가. token userId를 사용하여 MemberEntity 가져옴(보안상 더 좋은 선택일 듯)
    - getJoinApplications() : 파라미터에서 토큰 제거 & userId 추가, 토큰 관련 로직 삭제
    - getJoinApplicationDetail() : 파라미터에서 토큰 제거 & userId 추가, 토큰 관련 로직 수정(userId와 entity.member.id 비교) 
    - updateJoinApply() : 파라미터에서 토큰 제거 & userId 추가, 토큰 관련 로직 수정(userId와 entity.member.id 비교) 
    - removeJoinApply() : 파라미터에서 토큰 제거 & userId 추가, 토큰 관련 로직 수정(userId와 entity.member.id 비교)
  - Dto 수정 - JoinApplyDto.Request : userId 삭제(토큰에 있는 userId로 대체) 
- 조회
  - 리스트 조회 - UserJoinController : @DefaultPageable 어노테이션 사용하여 기본 페이지값 설정(JPA) - UserJoinService getJoinApplications() : PageUtil 메서드 삭제. pageable 설정은 controller 계층에서 처리 - 정렬 기준 제한 : isValidSortField(String field) 사용하여 요청 시 특정 필드만 요청 가능하게 제한 - ErrorCode 추가(INVALID_SORT)

도메인
- MemberEntity : List<RunRecordEntity> runRecordEntities = new ArrayList<>(); 추가
- CrewRepository :      findByMember_IdAndCrew_CrewId -> findByMember_IdAndCrew_Id
- ChatRoomRepository : deleteAllByCrewMember_Id(Long crewMemberId); 사용하지 않는 메서드 삭제

기타
- BooleanToIntegerConverter : Boolean 타입 데이터를데이터베이스로 저장할 때 Integer(0, 1)로 변환. RunRecordEntity, RunGoalEntity 에 적용함
 
### 참고 스크린샷

### 기타
- DefaultPageable 어노테이션을 사용하여 기본 페이지네이션 설정 용이. PageUtil 클래스는 제거해도 좋을 듯

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
