### PR TITLE
fix - CrewMember-Get

### DIFF
--- a/src/main/java/com/example/runningservice/dto/crewMember/GetCrewMemberRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/crewMember/GetCrewMemberRequestDto.java
@@ -3,14 +3,18 @@ package com.example.runningservice.dto.crewMember;
 import com.example.runningservice.enums.CrewRole;
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.util.validator.YearRange;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class GetCrewMemberRequestDto {
 
     @Getter
     @Builder
     @YearRange(minYear = "minYear", maxYear = "maxYear")
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class Filter {
         private Gender gender;
         private Integer minYear;

--- a/src/main/java/com/example/runningservice/entity/CrewMemberEntity.java
+++ b/src/main/java/com/example/runningservice/entity/CrewMemberEntity.java
@@ -25,8 +25,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
 @Entity
+@Builder
 @Table(name = "crew_member", uniqueConstraints = {
     @UniqueConstraint(columnNames = {"member_id", "crew_id"})
 })
@@ -44,14 +44,27 @@ public class CrewMemberEntity {
     private CrewEntity crew;
     @Enumerated(EnumType.STRING)
     private CrewRole role;
+    private Integer roleOrder;
     @CreatedDate
     private LocalDateTime joinedAt;
+
+    @Builder
+    public CrewMemberEntity(Long id, MemberEntity member, CrewEntity crew, CrewRole role,
+        LocalDateTime joinedAt) {
+        this.id = id;
+        this.member = member;
+        this.crew = crew;
+        this.role = role;
+        this.roleOrder = role != null ? role.getOrder() : null;
+        this.joinedAt = joinedAt;
+    }
 
     public static CrewMemberEntity of(MemberEntity member, CrewEntity crew) {
         return CrewMemberEntity.builder()
             .member(member)
             .crew(crew)
             .role(CrewRole.MEMBER)
+            .roleOrder(CrewRole.MEMBER.getOrder())
             .build();
     }
 
@@ -59,10 +72,12 @@ public class CrewMemberEntity {
         if (newRole == this.role) {
             throw new CustomException(ErrorCode.ROLE_NOT_CHANGED);
         }
-            this.role = newRole;
+        this.role = newRole;
+        this.roleOrder = newRole.getOrder();
     }
 
     public void acceptLeaderRole() {
         this.role = CrewRole.LEADER;
+        this.roleOrder = CrewRole.LEADER.getOrder();
     }
 }

--- a/src/main/java/com/example/runningservice/repository/crewMember/CrewMemberRepository.java
+++ b/src/main/java/com/example/runningservice/repository/crewMember/CrewMemberRepository.java
@@ -30,5 +30,5 @@ public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Lo
 
     List<CrewMemberEntity> findByCrew(CrewEntity crew);
 
-    Page<CrewMemberEntity> findAllByOrderByRoleOrderAscJoinedAtAsc(Pageable pageable);
+    Page<CrewMemberEntity> findByCrew_IdOrderByRoleOrderAsc(Long crewId, Pageable pageable);
 }

--- a/src/main/java/com/example/runningservice/security/WebConfig.java
+++ b/src/main/java/com/example/runningservice/security/WebConfig.java
@@ -3,6 +3,7 @@ package com.example.runningservice.security;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -11,5 +12,14 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new LoginUserResolver());
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOriginPatterns("http://localhost:*")
+            .allowedMethods("*") // 모든 HTTP 메서드 허용
+            .allowedHeaders("*") // 모든 헤더 허용
+            .allowCredentials(true); // 쿠키 전송 허용
     }
 }

--- a/src/main/java/com/example/runningservice/service/CrewMemberService.java
+++ b/src/main/java/com/example/runningservice/service/CrewMemberService.java
@@ -13,7 +13,6 @@ import com.example.runningservice.repository.JoinApplicationRepository;
 import com.example.runningservice.repository.chat.ChatJoinRepository;
 import com.example.runningservice.repository.crewMember.CrewMemberBlackListRepository;
 import com.example.runningservice.repository.crewMember.CrewMemberRepository;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +30,6 @@ public class CrewMemberService {
     private final JoinApplicationRepository joinApplicationRepository;
     private final CrewMemberBlackListRepository crewMemberBlackListRepository;
     private final ChatJoinRepository chatJoinRepository;
-    private final JPAQueryFactory queryFactory;
 
     /**
      * 크루원 조회
@@ -52,7 +50,8 @@ public class CrewMemberService {
         if (filterDto.getCrewRole() == null
             && filterDto.getGender() == null && filterDto.getMaxYear() == null
             && filterDto.getMinYear() == null) {
-            return crewMemberRepository.findAllByOrderByRoleOrderAscJoinedAtAsc(pageable);
+            return crewMemberRepository.findByCrew_IdOrderByRoleOrderAsc(crewId,
+                pageable);
         }
 
         return crewMemberRepository.findAllByCrewIdAndFilter(crewId, filterDto, pageable);

--- a/src/test/java/com/example/runningservice/repository/CrewMemberRepositoryTest.java
+++ b/src/test/java/com/example/runningservice/repository/CrewMemberRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.example.runningservice.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.example.runningservice.config.QueryDslConfig;
+import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.enums.CrewRole;
+import com.example.runningservice.repository.crew.CrewRepository;
+import com.example.runningservice.repository.crewMember.CrewMemberRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+public class CrewMemberRepositoryTest {
+
+    @Autowired
+    private CrewMemberRepository crewMemberRepository;
+
+    @Autowired
+    private CrewRepository crewRepository;
+
+    @Test
+    void test_findByCrewIdOrderByRoleOrderAscJoinedAtAsc() {
+        //given
+        Long crewId = 1L;
+        CrewEntity crew = CrewEntity.builder()
+            .id(crewId)
+            .build();
+
+        CrewMemberEntity crewMember1 = CrewMemberEntity.builder()
+            .crew(crew)
+            .id(1L)
+            .role(CrewRole.LEADER)
+            .roleOrder(CrewRole.LEADER.getOrder())
+            .joinedAt(LocalDateTime.of(2024, 1, 1, 1, 1))
+            .build();
+        System.out.println("crewMember1: " + crewMember1.getRoleOrder());
+        CrewMemberEntity crewMember2 = CrewMemberEntity.builder()
+            .crew(crew)
+            .id(2L)
+            .role(CrewRole.MEMBER)
+            .roleOrder(CrewRole.MEMBER.getOrder())
+            .joinedAt(LocalDateTime.of(2024, 1, 1, 1, 3))
+            .build();
+        System.out.println("crewMember2: " + crewMember2.getRoleOrder());
+        CrewMemberEntity crewMember3 = CrewMemberEntity.builder()
+            .crew(crew)
+            .id(3L)
+            .role(CrewRole.STAFF)
+            .roleOrder(CrewRole.STAFF.getOrder())
+            .joinedAt(LocalDateTime.of(2024, 1, 1, 1, 2))
+            .build();
+        System.out.println("crewMember3: " + crewMember3.getRoleOrder());
+        crewRepository.save(crew);
+        crewMemberRepository.save(crewMember1);
+        crewMemberRepository.save(crewMember2);
+        crewMemberRepository.save(crewMember3);
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Direction.ASC, "joinedAt"));
+
+        //when
+        Page<CrewMemberEntity> result = crewMemberRepository.findByCrew_IdOrderByRoleOrderAsc(
+            crewId, pageable);
+
+        //then
+        assertEquals(3, result.getTotalElements());
+        assertEquals(CrewRole.LEADER, result.getContent().get(0).getRole());
+        assertEquals(CrewRole.STAFF, result.getContent().get(1).getRole());
+        assertEquals(CrewRole.MEMBER, result.getContent().get(2).getRole());
+    }
+
+}


### PR DESCRIPTION


### 이 PR을 통해 해결하려는 문제
- 크루원 조회 관련 버그 해결
  - 요청 파라미터에 대한 바인딩 불안정성 해결
  - filter가 없을 때 서버 오류 발생 
 `java.lang.IllegalStateException: Cannot resolve parameter names for constructor com.example.runningservice.dto.crewMember.GetCrewMemberRequestDto$Filter(com.example.runningservice.enums.Gender,java.lang.Integer,java.lang.Integer,com.example.runningservice.enums.CrewRole)
`
### 이 PR에서 변경된 사항
-크루원 조회 관련 수정
  - GetCrewMemberRequestDto.Filter 에 생성자 추가(All & No)
  - CrewMemberEntity 에 Integer roleOrder 필드 추가
  package com.example.runningservice.entity;

```
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;
    @ManyToOne
    @JoinColumn(name = "member_id")
    private MemberEntity member;
    @ManyToOne
    @JoinColumn(name = "crew_id")
    private CrewEntity crew;
    @Enumerated(EnumType.STRING)
    private CrewRole role;
    private Integer roleOrder;
    @CreatedDate
    private LocalDateTime joinedAt;

    @Builder
    public CrewMemberEntity(Long id, MemberEntity member, CrewEntity crew, CrewRole role,
        LocalDateTime joinedAt) {
        this.id = id;
        this.member = member;
        this.crew = crew;
        this.role = role;
        this.roleOrder = role != null ? role.getOrder() : null;
        this.joinedAt = joinedAt;
    }

    public static CrewMemberEntity of(MemberEntity member, CrewEntity crew) {
        return CrewMemberEntity.builder()
            .member(member)
            .crew(crew)
            .role(CrewRole.MEMBER)
            .roleOrder(CrewRole.MEMBER.getOrder())
            .build();
    }

    public void changeRoleTo(CrewRole newRole) {
        if (newRole == this.role) {
            throw new CustomException(ErrorCode.ROLE_NOT_CHANGED);
        }
        this.role = newRole;
        this.roleOrder = newRole.getOrder();
    }

    public void acceptLeaderRole() {
        this.role = CrewRole.LEADER;
        this.roleOrder = CrewRole.LEADER.getOrder();
    }
}

```

  - CrewMemberRepository 메서드 수정
    - 파라미터에 Long CrewId 추가
    - JPA 메서드명에 crew_id 추가, JoinedAtASC 삭제
 - 기타
   - webConfig : allowedOriginPatterns 추가(master 브랜치에 미리 추가되어 있던 내용)

### 참고 스크린샷

### 기타
- CrewRole 이넘클래스의 필드에 Integer order를 설정하고 order 데이터를 기준으로 정렬을 하려고 했으나 데이터베이스에 저장될 때 String으로 변환되어 order 정보를 사용할 수가 없어 에러가 발생함
- 필드를 추가하고 CrewRole role에 저장되는 값에 따라 roleOrder가 설정되도록 수정함

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
