### PR TITLE
fix: chatjoin 조회방식 변경

### DIFF
--- a/src/main/java/com/example/runningservice/service/chat/ChatRoomService.java
+++ b/src/main/java/com/example/runningservice/service/chat/ChatRoomService.java
@@ -179,9 +179,9 @@ public class ChatRoomService {
         MemberEntity adminEntity = memberRepository.findMemberById(adminId);
 
         // 채팅방 참여중인지 확인
-        ChatJoinEntity memberChatJoinEntity = chatJoinRepository.findByChatRoomAndMember(chatRoomEntity, memberEntity);
-        ChatJoinEntity adminChatJoinEntity = chatJoinRepository.findByChatRoomAndMember(chatRoomEntity, adminEntity);
-        if (memberChatJoinEntity == null || adminEntity == null) {
+        ChatJoinEntity memberChatJoinEntity = chatJoinRepository.findByChatRoom_IdAndMember_Id(roomId, memberId);
+        ChatJoinEntity adminChatJoinEntity = chatJoinRepository.findByChatRoom_IdAndMember_Id(roomId, adminId);
+        if (memberChatJoinEntity == null || adminChatJoinEntity == null) {
             throw new RuntimeException("멤버가 채팅방에 참여중이지 않습니다.");
         }
 
@@ -194,14 +194,14 @@ public class ChatRoomService {
 
     // 크루 멤버인지 확인
     public void validateCrewMember(CrewEntity crew, MemberEntity member) {
-        if (!crewMemberRepository.findByCrewAndMember(crew, member).isPresent()) {
+        if (crewMemberRepository.findByCrewAndMember(crew, member).isEmpty()) {
             throw new RuntimeException("해당 사용자가 크루에 가입되어 있지 않습니다.");
         }
     }
 
     public void validateCrewLeaderOrStaff(CrewEntity crew, MemberEntity member) {
         List<CrewRole> crewRoles = Arrays.asList(CrewRole.LEADER, CrewRole.STAFF);
-        if (!crewMemberRepository.findByCrewAndMemberAndRoleIn(crew, member, crewRoles).isPresent()) {
+        if (crewMemberRepository.findByCrewAndMemberAndRoleIn(crew, member, crewRoles).isEmpty()) {
             throw new RuntimeException("해당 멤버는 운영진이 아닙니다.");
         }
     }

--- a/src/test/java/com/example/runningservice/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/ChatRoomServiceTest.java
@@ -316,7 +316,7 @@ public class ChatRoomServiceTest {
         ChatJoinEntity chatJoinEntity = new ChatJoinEntity();
         when(memberRepository.findMemberById(memberAEntity.getId())).thenReturn(memberAEntity);
         when(chatRoomRepository.findChatRoomById(chatRoomEntity.getId())).thenReturn(chatRoomEntity);
-        when(chatJoinRepository.findByChatRoomAndMember(chatRoomEntity, memberAEntity)).thenReturn(chatJoinEntity);
+        when(chatJoinRepository.findByChatRoom_IdAndMember_Id(chatRoomEntity.getId(), memberAEntity.getId())).thenReturn(chatJoinEntity);
 
         doNothing().when(chatJoinRepository).delete(any(ChatJoinEntity.class));
 
@@ -350,9 +350,9 @@ public class ChatRoomServiceTest {
         ChatJoinEntity adminChatJoinEntity = new ChatJoinEntity();
         ChatJoinEntity memberChatJoinEntity = new ChatJoinEntity();
 
-        when(chatJoinRepository.findByChatRoomAndMember(chatRoomEntity, memberAEntity))
+        when(chatJoinRepository.findByChatRoom_IdAndMember_Id(chatRoomEntity.getId(), memberAEntity.getId()))
             .thenReturn(adminChatJoinEntity);
-        when(chatJoinRepository.findByChatRoomAndMember(chatRoomEntity, memberBEntity))
+        when(chatJoinRepository.findByChatRoom_IdAndMember_Id(chatRoomEntity.getId(), memberBEntity.getId()))
             .thenReturn(memberChatJoinEntity);
         doNothing().when(chatJoinRepository).delete(memberChatJoinEntity);
 


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- ChatRoomServiceTest  leaveChatRoom_success FAILED 문제 해결

### 이 PR에서 변경된 사항
- ChatRoomRepository
ChatJoin 조회시 매개변수로 chatRoomEntity, memberEntity로 조회 -> chatRoomId, memberId로 조회하도록 변경
ChatRoomService 및 ChatRoomServiceTest에 변경된 사항 반영

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
