### PR TITLE
Fix signup&login 002

### DIFF
--- a/src/main/java/com/example/runningservice/config/S3Config.java
+++ b/src/main/java/com/example/runningservice/config/S3Config.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
@@ -14,6 +15,9 @@ public class S3Config {
 
     @Value("${aws.s3.roleArn}")
     private String roleARN;
+
+    @Value("${aws.s3.region}")
+    private Region region;
 
     @Bean
     public StsClient stsClient() {
@@ -35,6 +39,7 @@ public class S3Config {
     public S3Client amazonS3Client(AwsCredentialsProvider credentialsProvider) {
         return S3Client.builder()
             .credentialsProvider(credentialsProvider)
+            .region(region)
             .build();
     }
 }

--- a/src/main/java/com/example/runningservice/controller/SignupController.java
+++ b/src/main/java/com/example/runningservice/controller/SignupController.java
@@ -46,7 +46,7 @@ public class SignupController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/user/signup/nickname-verify")
+    @GetMapping("/signup/nickname-verify")
     ResponseEntity<?> verifyNickname(@RequestParam String nickname) {
 
         signupService.verifyNickName(nickname);

--- a/src/main/java/com/example/runningservice/controller/SignupController.java
+++ b/src/main/java/com/example/runningservice/controller/SignupController.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -40,7 +39,7 @@ public class SignupController {
         return ResponseEntity.ok().build();
     }
 
-    @PutMapping("/signup/email-verify")
+    @GetMapping("/signup/email-verify")
     ResponseEntity<Void> verifyUser(@RequestParam String email, @RequestParam String code) {
         signupService.verifyUser(email, code);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/example/runningservice/dto/SignupRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/SignupRequestDto.java
@@ -60,8 +60,10 @@ public class SignupRequestDto {
     @Size(min = 2, max = 12)
     private String nickName;
 
+    @NotBlank
     private Gender gender;
 
+    @NotBlank
     @ValidYear
     private Integer birthYear;
     private Region activityRegion;

--- a/src/main/java/com/example/runningservice/dto/SignupRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/SignupRequestDto.java
@@ -60,7 +60,7 @@ public class SignupRequestDto {
     @Size(min = 2, max = 12)
     private String nickName;
 
-    @NotBlank
+    @NotNull
     private Gender gender;
 
     @NotNull

--- a/src/main/java/com/example/runningservice/dto/SignupRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/SignupRequestDto.java
@@ -63,7 +63,7 @@ public class SignupRequestDto {
     @NotBlank
     private Gender gender;
 
-    @NotBlank
+    @NotNull
     @ValidYear
     private Integer birthYear;
     private Region activityRegion;

--- a/src/main/java/com/example/runningservice/dto/SignupRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/SignupRequestDto.java
@@ -67,7 +67,7 @@ public class SignupRequestDto {
     @ValidYear
     private Integer birthYear;
     private Region activityRegion;
-    private MultipartFile profileImage; // 프로필 이미지 추가
+    private MultipartFile profileImage;
 
     @NotNull
     private Visibility nameVisibility = Visibility.PRIVATE;
@@ -84,6 +84,7 @@ public class SignupRequestDto {
             .emailVerified(false)
             .password(passwordEncoder.encode(password))
             .phoneNumber(aesUtil.encrypt(phoneNumber))
+            .phoneNumberHash(aesUtil.generateHash(phoneNumber))
             .name(name)
             .nickName(nickName)
             .birthYear(birthYear)

--- a/src/main/java/com/example/runningservice/entity/MemberEntity.java
+++ b/src/main/java/com/example/runningservice/entity/MemberEntity.java
@@ -6,6 +6,7 @@ import com.example.runningservice.enums.Notification;
 import com.example.runningservice.enums.Region;
 import com.example.runningservice.enums.Role;
 import com.example.runningservice.enums.Visibility;
+import com.example.runningservice.util.AESUtil;
 import com.example.runningservice.util.converter.GenderConverter;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -51,6 +52,8 @@ public class MemberEntity extends BaseEntity {
     private String password;
     @Column(nullable = false)
     private String phoneNumber;
+    @Column(nullable = false, unique = true)
+    private String phoneNumberHash;
     @Column(nullable = false)
     private String name;
     @Column(nullable = false)
@@ -132,9 +135,10 @@ public class MemberEntity extends BaseEntity {
         this.birthYearVisibility = birthYearVisibility;
     }
 
-    public void updateAdditionalInfo(SignupRequestDto form) {
+    public void updateAdditionalInfo(SignupRequestDto form, AESUtil aesUtil) {
         this.name = form.getName();
         this.phoneNumber = form.getPhoneNumber();
+        this.phoneNumberHash = aesUtil.generateHash(form.getPhoneNumber());
         this.gender = form.getGender();
         this.birthYear = form.getBirthYear();
         this.activityRegion = form.getActivityRegion();

--- a/src/main/java/com/example/runningservice/repository/MemberRepository.java
+++ b/src/main/java/com/example/runningservice/repository/MemberRepository.java
@@ -13,7 +13,7 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
     boolean existsByEmail(String email);
 
-    boolean existsByPhoneNumber(String encryptedPhoneNumber);
+    boolean existsByPhoneNumberHash(String phoneNumberHash);
 
     default MemberEntity findMemberById(Long userId) {
         return findById(userId)

--- a/src/main/java/com/example/runningservice/service/SignupService.java
+++ b/src/main/java/com/example/runningservice/service/SignupService.java
@@ -79,8 +79,13 @@ public class SignupService {
         if (memberRepository.existsByEmail(registerForm.getEmail())) {
             throw new CustomException(ErrorCode.ALREADY_EXIST_EMAIL);
         }
-        // 회원 전화번호 중복 체크
-        if (memberRepository.existsByPhoneNumber(aesUtil.encrypt(registerForm.getPhoneNumber()))) {
+        // 닉네임 중복 체크
+        if (memberRepository.existsByNickName(registerForm.getNickName())) {
+            throw new CustomException(ErrorCode.ALREADY_EXIST_NICKNAME);
+        }
+        // 휴대전화번호 중복 체크
+        if (memberRepository.existsByPhoneNumberHash(
+            aesUtil.generateHash(registerForm.getPhoneNumber()))) {
             throw new CustomException(ErrorCode.ALREADY_EXIST_PHONE);
         }
     }
@@ -127,7 +132,7 @@ public class SignupService {
         MemberEntity memberEntity = memberRepository.findByEmail(form.getEmail())
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
-        memberEntity.updateAdditionalInfo(form);
+        memberEntity.updateAdditionalInfo(form, aesUtil);
 
         return MemberResponseDto.of(memberRepository.save(memberEntity), aesUtil);
     }

--- a/src/main/java/com/example/runningservice/service/SignupService.java
+++ b/src/main/java/com/example/runningservice/service/SignupService.java
@@ -95,7 +95,7 @@ public class SignupService {
 
         StringBuilder sb = new StringBuilder();
         sb.append(name).append("님, 안녕하세요!").append("회원가입 완료를 위해 아래 인증 코드를 클릭해주세요.\n\n")
-            .append("http://localhost:8080/user/signup/email-verify?email=").append(email)
+            .append("http://13.209.127.192:8080/user/signup/email-verify?email=").append(email)
             .append("&code=").append(code);
         return new String(sb);
     }

--- a/src/main/java/com/example/runningservice/util/AESUtil.java
+++ b/src/main/java/com/example/runningservice/util/AESUtil.java
@@ -5,6 +5,7 @@ import com.example.runningservice.exception.ErrorCode;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
@@ -19,10 +20,14 @@ import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 @Slf4j
+@Component
+@Setter
 public class AESUtil {
     private static final String ALGORITHM = "AES";
     private static final String TRANSFORMATION = "AES/CBC/PKCS5Padding";
@@ -108,9 +113,19 @@ public class AESUtil {
         }
     }
 
-    public static IvParameterSpec generateIv() {
+    private static IvParameterSpec generateIv() {
         byte[] iv = new byte[IV_LENGTH_BYTE];
         new SecureRandom().nextBytes(iv);
         return new IvParameterSpec(iv);
+    }
+
+    public String generateHash(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/com/example/runningservice/dto/SignupRequestDtoTest.java
+++ b/src/test/java/com/example/runningservice/dto/SignupRequestDtoTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Region;
+import com.example.runningservice.enums.Visibility;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -55,14 +56,19 @@ class SignupRequestDtoTest {
         // Given
         SignupRequestDto signupRequestDto = SignupRequestDto.builder()
             .email("email@example.com")
-            .password("password") // Invalid password format
-            .confirmPassword("password")
+            .password("password!")
+            .confirmPassword("password!")
             .phoneNumber("01012345678")
             .name("Kim")
             .nickName("Kim")
             .gender(Gender.MALE)
+            .profileImage(null)
             .birthYear(1990)
             .activityRegion(Region.SEOUL)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .nameVisibility(Visibility.PUBLIC)
+            .genderVisibility(Visibility.PUBLIC)
+            .phoneNumberVisibility(Visibility.PUBLIC)
             .build();
 
         // When
@@ -87,8 +93,13 @@ class SignupRequestDtoTest {
             .name("Kim")
             .nickName("Kim")
             .gender(Gender.MALE)
+            .profileImage(null)
             .birthYear(1990)
             .activityRegion(Region.SEOUL)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .nameVisibility(Visibility.PUBLIC)
+            .genderVisibility(Visibility.PUBLIC)
+            .nameVisibility(Visibility.PUBLIC)
             .build();
 
         // When
@@ -96,11 +107,20 @@ class SignupRequestDtoTest {
             signupRequestDto);
 
         // Then
-        assertEquals(1, violations.size());
-        ConstraintViolation<SignupRequestDto> violation = violations.iterator().next();
-        assertEquals("비밀번호가 일치하지 않습니다.", violation.getMessage());
-        assertEquals(SignupRequestDto.class.getSimpleName(),
-            violation.getRootBeanClass().getSimpleName());
+        assertEquals(2, violations.size());
+
+        // 모든 violation을 확인하면서 메시지와 필드를 검증
+        for (ConstraintViolation<SignupRequestDto> violation : violations) {
+            String message = violation.getMessage();
+            String propertyPath = violation.getPropertyPath().toString();
+
+            if (propertyPath.equals("confirmPassword")) {
+                assertEquals("비밀번호가 일치하지 않습니다.", message);
+            } else if (propertyPath.equals("password") || propertyPath.equals("confirmPassword")) {
+                // 다른 유효성 검사 위반 메시지 확인 (예: NotBlank 등의 메시지)
+                assertEquals("필수 정보입니다.", message);
+            }
+        }
     }
 
     @Test
@@ -108,14 +128,19 @@ class SignupRequestDtoTest {
         // Given
         SignupRequestDto signupRequestDto = SignupRequestDto.builder()
             .email("email@example.com")
-            .password("Password123!")
-            .confirmPassword("Password123!")
-            .phoneNumber("invalid-phone-number") // Invalid phone number format
-            .name("John Doe")
-            .nickName("johndoe")
+            .password("Qwerqwer1!")
+            .confirmPassword("Qwerqwer1!")
+            .phoneNumber("010123456")
+            .name("Kim")
+            .nickName("Kim")
             .gender(Gender.MALE)
+            .profileImage(null)
             .birthYear(1990)
             .activityRegion(Region.SEOUL)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .nameVisibility(Visibility.PUBLIC)
+            .genderVisibility(Visibility.PUBLIC)
+            .phoneNumberVisibility(Visibility.PUBLIC)
             .build();
 
         // When
@@ -136,11 +161,16 @@ class SignupRequestDtoTest {
             .password("Password123!")
             .confirmPassword("Password123!")
             .phoneNumber("01012345678")
-            .name("") // Invalid name (empty)
-            .nickName("johndoe")
+            .name("")
+            .nickName("Kim")
             .gender(Gender.MALE)
+            .profileImage(null)
             .birthYear(1990)
             .activityRegion(Region.SEOUL)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .nameVisibility(Visibility.PUBLIC)
+            .genderVisibility(Visibility.PUBLIC)
+            .phoneNumberVisibility(Visibility.PUBLIC)
             .build();
 
         // When
@@ -182,6 +212,10 @@ class SignupRequestDtoTest {
             .gender(Gender.MALE)
             .birthYear(1800) // Invalid birth year (too early)
             .activityRegion(Region.SEOUL)
+            .nameVisibility(Visibility.PUBLIC)
+            .birthYearVisibility(Visibility.PUBLIC)
+            .phoneNumberVisibility(Visibility.PUBLIC)
+            .genderVisibility(Visibility.PUBLIC)
             .build();
 
         // When

--- a/src/test/java/com/example/runningservice/service/LogoutServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/LogoutServiceTest.java
@@ -2,7 +2,6 @@ package com.example.runningservice.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -11,7 +10,6 @@ import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.security.CustomUserDetails;
 import com.example.runningservice.util.JwtUtil;
-import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
@@ -71,47 +69,8 @@ class LogoutServiceTest {
     }
 
     @Test
-    void testLogout_UserEmailTokenEmailMisMatch() {
-        //given
-        when(request.getHeader("Authorization")).thenReturn("Bearer validRefreshToken");
-        when(authentication.getPrincipal()).thenReturn(customUserDetails);
-        when(customUserDetails.getUsername()).thenReturn("username");
-        when(jwtUtil.validateToken("username", "validRefreshToken")).thenCallRealMethod();
-        Claims mockClaims = mock(Claims.class);
-        when(jwtUtil.extractEmail("validRefreshToken")).thenReturn("differentEmail");
-
-        //when
-        CustomException exception = assertThrows(CustomException.class,
-            () -> logoutService.logout(request, response, authentication));
-
-        //then
-        assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());
-    }
-
-    @Test
-    void testLogout_ExpiredToken() {
-        // given
-        when(request.getHeader("Authorization")).thenReturn("Bearer validRefreshToken");
-        when(authentication.getPrincipal()).thenReturn(customUserDetails);
-        when(customUserDetails.getUsername()).thenReturn("username");
-        when(jwtUtil.validateToken("username", "validRefreshToken")).thenCallRealMethod();
-        when(jwtUtil.extractEmail("validRefreshToken")).thenReturn("username");
-        when(jwtUtil.isTokenExpired("validRefreshToken")).thenReturn(true);
-
-        //when
-        CustomException exception = assertThrows(CustomException.class,
-            () -> logoutService.logout(request, response, authentication));
-
-        //then
-        assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());
-    }
-
-    @Test
     void testLogout_TokenAlreadyInBlacklist() {
         when(request.getHeader("Authorization")).thenReturn("Bearer validRefreshToken");
-        when(authentication.getPrincipal()).thenReturn(customUserDetails);
-        when(customUserDetails.getUsername()).thenReturn("username");
-        when(jwtUtil.validateToken("username", "validRefreshToken")).thenReturn(true);
         when(tokenBlackList.isListed("validRefreshToken")).thenReturn(true);
 
         //when
@@ -126,9 +85,6 @@ class LogoutServiceTest {
     void testLogout_success() {
         //given
         when(request.getHeader("Authorization")).thenReturn("Bearer validRefreshToken");
-        when(authentication.getPrincipal()).thenReturn(customUserDetails);
-        when(customUserDetails.getUsername()).thenReturn("username");
-        when(jwtUtil.validateToken("username", "validRefreshToken")).thenReturn(true);
         when(tokenBlackList.isListed("validRefreshToken")).thenReturn(false);
 
         //when

--- a/src/test/java/com/example/runningservice/service/SignupServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/SignupServiceTest.java
@@ -144,7 +144,7 @@ class SignupServiceTest {
             .build();
 
         given(aesUtil.encrypt(signupRequestDto.getPhoneNumber())).willReturn("encryptedPhoneNumber");
-        given(memberRepository.existsByPhoneNumber("encryptedPhoneNumber")).willReturn(true);
+        given(memberRepository.existsByPhoneNumberHash("encryptedPhoneNumber")).willReturn(true);
 
         // When & Then
         CustomException exception = assertThrows(CustomException.class, () -> {

--- a/src/test/java/com/example/runningservice/util/AESUtilTest.java
+++ b/src/test/java/com/example/runningservice/util/AESUtilTest.java
@@ -1,0 +1,60 @@
+package com.example.runningservice.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AESUtilTest {
+    private AESUtil aesUtil;
+
+    @BeforeEach
+    public void setUp() {
+        aesUtil = new AESUtil();
+        aesUtil.setPassword("password");
+        aesUtil.setSalt("salt");
+    }
+
+    @Test
+    public void testEncryptDecrypt() throws Exception {
+        String originalText = "TestString123";
+
+        // 암호화
+        String encryptedText = aesUtil.encrypt(originalText);
+        assertNotNull(encryptedText);
+
+        // 복호화
+        String decryptedText = aesUtil.decrypt(encryptedText);
+        assertEquals(originalText, decryptedText);
+    }
+
+    @Test
+    public void testDecryptWithInvalidData() {
+        String invalidEncryptedData = "invalidEncryptedData";
+
+        Exception exception = assertThrows(CustomException.class, () -> {
+            aesUtil.decrypt(invalidEncryptedData);
+        });
+
+        String expectedMessage = ErrorCode.DECRYPTION_ERROR.getMessage();
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage), "Exception message should contain decryption error");
+    }
+
+    @Test
+    void repeatableTest () throws Exception {
+        //given
+        String plainText = "TestString123";
+        String firstEncryptedText = aesUtil.encrypt(plainText);
+        String secondEncryptedText = aesUtil.encrypt(plainText);
+
+        //then
+        assertEquals(firstEncryptedText, secondEncryptedText);
+    }
+}


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제

### 이 PR에서 변경된 사항
- S3 Config: S3Client에 region 추가

```
`
    @Value("${aws.s3.region}")
    private Region region;

public S3Client amazonS3Client(AwsCredentialsProvider credentialsProvider) {
        return S3Client.builder()
            .credentialsProvider(credentialsProvider)
            .region(region)
            .build();
    }`
```

- SignupRequestDto: gender, birthYear에 NotNull 어노테이션 추가(필수처리)

- SignupController
   - 닉네임 중복 확인 uri 수정 ("/user/user/signup/nickname-verify" -> "/user/signup/nickname-verify")
   - 이메일 인증 메서드 수정 (PUT -> GET) : 클릭시 기본 메서드설정 GET
```
    @GetMapping("/signup/email-verify")
    ResponseEntity<Void> verifyUser(@RequestParam String email, @RequestParam String code) {
        signupService.verifyUser(email, code);
        return ResponseEntity.ok().build();
    }
```

    @GetMapping("/signup/nickname-verify")
    ResponseEntity<?> verifyNickname(@RequestParam String nickname) {

        signupService.verifyNickName(nickname);


- SignupService:
  - email 인증 url 수정(localhost -> 서버IP)
  - 닉네임 중복체크 추가
  - 휴대전봐전호 중복체크 수정(phoneNumberHash로 비교)
```
        // 닉네임 중복 체크
        if (memberRepository.existsByNickName(registerForm.getNickName())) {
            throw new CustomException(ErrorCode.ALREADY_EXIST_NICKNAME);
        }
        // 휴대전화번호 중복 체크
        if (memberRepository.existsByPhoneNumberHash(
            aesUtil.generateHash(registerForm.getPhoneNumber()))) {
            throw new CustomException(ErrorCode.ALREADY_EXIST_PHONE);
        }
```

- AESUtil : generateHash() 메서드 추가
```
    public String generateHash(String input) {
        try {
            MessageDigest digest = MessageDigest.getInstance("SHA-256");
            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
            return Base64.getEncoder().encodeToString(hash);
        } catch (NoSuchAlgorithmException e) {
            throw new RuntimeException(e);
        }
    }
```
- MemberRepository : 메서드 수정 (existsByPhoneNumber -> existsByPhoneNumberHash)
- MemberEntity : phoneNumberHash 필드 추가
- AuthService : authenticate() 리팩토링 (UsernamePasswordAuthenticationToken 내부에서 CustomUserDetailsService가 호출되므로 해당 메서드를 중복하여 호출하지 않도록 수정)
- 테스트 코드 수정 : AuthServiceTest, CrewApplicantControllerTest, LogoutServiceTest, SignupRequestDtoTest, SignupServiceTest, AESUtilTest

### 참고 스크린샷

### 기타 / 참고사항
- commit message 오기 (fix-CrewMember-001 -> fix-signup&login-002
- EC2 에서 버킷을 찾지 못하는 이슈 있어 Region을 S3Config에 추가함(직접적인 문제 원인이었는지는 불명확. 명시해주는 것이 안정적일 듯)
- NotBlank 어노테이션은 String에만 가능
- 휴대전화번호 중복체크를 위해 해시정보 저장 필드 추가. AES로 암호화하여 저장 보관하고 중복체크 시에는 해시처리된 값을 가지고 비교함. (AES 암호화는 암호화할 때마다 다른 암호값으로 저장되어 중복체크 불가)

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
