### PR TITLE
fix : Jwt-001 토큰 필터링 부분 코드 수정(401 에러 출력하도록 수정)

### DIFF
--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
-    TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "토큰이 만료되었습니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "사용 불가한 토큰입니다."),
     UNABLE_TO_GET_TOKEN(HttpStatus.BAD_REQUEST, "발급된 토큰이 없습니다."),

--- a/src/main/java/com/example/runningservice/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/runningservice/security/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.example.runningservice.security;
 
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.util.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -35,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         log.debug("request path: {}", request.getRequestURI());
         log.debug("accessJwt: {}", accessJwt);
         if (accessJwt != null &&
-            jwtUtil.validateToken(jwtUtil.extractEmail(accessJwt), accessJwt)) {
+            jwtUtil.isTokenExpired(accessJwt)) {
             Authentication authentication = jwtUtil.getAuthentication(accessJwt);
             log.info("Filtering request token Authentication: {}", authentication);
             SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -44,6 +46,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             );
             // LoginUserResolver에서 request를 통해 가져오기 위해 토큰에서 id를 가져와 저장한다.
             request.setAttribute("loginId", jwtUtil.extractUserId(accessJwt));
+        } else if (jwtUtil.isTokenExpired(accessJwt)) {
+            throw new CustomException(ErrorCode.TOKEN_EXPIRED);
         }
         log.info("Filtering request token: {}", accessJwt);
         log.info("authentication: {}", SecurityContextHolder.getContext().getAuthentication());


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 토큰 갱신을 할 수 있도록 jwtAuthenticationFilter에서 401 에러 발생시키도록 수정

### 이 PR에서 변경된 사항
- JwtAuthenticationFilter
  - jwtUtil.validate() -> jwtUtil.isTokenExpired() 수정 (불필요한 검증과정 제거)
  - 401 에러 출력
 - ErrorCode :  TOKEN_EXPIRED의 HttpStatus를 400 -> 401 수정
### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
