### PR TITLE
fix-refresh-token 토큰 갱신 버그 수정

### DIFF
--- a/src/main/java/com/example/runningservice/controller/AuthController.java
+++ b/src/main/java/com/example/runningservice/controller/AuthController.java
@@ -38,8 +38,7 @@ public class AuthController {
 
     @PostMapping("/token/refresh")
     public ResponseEntity<String> refreshToken(
-        HttpServletRequest request, Principal principal,
-        HttpServletResponse response) {
+        HttpServletRequest request, HttpServletResponse response) {
 
         String refreshToken = extractTokenFromCookie(request);
 
@@ -47,7 +46,7 @@ public class AuthController {
             throw new CustomException(ErrorCode.NO_VALID_REFRESH_TOKEN);
         }
 
-        JwtResponse jwtResponse = authService.refreshToken(refreshToken, principal);
+        JwtResponse jwtResponse = authService.refreshToken(refreshToken);
 
         setResponseHeader(response, jwtResponse);
 

--- a/src/test/java/com/example/runningservice/service/AuthServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/AuthServiceTest.java
@@ -189,11 +189,9 @@ class AuthServiceTest {
             "access-token");
         when(jwtUtil.generateRefreshToken("test@example.com", userDetails.getId(),
             authorities)).thenReturn("refresh-token");
-        when(principal.getName()).thenReturn(principalEmail);
-        when(jwtUtil.validateToken(principalEmail, refreshToken)).thenCallRealMethod();
         when(jwtUtil.isTokenExpired(refreshToken)).thenReturn(false);
         //when
-        JwtResponse jwtResponse = authService.refreshToken(refreshToken, principal);
+        JwtResponse jwtResponse = authService.refreshToken(refreshToken);
         //then
         assertNotNull(jwtResponse);
         assertEquals("refresh-token", jwtResponse.getRefreshJwt());
@@ -209,7 +207,7 @@ class AuthServiceTest {
 
         // When & Then
         CustomException exception = assertThrows(CustomException.class, () -> {
-            authService.refreshToken(refreshToken, principal);
+            authService.refreshToken(refreshToken);
         });
 
         assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, exception.getErrorCode());
@@ -221,35 +219,13 @@ class AuthServiceTest {
     void testRefreshToken_TokenExpired() {
         // Given
         String refreshToken = "expired-refresh-token";
-        String principalEmail = "test@example.com";
+        String email = "test@example.com";
         when(tokenBlackList.isListed(refreshToken)).thenReturn(false);
-        when(principal.getName()).thenReturn(principalEmail);
-        when(jwtUtil.validateToken(principalEmail, refreshToken)).thenCallRealMethod();
-        when(jwtUtil.extractEmail(refreshToken)).thenReturn(principalEmail);
         when(jwtUtil.isTokenExpired(refreshToken)).thenReturn(true);
 
         // When & Then
         CustomException exception = assertThrows(CustomException.class, () -> {
-            authService.refreshToken(refreshToken, principal);
-        });
-
-        assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());
-    }
-
-
-    @Test
-    void testRefreshToken_EmailMisMatch() {
-        // Given
-        String refreshToken = "expired-refresh-token";
-        String principalEmail = "test@example.com";
-        when(tokenBlackList.isListed(refreshToken)).thenReturn(false);
-        when(principal.getName()).thenReturn(principalEmail);
-        when(jwtUtil.validateToken(principalEmail, refreshToken)).thenCallRealMethod();
-        when(jwtUtil.extractEmail(refreshToken)).thenReturn("diffrent-email");
-
-        // When & Then
-        CustomException exception = assertThrows(CustomException.class, () -> {
-            authService.refreshToken(refreshToken, principal);
+            authService.refreshToken(refreshToken);
         });
 
         assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());


### PR DESCRIPTION

### 이 PR을 통해 해결하려는 문제
- 토큰을 헤더로 보내주어야 security 필터를 거치며 Principal 정보가 등록되지만, refreshToken을 쿠키에 넣어 관리함으로써 Principal이 null로 들어오게 됨에 따라 nullPointException 발생

### 이 PR에서 변경된 사항
- AuthController : Principal 삭제
- AuthService : Principal 삭제된 버전으로 로직 수정
- AuthServiceTest : 수정된 코드 반영한 테스트코드 수정

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
