### PR TITLE
refactore: Profile 리팩터링

### DIFF
--- a/src/main/java/com/example/runningservice/controller/MemberController.java
+++ b/src/main/java/com/example/runningservice/controller/MemberController.java
@@ -18,30 +18,30 @@ public class MemberController {
     private final MemberService memberService;
 
     // 사용자 정보 조회
-    @GetMapping("/{user_id}/profile")
-    public ResponseEntity<MemberResponseDto> getMemberProfile(@PathVariable("user_id") Long userId) {
-        return ResponseEntity.ok(memberService.getMemberProfile(userId));
+    @GetMapping("/{member_id}/profile")
+    public ResponseEntity<MemberResponseDto> getMemberProfile(@PathVariable("member_id") Long memberId) {
+        return ResponseEntity.ok(memberService.getMemberProfile(memberId));
     }
 
     // 사용자 정보 수정
-    @PutMapping("/{user_id}/profile")
+    @PutMapping("/profile")
     public ResponseEntity<MemberResponseDto> updateMemberProfile(
-        @PathVariable("user_id") @LoginUser Long userId, @RequestBody @Valid UpdateMemberRequestDto updateMemberRequestDto) {
-        return ResponseEntity.ok(memberService.updateMemberProfile(userId, updateMemberRequestDto));
+        @LoginUser Long memberId, @RequestBody @Valid UpdateMemberRequestDto updateMemberRequestDto) {
+        return ResponseEntity.ok(memberService.updateMemberProfile(memberId, updateMemberRequestDto));
     }
 
     // 비밀번호 변경
-    @PutMapping("/{user_id}/password")
+    @PutMapping("/password")
     public ResponseEntity<Void> updateMemberPassword(
-        @PathVariable("user_id") @LoginUser Long userId, @RequestBody @Valid PasswordRequestDto passwordRequestDto) {
-        memberService.updateMemberPassword(userId, passwordRequestDto);
+        @LoginUser Long memberId, @RequestBody @Valid PasswordRequestDto passwordRequestDto) {
+        memberService.updateMemberPassword(memberId, passwordRequestDto);
         return ResponseEntity.ok().build();
     }
 
     // 회원 탈퇴
-    @DeleteMapping("/{user_id}")
-    public ResponseEntity<Void> deleteMember(@PathVariable("user_id") @LoginUser Long userId, @RequestBody DeleteRequestDto deleteRequestDto) {
-        memberService.deleteMember(userId, deleteRequestDto);
+    @DeleteMapping("")
+    public ResponseEntity<Void> deleteMember(@LoginUser Long memberId, @RequestBody DeleteRequestDto deleteRequestDto) {
+        memberService.deleteMember(memberId, deleteRequestDto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/runningservice/repository/JoinApplicationRepository.java
+++ b/src/main/java/com/example/runningservice/repository/JoinApplicationRepository.java
@@ -25,4 +25,6 @@ public interface JoinApplicationRepository extends JpaRepository<JoinApplyEntity
     Optional<JoinApplyEntity> findTopByMember_IdAndCrew_IdOrderByCreatedAtDesc(Long userId, Long crewId);
 
     void deleteByCrew_Id(Long crewId);
+
+    void deleteAllByMember_Id(Long memberId);
 }

--- a/src/main/java/com/example/runningservice/repository/RunGoalRepository.java
+++ b/src/main/java/com/example/runningservice/repository/RunGoalRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RunGoalRepository extends JpaRepository<RunGoalEntity, Long> {
     List<RunGoalEntity> findByUserId_Id(Long userId);
+
+    void deleteAllByUserId_Id(Long userId);
 }

--- a/src/main/java/com/example/runningservice/repository/RunRecordRepository.java
+++ b/src/main/java/com/example/runningservice/repository/RunRecordRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RunRecordRepository extends JpaRepository<RunRecordEntity, Long> {
     List<RunRecordEntity> findByUserId_Id(Long userId);
+
+    void deleteAllByUserId_Id(Long userId);
 }

--- a/src/main/java/com/example/runningservice/repository/UserNotificationRepository.java
+++ b/src/main/java/com/example/runningservice/repository/UserNotificationRepository.java
@@ -11,4 +11,6 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
 
     Page<UserNotificationEntity> findByMember_IdOrderByNotification_CreatedAtDesc(Long memberId,
         Pageable pageable);
+
+    void deleteAllByMember_Id(Long memberId);
 }

--- a/src/main/java/com/example/runningservice/repository/chat/ChatJoinRepository.java
+++ b/src/main/java/com/example/runningservice/repository/chat/ChatJoinRepository.java
@@ -33,4 +33,8 @@ public interface ChatJoinRepository extends JpaRepository<ChatJoinEntity, Long>,
 
     List<ChatJoinEntity> findByChatRoom_Id(Long chatRoomId);
 
+    List<ChatJoinEntity> findAllByMember_Id(Long memberId);
+
+    void deleteAllByMember_Id(Long memberId);
+
 }

--- a/src/main/java/com/example/runningservice/repository/chat/MessageRepository.java
+++ b/src/main/java/com/example/runningservice/repository/chat/MessageRepository.java
@@ -18,6 +18,6 @@ public interface MessageRepository extends JpaRepository<MessageEntity, Long> {
 
 
 
-    List<MessageEntity> findByChatJoin(ChatJoinEntity chatJoin);
+    List<MessageEntity> findAllByChatJoin(ChatJoinEntity chatJoin);
 
 }

--- a/src/main/java/com/example/runningservice/repository/crewMember/CrewMemberBlackListRepository.java
+++ b/src/main/java/com/example/runningservice/repository/crewMember/CrewMemberBlackListRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 public interface CrewMemberBlackListRepository extends JpaRepository<CrewMemberBlackListEntity, Long> {
 
     void deleteByCrew_Id(Long crewId);
+
+    void deleteAllByMember_Id(Long memberId);
 }

--- a/src/main/java/com/example/runningservice/repository/crewMember/CrewMemberRepository.java
+++ b/src/main/java/com/example/runningservice/repository/crewMember/CrewMemberRepository.java
@@ -31,4 +31,8 @@ public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Lo
     List<CrewMemberEntity> findByCrew(CrewEntity crew);
 
     Page<CrewMemberEntity> findAllByOrderByRoleOrderAscJoinedAtAsc(Pageable pageable);
+
+    List<CrewMemberEntity> findAllByMember_Id(Long memberId);
+
+    void deleteAllByMember_Id(Long memberId);
 }

--- a/src/main/java/com/example/runningservice/service/MemberService.java
+++ b/src/main/java/com/example/runningservice/service/MemberService.java
@@ -1,13 +1,20 @@
 package com.example.runningservice.service;
 
-import com.example.runningservice.dto.member.*;
+import com.example.runningservice.dto.member.DeleteRequestDto;
+import com.example.runningservice.dto.member.MemberResponseDto;
+import com.example.runningservice.dto.member.PasswordRequestDto;
+import com.example.runningservice.dto.member.UpdateMemberRequestDto;
+import com.example.runningservice.entity.CrewMemberEntity;
 import com.example.runningservice.entity.MemberEntity;
-import com.example.runningservice.enums.Gender;
-import com.example.runningservice.enums.Region;
-import com.example.runningservice.enums.Visibility;
+import com.example.runningservice.entity.chat.ChatJoinEntity;
+import com.example.runningservice.enums.CrewRole;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
-import com.example.runningservice.repository.MemberRepository;
+import com.example.runningservice.repository.*;
+import com.example.runningservice.repository.chat.ChatJoinRepository;
+import com.example.runningservice.repository.chat.MessageRepository;
+import com.example.runningservice.repository.crewMember.CrewMemberBlackListRepository;
+import com.example.runningservice.repository.crewMember.CrewMemberRepository;
 import com.example.runningservice.util.AESUtil;
 import com.example.runningservice.util.S3FileUtil;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +23,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -26,22 +35,30 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final AESUtil aesUtil;
     private final S3FileUtil s3FileUtil;
+    private final NotificationRepository notificationRepository;
+    private final RunGoalRepository runGoalRepository;
+    private final RunRecordRepository runRecordRepository;
+    private final JoinApplicationRepository joinApplicationRepository;
+    private final CrewMemberBlackListRepository crewMemberBlackListRepository;
+    private final CrewMemberRepository crewMemberRepository;
+    private final ChatJoinRepository chatJoinRepository;
+    private final MessageRepository messageRepository;
 
     // 사용자 정보 조회
     @Transactional
-    public MemberResponseDto getMemberProfile(Long userId) {
-        MemberEntity memberEntity = memberRepository.findMemberById(userId);
+    public MemberResponseDto getMemberProfile(Long memberId) {
+        MemberEntity memberEntity = memberRepository.findMemberById(memberId);
         return MemberResponseDto.of(memberEntity, aesUtil);
     }
 
     // 사용자 정보 수정
     @Transactional
-    public MemberResponseDto updateMemberProfile(Long userId,
+    public MemberResponseDto updateMemberProfile(Long memberId,
                                                  UpdateMemberRequestDto updateMemberRequestDto) {
-        MemberEntity memberEntity = memberRepository.findMemberById(userId);
+        MemberEntity memberEntity = memberRepository.findMemberById(memberId);
 
         // 프로필 이미지 업로드
-        profileImageUploadHandler(updateMemberRequestDto.getProfileImage(), userId, memberEntity);
+        profileImageUploadHandler(updateMemberRequestDto.getProfileImage(), memberId, memberEntity);
 
         memberEntity.updateMemberProfile(updateMemberRequestDto);
 
@@ -52,8 +69,8 @@ public class MemberService {
 
     // 비밀번호 변경
     @Transactional
-    public void updateMemberPassword(Long userId, PasswordRequestDto passwordRequestDto) {
-        MemberEntity memberEntity = memberRepository.findMemberById(userId);
+    public void updateMemberPassword(Long memberId, PasswordRequestDto passwordRequestDto) {
+        MemberEntity memberEntity = memberRepository.findMemberById(memberId);
 
         try {
             // 저장된 비밀번호화 입력한 oldPassword가 일치하는지 확인
@@ -72,18 +89,56 @@ public class MemberService {
 
     // 회원 탈퇴
     @Transactional
-    public void deleteMember(Long userId, DeleteRequestDto deleteRequestDto) {
-        MemberEntity memberEntity = memberRepository.findMemberById(userId);
+    public void deleteMember(Long memberId, DeleteRequestDto deleteRequestDto) {
+        MemberEntity memberEntity = memberRepository.findMemberById(memberId);
 
         try {
             // 저장된 비밀번호화 입력한 oldPassword가 일치하는지 확인
             validateOldPassword(deleteRequestDto.getPassword(), memberEntity.getPassword());
-
-            // 회원 탈퇴
-            memberRepository.delete(memberEntity);
         } catch (Exception e) {
             throw new CustomException(ErrorCode.ENCRYPTION_ERROR);
         }
+
+        // 사용자 알람 제거
+
+        // 사용자 목표 제거
+        runGoalRepository.deleteAllByUserId_Id(memberId);
+
+        // 사용자 기록 제거
+        runRecordRepository.deleteAllByUserId_Id(memberId);
+
+        // 크루 가입 상태 확인
+        List<CrewMemberEntity> crewMemberEntities = crewMemberRepository.findAllByMember_Id(memberId);
+        if (!crewMemberEntities.isEmpty()){
+            // 가입되어있는 경우
+            // 크루 리더인지 확인
+            crewMemberEntities.stream()
+                .filter(crewMemberEntity -> crewMemberEntity.getRole() == CrewRole.LEADER)
+                .findAny()
+                .ifPresent(crewMemberEntity -> {
+                    throw new RuntimeException("크루 리더 위임 후 탈퇴해주세요");
+                });
+
+            // 참여중인 채팅방 확인
+            List<ChatJoinEntity> chatJoinEntities = chatJoinRepository.findAllByMember_Id(memberId);
+
+            if (!chatJoinEntities.isEmpty()){
+                // 참여중인 채팅방의 메시지 연결 끊기
+                chatJoinEntities.stream()
+                    .flatMap(chatJoinEntity -> messageRepository.findAllByChatJoin(chatJoinEntity).stream())
+                    .forEach(message -> message.setChatJoinNull(null));
+
+                // 참여중인 채팅방 퇴장
+                chatJoinRepository.deleteAllByMember_Id(memberId);
+            }
+
+            joinApplicationRepository.deleteAllByMember_Id(memberId);
+            crewMemberBlackListRepository.deleteAllByMember_Id(memberId);
+            crewMemberRepository.deleteAllByMember_Id(memberId);
+        }
+
+        // 회원 탈퇴
+        memberRepository.delete(memberEntity);
     }
 
     // 이미지 업데이트

--- a/src/main/java/com/example/runningservice/service/chat/ChatRoomService.java
+++ b/src/main/java/com/example/runningservice/service/chat/ChatRoomService.java
@@ -159,7 +159,7 @@ public class ChatRoomService {
             throw new RuntimeException("멤버가 채팅방에 참여중이지 않습니다.");
         }
 
-        List<MessageEntity> messages = messageRepository.findByChatJoin(chatJoinEntity);
+        List<MessageEntity> messages = messageRepository.findAllByChatJoin(chatJoinEntity);
         for (MessageEntity message : messages) {
             message.setChatJoinNull(null);
         }

--- a/src/test/java/com/example/runningservice/service/MemberServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/MemberServiceTest.java
@@ -10,6 +10,13 @@ import com.example.runningservice.enums.Region;
 import com.example.runningservice.enums.Role;
 import com.example.runningservice.enums.Visibility;
 import com.example.runningservice.repository.MemberRepository;
+import com.example.runningservice.repository.RunGoalRepository;
+import com.example.runningservice.repository.RunRecordRepository;
+import com.example.runningservice.repository.chat.ChatJoinRepository;
+import com.example.runningservice.repository.chat.MessageRepository;
+import com.example.runningservice.repository.crew.CrewRepository;
+import com.example.runningservice.repository.crewMember.CrewMemberBlackListRepository;
+import com.example.runningservice.repository.crewMember.CrewMemberRepository;
 import com.example.runningservice.util.AESUtil;
 import com.example.runningservice.util.S3FileUtil;
 import org.junit.jupiter.api.Test;
@@ -32,6 +39,27 @@ public class MemberServiceTest {
 
     @Mock
     private MemberRepository memberRepository;
+
+    @Mock
+    private RunGoalRepository runGoalRepository;
+
+    @Mock
+    private RunRecordRepository runRecordRepository;
+
+    @Mock
+    private CrewMemberRepository crewMemberRepository;
+
+    @Mock
+    private CrewRepository crewRepository;
+
+    @Mock
+    private ChatJoinRepository chatJoinRepository;
+
+    @Mock
+    private MessageRepository messageRepository;
+
+    @Mock
+    private CrewMemberBlackListRepository crewMemberBlackListRepository;
 
     @Mock
     private PasswordEncoder passwordEncoder;


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- url 에 id값이 노출되지 않도록 수정

### 이 PR에서 변경된 사항
- MemberController에서 PathVariable 값으로 user_id를 넣어주는 부분을 @LoginUser 어노테이션으로 대체
- 유저 삭제 메서드 동작과정에서 해당 유저와 관련된 entity 데이터 먼저 삭제후 삭제되도록 수정
-- 크루 리더를 가지고 있는 경우 에러 발생
-- 채팅방에 입장중인 경우 MessageEntity의 Chatjoin 값을 null로 변경후 ChatJoin 데이터를 삭제처리하도록 변경

### 참고 스크린샷

### 기타
- @LoginUser  어노테이션을 사용하는 경우 로그인한 유저의 id값을 가져오기 때문에 따로 사용자 본인임을 인증할 필요는 없을거같아 LoginUser 어노테이션만 사용하였습니다.
- 사용자 조회의 경우 다른 사용자를 조회하거나 로그인없이도 조회가 가능하게끔 해야하기 때문에 @LoginUser 어노테이션 사용 x

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [ ] API 테스트
