### PR TITLE
Feat total count 001 : 크루/활동/정기러닝 반환 형식에 Page 정보 추가

### DIFF
--- a/src/main/java/com/example/runningservice/controller/ActivityController.java
+++ b/src/main/java/com/example/runningservice/controller/ActivityController.java
@@ -8,8 +8,8 @@ import com.example.runningservice.enums.ActivityCategory;
 import com.example.runningservice.service.ActivityService;
 import com.example.runningservice.util.LoginUser;
 import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -84,7 +84,7 @@ public class ActivityController {
      */
     @GetMapping("/crew/{crewId}/activity/date")
     @CrewRoleCheck(role = {"LEADER", "MEMBER", "STAFF"})
-    public ResponseEntity<List<ActivityResponseDto>> getCrewActivityByDate(@LoginUser Long userId,
+    public ResponseEntity<Page<ActivityResponseDto>> getCrewActivityByDate(@LoginUser Long userId,
         @PathVariable("crewId") Long crewId, Pageable pageable,
         @RequestParam(value = "startDate", required = false) LocalDate startDate,
         @RequestParam(value = "endDate", required = false) LocalDate endDate,
@@ -102,7 +102,7 @@ public class ActivityController {
      * 다가오는 크루 (정기/번개)러닝 일정 조회
      */
     @GetMapping("/crew/{crewId}/activity")
-    public ResponseEntity<List<ActivityResponseDto>> getCrewActivity(@LoginUser Long userId,
+    public ResponseEntity<Page<ActivityResponseDto>> getCrewActivity(@LoginUser Long userId,
         @PathVariable("crewId") Long crewId, Pageable pageable,
         @RequestParam(value = "category", required = false) ActivityCategory category) {
 

--- a/src/main/java/com/example/runningservice/controller/CrewController.java
+++ b/src/main/java/com/example/runningservice/controller/CrewController.java
@@ -13,8 +13,8 @@ import com.example.runningservice.enums.Region;
 import com.example.runningservice.service.CrewService;
 import com.example.runningservice.util.LoginUser;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -74,7 +74,7 @@ public class CrewController {
      * 참가 중인 크루 리스트 조회
      */
     @GetMapping("/participate")
-    public ResponseEntity<List<CrewRoleResponseDto>> getParticipateCrewList(@LoginUser Long userId,
+    public ResponseEntity<Page<CrewRoleResponseDto>> getParticipateCrewList(@LoginUser Long userId,
         Pageable pageable) {
 
         return ResponseEntity.ok(crewService.getParticipateCrewList(userId, pageable));
@@ -84,7 +84,7 @@ public class CrewController {
      * 전체 크루 필터링 조회
      */
     @GetMapping
-    public ResponseEntity<List<CrewJoinStatusResponseDto>> getCrewList(@LoginUser Long userId,
+    public ResponseEntity<Page<CrewJoinStatusResponseDto>> getCrewList(@LoginUser Long userId,
         @RequestParam(value = "activityRegion", required = false) Region activityRegion,
         @RequestParam(value = "minYear", required = false) Integer minYear,
         @RequestParam(value = "maxYear", required = false) Integer maxYear,

--- a/src/main/java/com/example/runningservice/controller/ParticipantController.java
+++ b/src/main/java/com/example/runningservice/controller/ParticipantController.java
@@ -4,8 +4,8 @@ import com.example.runningservice.aop.CrewRoleCheck;
 import com.example.runningservice.dto.activity.ParticipantResponseDto;
 import com.example.runningservice.service.ParticipantService;
 import com.example.runningservice.util.LoginUser;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -47,7 +47,7 @@ public class ParticipantController {
      */
     @GetMapping("/crew/{crewId}/activity/{activityId}/attendance")
     @CrewRoleCheck(role = {"LEADER", "STAFF", "MEMBER"})
-    public ResponseEntity<List<ParticipantResponseDto>> getActivityParticipant(
+    public ResponseEntity<Page<ParticipantResponseDto>> getActivityParticipant(
         @LoginUser Long userId,
         @PathVariable("crewId") Long crewId, @PathVariable("activityId") Long activityId,
         Pageable pageable) {

--- a/src/main/java/com/example/runningservice/controller/RegularRunController.java
+++ b/src/main/java/com/example/runningservice/controller/RegularRunController.java
@@ -6,9 +6,7 @@ import com.example.runningservice.dto.regular_run.RegularRunRequestDto;
 import com.example.runningservice.dto.regular_run.RegularRunResponseDto;
 import com.example.runningservice.service.RegularRunService;
 import com.example.runningservice.util.LoginUser;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -68,7 +66,7 @@ public class RegularRunController {
      * 크루별 정기러닝 정보 조회
      */
     @GetMapping("/crew/regular")
-    public ResponseEntity<Page<CrewRegularRunResponseDto>> getRegularRunList(Pageable pageable) {
+    public ResponseEntity<CrewRegularRunResponseDto> getRegularRunList(Pageable pageable) {
         return ResponseEntity.ok(regularRunService.getRegularRunList(pageable));
     }
 
@@ -76,7 +74,7 @@ public class RegularRunController {
      * 특정 크루 정기 러닝 정보 조회
      */
     @GetMapping("/crew/{crewId}/regular")
-    public ResponseEntity<Map<String, Object>> getCrewRegularRunList(
+    public ResponseEntity<CrewRegularRunResponseDto> getCrewRegularRunList(
         @PathVariable("crewId") Long crewId, Pageable pageable) {
         return ResponseEntity.ok(regularRunService.getCrewRegularRunList(crewId, pageable));
     }

--- a/src/main/java/com/example/runningservice/controller/RegularRunController.java
+++ b/src/main/java/com/example/runningservice/controller/RegularRunController.java
@@ -6,8 +6,9 @@ import com.example.runningservice.dto.regular_run.RegularRunRequestDto;
 import com.example.runningservice.dto.regular_run.RegularRunResponseDto;
 import com.example.runningservice.service.RegularRunService;
 import com.example.runningservice.util.LoginUser;
-import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -67,7 +68,7 @@ public class RegularRunController {
      * 크루별 정기러닝 정보 조회
      */
     @GetMapping("/crew/regular")
-    public ResponseEntity<List<CrewRegularRunResponseDto>> getRegularRunList(Pageable pageable) {
+    public ResponseEntity<Page<CrewRegularRunResponseDto>> getRegularRunList(Pageable pageable) {
         return ResponseEntity.ok(regularRunService.getRegularRunList(pageable));
     }
 
@@ -75,7 +76,7 @@ public class RegularRunController {
      * 특정 크루 정기 러닝 정보 조회
      */
     @GetMapping("/crew/{crewId}/regular")
-    public ResponseEntity<CrewRegularRunResponseDto> getCrewRegularRunList(
+    public ResponseEntity<Map<String, Object>> getCrewRegularRunList(
         @PathVariable("crewId") Long crewId, Pageable pageable) {
         return ResponseEntity.ok(regularRunService.getCrewRegularRunList(crewId, pageable));
     }

--- a/src/main/java/com/example/runningservice/dto/crew/CrewRoleResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/crew/CrewRoleResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.runningservice.dto.crew;
 
 import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.CrewMemberEntity;
 import com.example.runningservice.enums.CrewRole;
 import com.example.runningservice.enums.Region;
 import java.util.List;
@@ -18,7 +19,9 @@ public class CrewRoleResponseDto extends CrewBaseResponseDto {
 
     private CrewRole role;
 
-    public static CrewRoleResponseDto fromEntity(CrewEntity crewEntity, CrewRole crewRole) {
+    public static CrewRoleResponseDto fromEntity(CrewMemberEntity crewMemberEntity) {
+        CrewEntity crewEntity = crewMemberEntity.getCrew();
+
         return CrewRoleResponseDto.builder()
             .crewId(crewEntity.getId())
             .leader(crewEntity.getLeader().getNickName())
@@ -31,7 +34,7 @@ public class CrewRoleResponseDto extends CrewBaseResponseDto {
             .activityRegion(Optional.ofNullable(crewEntity.getActivityRegion())
                 .map(Region::getRegionName)
                 .orElse(null))
-            .role(crewRole)
+            .role(crewMemberEntity.getRole())
             .build();
     }
 }

--- a/src/main/java/com/example/runningservice/dto/regular_run/CrewRegularRunResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/regular_run/CrewRegularRunResponseDto.java
@@ -12,6 +12,17 @@ import lombok.NoArgsConstructor;
 @Getter
 public class CrewRegularRunResponseDto {
 
-    private Long crewId;
-    private List<RegularRunResponseDto> data;
+    private Object content;
+    private Integer totalPages;
+    private Long totalElements;
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class Content {
+
+        private Long crewId;
+        private List<RegularRunResponseDto> data;
+    }
 }

--- a/src/main/java/com/example/runningservice/repository/ActivityRepository.java
+++ b/src/main/java/com/example/runningservice/repository/ActivityRepository.java
@@ -24,8 +24,14 @@ public interface ActivityRepository extends JpaRepository<ActivityEntity, Long> 
         @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate,
         Pageable pageable);
 
+    @Query("SELECT a "
+        + "FROM ActivityEntity a "
+        + "WHERE a.date >= CURRENT_DATE "
+        + "AND (:category IS NULL OR a.category = :category)"
+        + "AND a.crew.id = :crewId ")
     Page<ActivityEntity> findByCrew_IdAndCategoryAndDateGreaterThanEqualOrderByDate(
-        Long crewId, ActivityCategory category, LocalDate startDate, Pageable pageable);
+        @Param("crewId") Long crewId, @Param("category") ActivityCategory category,
+        Pageable pageable);
 
     int countByCrew_Id(Long crewId);
 

--- a/src/main/java/com/example/runningservice/service/ActivityService.java
+++ b/src/main/java/com/example/runningservice/service/ActivityService.java
@@ -17,8 +17,8 @@ import com.example.runningservice.repository.MemberRepository;
 import com.example.runningservice.repository.crew.CrewRepository;
 import com.example.runningservice.repository.crewMember.CrewMemberRepository;
 import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -165,31 +165,29 @@ public class ActivityService {
     /**
      * 날짜별 크루 (정기/번개)러닝 일정 조회
      */
-    public List<ActivityResponseDto> getCrewActivityByDate(Long crewId,
+    public Page<ActivityResponseDto> getCrewActivityByDate(Long crewId,
         ActivityFilterDto activityFilter, Pageable pageable) {
         if (!validateDate(activityFilter.getStartDate(), activityFilter.getEndDate())) {
             throw new CustomException(ErrorCode.INVALID_DATE_RANGE);
         }
 
-        List<ActivityEntity> activityPage = activityRepository.findByCrewIdAndCategoryAndDateBetween(
-                crewId, activityFilter.getCategory(), activityFilter.getStartDate(),
-                activityFilter.getEndDate(), pageable)
-            .getContent();
+        Page<ActivityEntity> activityPage = activityRepository.findByCrewIdAndCategoryAndDateBetween(
+            crewId, activityFilter.getCategory(), activityFilter.getStartDate(),
+            activityFilter.getEndDate(), pageable);
 
-        return activityPage.stream().map(ActivityResponseDto::fromEntity).toList();
+        return activityPage.map(ActivityResponseDto::fromEntity);
     }
 
     /**
      * 다가오는 크루 (정기/번개)러닝 일정 조회
      */
-    public List<ActivityResponseDto> getCrewActivity(Long crewId, ActivityCategory category,
+    public Page<ActivityResponseDto> getCrewActivity(Long crewId, ActivityCategory category,
         Pageable pageable) {
-        List<ActivityEntity> activityPage = activityRepository
+        Page<ActivityEntity> activityPage = activityRepository
             .findByCrew_IdAndCategoryAndDateGreaterThanEqualOrderByDate(
-                crewId, category, LocalDate.now(), pageable)
-            .getContent();
+                crewId, category, pageable);
 
-        return activityPage.stream().map(ActivityResponseDto::fromEntity).toList();
+        return activityPage.map(ActivityResponseDto::fromEntity);
     }
 
     // 시작 날짜가 종료 날짜보다 빠르거나 같은지 체크한다.

--- a/src/main/java/com/example/runningservice/service/ParticipantService.java
+++ b/src/main/java/com/example/runningservice/service/ParticipantService.java
@@ -9,8 +9,6 @@ import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.ActivityRepository;
 import com.example.runningservice.repository.MemberRepository;
 import com.example.runningservice.repository.ParticipantRepository;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -76,21 +74,16 @@ public class ParticipantService {
      * 활동 참석자를 조회한다.
      */
     @Transactional
-    public List<ParticipantResponseDto> getActivityParticipant(Long activityId, Pageable pageable) {
+    public Page<ParticipantResponseDto> getActivityParticipant(Long activityId, Pageable pageable) {
         Page<ParticipantEntity> participantPage = participantRepository.findByActivity_Id(
             activityId, pageable);
 
-        List<ParticipantResponseDto> response = new ArrayList<>();
-        for (ParticipantEntity participant : participantPage) {
-            response.add(ParticipantResponseDto.builder()
-                .userId(participant.getMember().getId())
-                .activityId(activityId)
-                .nickName(participant.getMember().getNickName())
-                .birthYear(participant.getMember().getBirthYear())
-                .gender(participant.getMember().getGender())
-                .build());
-        }
-
-        return response;
+        return participantPage.map(entity -> ParticipantResponseDto.builder()
+            .userId(entity.getMember().getId())
+            .activityId(activityId)
+            .nickName(entity.getMember().getNickName())
+            .birthYear(entity.getMember().getBirthYear())
+            .gender(entity.getMember().getGender())
+            .build());
     }
 }

--- a/src/main/java/com/example/runningservice/service/RegularRunService.java
+++ b/src/main/java/com/example/runningservice/service/RegularRunService.java
@@ -9,11 +9,13 @@ import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.RegularRunMeetingRepository;
 import com.example.runningservice.repository.crew.CrewRepository;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -79,7 +81,7 @@ public class RegularRunService {
      * 크루별 정기러닝 정보 조회
      */
     @Transactional
-    public List<CrewRegularRunResponseDto> getRegularRunList(Pageable pageable) {
+    public Page<CrewRegularRunResponseDto> getRegularRunList(Pageable pageable) {
         // 갯수만큼 크루 ID를 조회하고, 크루 ID에 해당하는 모든 정기러닝 조회
         Page<CrewEntity> crewEntities = crewRepository.findAll(pageable);
 
@@ -97,25 +99,33 @@ public class RegularRunService {
                 )
             ));
 
-        return crewRegularMap.entrySet().stream()
+        return new PageImpl<>(crewRegularMap.entrySet().stream()
             .map(entry -> CrewRegularRunResponseDto.builder()
                 .crewId(entry.getKey())
                 .data(entry.getValue())
                 .build())
-            .collect(Collectors.toList());
+            .collect(Collectors.toList()),
+            crewEntities.getPageable(),
+            crewEntities.getSize());
     }
 
     /**
      * 특정 크루의 정기러닝 정보 조회
      */
-    public CrewRegularRunResponseDto getCrewRegularRunList(Long crewId, Pageable pageable) {
+    public Map<String, Object> getCrewRegularRunList(Long crewId, Pageable pageable) {
         Page<RegularRunMeetingEntity> crewEntities = regularRunMeetingRepository.findByCrew_Id(
             crewId, pageable);
 
-        return CrewRegularRunResponseDto.builder()
+        // 구조가 바뀌므로 페이징 값은 따로 넣어줌
+        Map<String, Object> response = new HashMap<>();
+        response.put("totalElements", crewEntities.getTotalElements());
+        response.put("totalPages", crewEntities.getTotalPages());
+        response.put("content", CrewRegularRunResponseDto.builder()
             .crewId(crewId)
-            .data(crewEntities.stream().map(RegularRunResponseDto::fromEntity).toList())
-            .build();
+            .data(crewEntities.getContent().stream().map(RegularRunResponseDto::fromEntity).toList())
+            .build());
+
+        return response;
     }
 
     /**

--- a/src/test/java/com/example/runningservice/service/ActivityServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/ActivityServiceTest.java
@@ -350,12 +350,13 @@ class ActivityServiceTest {
             .willReturn(activityList);
 
         // when
-        List<ActivityResponseDto> response = activityService.getCrewActivityByDate(crewId,
+        Page<ActivityResponseDto> response = activityService.getCrewActivityByDate(crewId,
             equalDate, pageable);
 
         // then
         verify(activityRepository, times(1)).findByCrewIdAndCategoryAndDateBetween(
-            crewId, equalDate.getCategory(), equalDate.getStartDate(), equalDate.getEndDate(), pageable);
-        assertEquals(response.size(), activityList.getSize());
+            crewId, equalDate.getCategory(), equalDate.getStartDate(), equalDate.getEndDate(),
+            pageable);
+        assertEquals(response.getContent().size(), activityList.getSize());
     }
 }

--- a/src/test/java/com/example/runningservice/service/CrewServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/CrewServiceTest.java
@@ -295,13 +295,13 @@ class CrewServiceTest {
         given(crewMemberRepository.findByMember_IdOrderByJoinedAt(loginId, pageable))
             .willReturn(result);
 
-        List<CrewRoleResponseDto> crewList = crewService.getParticipateCrewList(loginId, pageable);
+        Page<CrewRoleResponseDto> crewList = crewService.getParticipateCrewList(loginId, pageable);
 
-        assertEquals(crewList.size(), 2);
-        assertEquals(crewList.get(0).getCrewId(), 5);
-        assertEquals(crewList.get(0).getRole(), CrewRole.LEADER);
-        assertEquals(crewList.get(1).getCrewId(), 10);
-        assertEquals(crewList.get(1).getRole(), CrewRole.MEMBER);
+        assertEquals(crewList.getContent().size(), 2);
+        assertEquals(crewList.getContent().get(0).getCrewId(), 5);
+        assertEquals(crewList.getContent().get(0).getRole(), CrewRole.LEADER);
+        assertEquals(crewList.getContent().get(1).getCrewId(), 10);
+        assertEquals(crewList.getContent().get(1).getRole(), CrewRole.MEMBER);
     }
 
     @Test
@@ -325,13 +325,13 @@ class CrewServiceTest {
             .willReturn(result);
         given(memberRepository.findMemberById(loginId)).willReturn(member);
 
-        List<CrewJoinStatusResponseDto> response = crewService.getCrewList(loginId, crewInfo,
+        Page<CrewJoinStatusResponseDto> response = crewService.getCrewList(loginId, crewInfo,
             pageable);
 
         verify(crewRepository, times(1)).findFullCrewList(any(), any(), any(),
             any(), any(), any(), any());
-        assertEquals(response.size(), 2);
-        assertTrue(response.get(0).isJoined());
+        assertEquals(response.getContent().size(), 2);
+        assertTrue(response.getContent().get(0).isJoined());
     }
 
     @Test
@@ -353,12 +353,12 @@ class CrewServiceTest {
         given(crewRepository.findFullCrewList(any(), any(), any(), any(), any(), any(), any()))
             .willReturn(result);
 
-        List<CrewJoinStatusResponseDto> response = crewService.getCrewList(null, crewInfo,
+        Page<CrewJoinStatusResponseDto> response = crewService.getCrewList(null, crewInfo,
             pageable);
 
         verify(crewRepository, times(1)).findFullCrewList(any(), any(), any(),
             any(), any(), any(), any());
-        assertEquals(response.size(), 2);
-        assertFalse(response.get(0).isJoined());
+        assertEquals(response.getContent().size(), 2);
+        assertFalse(response.getContent().get(0).isJoined());
     }
 }

--- a/src/test/java/com/example/runningservice/service/ParticipantServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/ParticipantServiceTest.java
@@ -100,12 +100,12 @@ class ParticipantServiceTest {
             participantPage);
 
         // when
-        List<ParticipantResponseDto> response = participantService.getActivityParticipant(
+        Page<ParticipantResponseDto> response = participantService.getActivityParticipant(
             activityId, pageable);
 
         // then
-        Assertions.assertEquals(response.size(), participantList.size());
-        Assertions.assertEquals(response.get(0).getNickName(), member1.getNickName());
-        Assertions.assertEquals(response.get(1).getNickName(), member2.getNickName());
+        Assertions.assertEquals(response.getContent().size(), participantList.size());
+        Assertions.assertEquals(response.getContent().get(0).getNickName(), member1.getNickName());
+        Assertions.assertEquals(response.getContent().get(1).getNickName(), member2.getNickName());
     }
 }

--- a/src/test/java/com/example/runningservice/service/RegularRunServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/RegularRunServiceTest.java
@@ -9,13 +9,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.example.runningservice.dto.regular_run.CrewRegularRunResponseDto;
+import com.example.runningservice.dto.regular_run.CrewRegularRunResponseDto.Content;
 import com.example.runningservice.dto.regular_run.RegularRunRequestDto;
 import com.example.runningservice.dto.regular_run.RegularRunResponseDto;
 import com.example.runningservice.entity.CrewEntity;
 import com.example.runningservice.entity.RegularRunMeetingEntity;
 import com.example.runningservice.enums.Region;
-import com.example.runningservice.repository.crew.CrewRepository;
 import com.example.runningservice.repository.RegularRunMeetingRepository;
+import com.example.runningservice.repository.crew.CrewRepository;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +54,7 @@ class RegularRunServiceTest {
         when(regularRunDto.getCount()).thenReturn(2);
         when(regularRunDto.getWeek()).thenReturn(3);
         when(regularRunDto.getDayOfWeek()).thenReturn(List.of("월요일", "화요일"));
-        when(regularRunDto.getTime()).thenReturn(LocalTime.of(1,1));
+        when(regularRunDto.getTime()).thenReturn(LocalTime.of(1, 1));
         when(regularRunDto.getActivityRegion()).thenReturn(Region.SEOUL);
         CrewEntity mockCrewEntity = new CrewEntity();
         given(crewRepository.findById(crewId)).willReturn(Optional.of(mockCrewEntity));
@@ -93,7 +94,8 @@ class RegularRunServiceTest {
 
         // Then
         assertNotNull(response);
-        assertEquals(regularRunDto.getActivityRegion().getRegionName(), response.getActivityRegion());
+        assertEquals(regularRunDto.getActivityRegion().getRegionName(),
+            response.getActivityRegion());
         assertEquals(List.of("월요일", "화요일"), response.getDayOfWeek());
     }
 
@@ -145,14 +147,16 @@ class RegularRunServiceTest {
         given(regularRunMeetingRepository.findByCrewIdIn(crewIdList)).willReturn(regularList);
 
         // When
-        List<CrewRegularRunResponseDto> response = regularRunService.getRegularRunList(pageable);
+        CrewRegularRunResponseDto response = regularRunService.getRegularRunList(pageable);
+        List<CrewRegularRunResponseDto.Content> content = (List<Content>) response.getContent();
 
         // Then
         assertNotNull(response);
-        assertEquals(2, response.size());
-        assertEquals(crewIdList.get(0), response.get(0).getCrewId());
-        assertEquals(1, response.get(0).getData().size());
-        assertEquals(Region.SEOUL.getRegionName(), response.get(0).getData().get(0).getActivityRegion());
+        assertEquals(content, response.getContent());
+        assertEquals(crewIdList.get(0), content.get(0).getCrewId());
+        assertEquals(1, content.get(0).getData().size());
+        assertEquals(Region.SEOUL.getRegionName(),
+            content.get(0).getData().get(0).getActivityRegion());
     }
 
     @Test
@@ -172,11 +176,12 @@ class RegularRunServiceTest {
         // when
         CrewRegularRunResponseDto result = regularRunService.getCrewRegularRunList(crewId,
             Pageable.unpaged());
+        CrewRegularRunResponseDto.Content content = (Content) result.getContent();
 
         // then
         assertNotNull(result);
-        assertEquals(crewId, result.getCrewId());
-        assertEquals(1, result.getData().size());
+        assertEquals(crewId, content.getCrewId());
+        assertEquals(1, content.getData().size());
         verify(regularRunMeetingRepository).findByCrew_Id(crewId, Pageable.unpaged());
     }
 


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 크루/활동/정기러닝 조회 시, Page 정보 함께 반환
- 활동 카테고리 null 일때는 모든 카테고리가 조회되도록 fix

### 이 PR에서 변경된 사항
- 크루, 활동 목록 조회 List 대신 Page 리턴
- 다가오는 크루 일정 JPA 메서드 JPQL로 변경
- 오늘 날짜 값 직접 입력하지 않고 CURRENT_DATE로 처리
- 참석자 조회 dto : CrewMember 안에서 crew와 crewRole을 모두 조회할 수 있으므로 CrewMember를 가져오도록 함
- 정기러닝은 id를 따로 분리해서 조회하므로 Page를 쓰기 애매해 DTO를 따로 두어 페이징 값을 처리
- 반환 값 수정에 맞게 테스트 코드 수정

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
