### PR TITLE
Join user 003 - UserJoinService 나이검증 로직 수정

### DIFF
--- a/src/main/java/com/example/runningservice/service/UserJoinService.java
+++ b/src/main/java/com/example/runningservice/service/UserJoinService.java
@@ -190,11 +190,11 @@ public class UserJoinService {
             }
 
             int memberBirthYear = memberEntity.getBirthYear();
-            if (maxYear != null && memberBirthYear > maxYear) {
+            if (maxYear != null && memberBirthYear > minYear) {
                 throw new CustomException(ErrorCode.AGE_RESTRICTION_NOT_MET);
             }
 
-            if (minYear != null && memberBirthYear < minYear) {
+            if (minYear != null && memberBirthYear < maxYear) {
                 throw new CustomException(ErrorCode.AGE_RESTRICTION_NOT_MET);
             }
         }

--- a/src/main/java/com/example/runningservice/service/UserJoinService.java
+++ b/src/main/java/com/example/runningservice/service/UserJoinService.java
@@ -190,11 +190,11 @@ public class UserJoinService {
             }
 
             int memberBirthYear = memberEntity.getBirthYear();
-            if (maxYear != null && memberBirthYear > minYear) {
+            if (minYear != null && memberBirthYear > minYear) {
                 throw new CustomException(ErrorCode.AGE_RESTRICTION_NOT_MET);
             }
 
-            if (minYear != null && memberBirthYear < maxYear) {
+            if (maxYear != null && memberBirthYear < maxYear) {
                 throw new CustomException(ErrorCode.AGE_RESTRICTION_NOT_MET);
             }
         }

--- a/src/test/java/com/example/runningservice/service/UserJoinServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/UserJoinServiceTest.java
@@ -359,7 +359,6 @@ class UserJoinServiceTest {
             .nickName("testNickName").birthYear(1995).birthYearVisibility(Visibility.PUBLIC)
             .gender(Gender.MALE).genderVisibility(Visibility.PUBLIC).build();
         CrewEntity crewEntity = CrewEntity.builder().id(crewId).crewName("testCrewName")
-            .minYear(1994)
             .gender(Gender.FEMALE).leaderRequired(true).build(); // 필드들 초기화
 
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(memberEntity));
@@ -382,7 +381,7 @@ class UserJoinServiceTest {
         Long crewId = 1L;
         Long userId = 2L;
         MemberEntity memberEntity = MemberEntity.builder().id(userId).email("testEmail")
-            .nickName("testNickName").birthYear(1994).birthYearVisibility(Visibility.PUBLIC)
+            .nickName("testNickName").birthYear(1996).birthYearVisibility(Visibility.PUBLIC)
             .gender(Gender.FEMALE).genderVisibility(Visibility.PUBLIC).build();
         CrewEntity crewEntity = CrewEntity.builder()
             .id(crewId)
@@ -730,7 +729,7 @@ class UserJoinServiceTest {
         MemberEntity memberEntity = MemberEntity.builder().id(1L).email("testEmail")
             .nickName("testNickName").birthYear(1995).birthYearVisibility(Visibility.PUBLIC)
             .gender(Gender.FEMALE).build();
-        CrewEntity crewEntity = CrewEntity.builder().id(2L).crewName("testCrewName").minYear(1994)
+        CrewEntity crewEntity = CrewEntity.builder().id(2L).crewName("testCrewName")
             .leaderRequired(true).build(); // 필드들 초기화
         JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
             .member(memberEntity)
@@ -768,7 +767,6 @@ class UserJoinServiceTest {
             .nickName("testNickName").birthYear(1995).birthYearVisibility(Visibility.PUBLIC)
             .gender(Gender.FEMALE).build();
         CrewEntity crewEntity = CrewEntity.builder().id(crewId).crewName("testCrewName")
-            .minYear(1994)
             .leaderRequired(true).build(); // 필드들 초기화
 
         JoinApplyDto.Request joinApplyDto = JoinApplyDto.Request.builder().message("testMessage")
@@ -916,7 +914,6 @@ class UserJoinServiceTest {
             .nickName("testNickName").birthYear(1995).birthYearVisibility(Visibility.PUBLIC)
             .gender(Gender.FEMALE).build();
         CrewEntity crewEntity = CrewEntity.builder().id(crewId).crewName("testCrewName")
-            .minYear(1994)
             .leaderRequired(true).build(); // 필드들 초기화
         JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
             .member(memberEntity)


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- minYear는 어린 나이(숫자는 큼), maxYear는 많은 나이(숫자는 작음) 라는 점 반영하여 로직 수정

### 이 PR에서 변경된 사항
- minYear보다 숫자(memberBirthYear)가 크면 가입 제한
- maxYear보다 숫자(memberBirthYear가 작으면 가입 제한
```
private void validateAge(MemberEntity memberEntity, Integer maxYear, Integer minYear) {

        if (maxYear != null || minYear != null) {
            if (memberEntity.getBirthYear() == null) {
                throw new CustomException(ErrorCode.AGE_REQUIRED);
            }

            int memberBirthYear = memberEntity.getBirthYear();
            if (minYear != null && memberBirthYear > minYear) {
                throw new CustomException(ErrorCode.AGE_RESTRICTION_NOT_MET);
            }

            if (maxYear != null && memberBirthYear < maxYear) {
                throw new CustomException(ErrorCode.AGE_RESTRICTION_NOT_MET);
            }
        }
    }
```

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [ ] API 테스트
