### PR TITLE
fix-refresh-token refreshToken 관리를 cookie에서

### DIFF
--- a/src/main/java/com/example/runningservice/controller/AuthController.java
+++ b/src/main/java/com/example/runningservice/controller/AuthController.java
@@ -2,14 +2,19 @@ package com.example.runningservice.controller;
 
 import com.example.runningservice.dto.JwtResponse;
 import com.example.runningservice.dto.LoginRequestDto;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.service.AuthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,19 +25,60 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<JwtResponse> login(@RequestBody LoginRequestDto loginRequestDto)
+    public ResponseEntity<String> login(@RequestBody LoginRequestDto loginRequestDto,
+        HttpServletResponse response)
         throws Exception {
         JwtResponse jwtResponse = authService.authenticate(loginRequestDto);
 
-        return ResponseEntity.ok(jwtResponse);
+        //responseHeader에 쿠키 저장
+        setResponseHeader(response, jwtResponse);
+
+        return ResponseEntity.ok(jwtResponse.getAccessJwt());
     }
 
     @PostMapping("/token/refresh")
-    public ResponseEntity<JwtResponse> refreshToken(
-        @RequestHeader(name = "Authorization") String refreshToken, Principal principal) {
+    public ResponseEntity<String> refreshToken(
+        HttpServletRequest request, Principal principal,
+        HttpServletResponse response) {
 
-        refreshToken = refreshToken.replace("Bearer ", "");
-        return ResponseEntity.ok(authService.refreshToken(refreshToken, principal));
+        String refreshToken = extractTokenFromCookie(request);
+
+        if (refreshToken == null) {
+            throw new CustomException(ErrorCode.NO_VALID_REFRESH_TOKEN);
+        }
+
+        JwtResponse jwtResponse = authService.refreshToken(refreshToken, principal);
+
+        setResponseHeader(response, jwtResponse);
+
+        return ResponseEntity.ok(jwtResponse.getAccessJwt());
     }
 
+    private void setResponseHeader(HttpServletResponse response, JwtResponse jwtResponse) {
+        response.setHeader("Set-Cookie",
+            createRefreshTokenCookie(jwtResponse.getRefreshJwt()).toString());
+    }
+
+
+    private ResponseCookie createRefreshTokenCookie(String refreshToken) {
+        return ResponseCookie.from("refreshToken", refreshToken)
+            .maxAge(7 * 24 * 60 * 60) // 7일
+            .path("/")
+            .secure(false)
+            .sameSite("None")
+            .httpOnly(true)
+            .build();
+    }
+
+    private String extractTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refreshToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null; // 쿠키에서 토큰을 찾지 못한 경우
+    }
 }

--- a/src/main/java/com/example/runningservice/controller/OAuthController.java
+++ b/src/main/java/com/example/runningservice/controller/OAuthController.java
@@ -4,7 +4,9 @@ import com.example.runningservice.dto.JwtResponse;
 import com.example.runningservice.dto.googleToken.GoogleAccountProfileResponseDto;
 import com.example.runningservice.service.OAuth2Service;
 import com.example.runningservice.service.Oauth2ProcessService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,13 +20,33 @@ public class OAuthController {
     private final Oauth2ProcessService oauth2ProcessService;
 
     @GetMapping("login/oauth")
-    public ResponseEntity<JwtResponse> googleAccountProfileRes(@RequestParam String code) {
+    public ResponseEntity<JwtResponse> googleAccountProfileRes(@RequestParam String code,
+        HttpServletResponse response) {
 
         GoogleAccountProfileResponseDto googleAccountProfileResponseDto = oAuth2Service.getGoogleAccountProfile(
             code);
+        JwtResponse jwtResponse = oauth2ProcessService.processOauth2Info(
+            googleAccountProfileResponseDto);
 
-        return ResponseEntity.ok(
-            oauth2ProcessService.processOauth2Info(googleAccountProfileResponseDto));
+        setResponseHeader(response, jwtResponse);
+
+        return ResponseEntity.ok(jwtResponse);
+    }
+
+    private void setResponseHeader(HttpServletResponse response, JwtResponse jwtResponse) {
+        response.setHeader("Set-Cookie",
+            createRefreshTokenCookie(jwtResponse.getRefreshJwt()).toString());
+    }
+
+
+    private ResponseCookie createRefreshTokenCookie(String refreshToken) {
+        return ResponseCookie.from("refreshToken", refreshToken)
+            .maxAge(7 * 24 * 60 * 60) // 7알
+            .path("/")
+            .secure(true)
+            .sameSite("None")
+            .httpOnly(true)
+            .build();
     }
 
 }

--- a/src/main/java/com/example/runningservice/dto/JwtResponse.java
+++ b/src/main/java/com/example/runningservice/dto/JwtResponse.java
@@ -1,6 +1,12 @@
 package com.example.runningservice.dto;
 
-import lombok.*;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import net.minidev.json.annotate.JsonIgnore;
 
 @Getter
 @Setter
@@ -8,6 +14,8 @@ import lombok.*;
 @NoArgsConstructor
 @Builder
 public class JwtResponse {
+    @JsonProperty("accessJwt")
     private String accessJwt;
+    @JsonIgnore
     private String refreshJwt;
 }

--- a/src/main/java/com/example/runningservice/security/SecurityConfig.java
+++ b/src/main/java/com/example/runningservice/security/SecurityConfig.java
@@ -58,7 +58,8 @@ public class SecurityConfig {
                         "/region",
                         "/posts/**",
                         "/crew",
-                        "/comments/**")
+                        "/comments/**",
+                        "/token/refresh/**")
                     .permitAll().requestMatchers(
                         HttpMethod.GET, "/crew/*")
                     .permitAll().requestMatchers(
@@ -66,14 +67,13 @@ public class SecurityConfig {
                     .permitAll().requestMatchers(
                         HttpMethod.GET, "/crew/*/activity")
                     .permitAll().requestMatchers(
-                        "/token/refresh/**",
                         "/posts/new",
                         "/comments/save",
                         "/crew/search/**",
                         "/logout",
                         "/crew/participate",
                         "/user/**",
-                        "crew/**")
+                        "/crew/**")
                     .hasAnyAuthority("ROLE_USER")
                     .anyRequest().authenticated())
             .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/example/runningservice/service/AuthService.java
+++ b/src/main/java/com/example/runningservice/service/AuthService.java
@@ -19,6 +19,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +31,7 @@ public class AuthService {
     private final JwtUtil jwtUtil;
     private final TokenBlackList tokenBlackList;
 
+    @Transactional
     public JwtResponse authenticate(LoginRequestDto loginRequestDto) throws Exception {
         //loginId와 비밀번호 일치여부 확인 (불일치 시 예외 발생)
         Authentication authentication = null;
@@ -67,6 +69,7 @@ public class AuthService {
         return new JwtResponse(accessJwt, refreshJwt);
     }
 
+    @Transactional
     public JwtResponse refreshToken(String refreshToken, Principal principal) {
         //refresh token 이 블랙리스트에 있는지 확인
         if (tokenBlackList.isListed(refreshToken)) {

--- a/src/main/java/com/example/runningservice/util/JwtUtil.java
+++ b/src/main/java/com/example/runningservice/util/JwtUtil.java
@@ -6,6 +6,7 @@ import com.example.runningservice.enums.Role;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.security.SignatureException;
@@ -78,6 +79,9 @@ public class JwtUtil {
         } catch (IllegalArgumentException e) {
             log.error("JWT claims string is empty: {}", e.getMessage());
             throw new CustomException(ErrorCode.INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
+            log.error("JWT token is expired: {}", e.getMessage());
+            throw new CustomException(ErrorCode.TOKEN_EXPIRED);
         }
     }
 


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- refreshToken 을 쿠키로 관리하도록 수정
- jwtAuthenticationFilter에서 토큰 만료 예외를 잡아내도록 수정

### 이 PR에서 변경된 사항
- JwtAuthenticationFilter, jwtUtil : 예외처리 수정
- AuthController, OAuthController : refreshToken을 쿠키에 저장
- SecurityConfig : 오타 수정, refresh Token 엔드포인트 Permitall() 처리

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
