### PR TITLE
fix : Signup&Login-004 jwt 필터에서 token이 null일 때 필터거치면서 생기는 버그 수정

### DIFF
--- a/src/main/java/com/example/runningservice/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/runningservice/security/JwtAuthenticationFilter.java
@@ -36,18 +36,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String accessJwt = resolveToken(request, ACCESS_TOKEN_HEADER);
         log.debug("request path: {}", request.getRequestURI());
         log.debug("accessJwt: {}", accessJwt);
-        if (accessJwt != null &&
-            !jwtUtil.isTokenExpired(accessJwt)) {
-            Authentication authentication = jwtUtil.getAuthentication(accessJwt);
-            log.info("Filtering request token Authentication: {}", authentication);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-            log.info(String.format("[%s] -> %s ",
+        if (accessJwt != null) {
+            if (!jwtUtil.isTokenExpired(accessJwt)) {
+                Authentication authentication = jwtUtil.getAuthentication(accessJwt);
+                log.info("Filtering request token Authentication: {}", authentication);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.info(String.format("[%s] -> %s ",
                     jwtUtil.extractEmail(accessJwt), request.getRequestURI())
-            );
-            // LoginUserResolver에서 request를 통해 가져오기 위해 토큰에서 id를 가져와 저장한다.
-            request.setAttribute("loginId", jwtUtil.extractUserId(accessJwt));
-        } else if (jwtUtil.isTokenExpired(accessJwt)) {
-            throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+                );
+                // LoginUserResolver에서 request를 통해 가져오기 위해 토큰에서 id를 가져와 저장한다.
+                request.setAttribute("loginId", jwtUtil.extractUserId(accessJwt));
+            } else {
+                throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+            }
         }
         log.info("Filtering request token: {}", accessJwt);
         log.info("authentication: {}", SecurityContextHolder.getContext().getAuthentication());


### PR DESCRIPTION

### 이 PR을 통해 해결하려는 문제
- 회원가입, 로그인과 같이 토큰이 필요없어도 이용가능한 서비스에서 토큰을 검증하는 로직이 동작하는 버그 해결

### 이 PR에서 변경된 사항
- token == null 일 때 유효기간을 검증하는 로직에 포함시키면서 생기는 버그 수정
```
if (accessJwt != null) {
            if (!jwtUtil.isTokenExpired(accessJwt)) {
                Authentication authentication = jwtUtil.getAuthentication(accessJwt);
                log.info("Filtering request token Authentication: {}", authentication);
                SecurityContextHolder.getContext().setAuthentication(authentication);
                log.info(String.format("[%s] -> %s ",
                    jwtUtil.extractEmail(accessJwt), request.getRequestURI())
                );
                // LoginUserResolver에서 request를 통해 가져오기 위해 토큰에서 id를 가져와 저장한다.
                request.setAttribute("loginId", jwtUtil.extractUserId(accessJwt));
            } else {
                throw new CustomException(ErrorCode.TOKEN_EXPIRED);
            }
        }
```

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [x] API 테스트
