### PR TITLE
fix : Signup 이미지 업로드 시 null체크

### DIFF
--- a/src/main/java/com/example/runningservice/service/SignupService.java
+++ b/src/main/java/com/example/runningservice/service/SignupService.java
@@ -109,7 +109,7 @@ public class SignupService {
      * s3에 회원 이미지 저장 :: user-{userId}로 저장
      */
     private String uploadFileAndReturnFileName(Long userId, MultipartFile userImage) {
-        if (userImage != null) {
+        if (userImage != null && !userImage.isEmpty()) {
             String fileName = "user-" + userId;
             s3FileUtil.putObject(fileName, userImage);
 


### PR DESCRIPTION

### 이 PR을 통해 해결하려는 문제
- 이미지 파일 업로드 시 생길 수 있는 버그 해결(null체크 & 빈값 체크)

### 이 PR에서 변경된 사항
- uploadFileAndReturnFileName() 메서드 수정 : if (userImage != null) 조건절에 !userImage.isEmpty()) 추가

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
