### PR TITLE
fix : login-exception 인증되지 않은 이메일로 로그인 시 적절한 예외 출력

### DIFF
--- a/src/main/java/com/example/runningservice/exception/NotVerifiedEmailException.java
+++ b/src/main/java/com/example/runningservice/exception/NotVerifiedEmailException.java
@@ -1,0 +1,12 @@
+package com.example.runningservice.exception;
+
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+@Getter
+public class NotVerifiedEmailException extends AuthenticationException {
+
+    public NotVerifiedEmailException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/example/runningservice/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/runningservice/security/CustomUserDetailsService.java
@@ -3,6 +3,7 @@ package com.example.runningservice.security;
 import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.exception.NotVerifiedEmailException;
 import com.example.runningservice.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,7 +25,9 @@ public class CustomUserDetailsService implements UserDetailsService {
         MemberEntity memberEntity = memberRepository.findByEmail(email)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
         //이메일 인증여부 확인
-        if (!memberEntity.isEmailVerified()) throw new CustomException(ErrorCode.INVALID_EMAIL);
+        if (!memberEntity.isEmailVerified()) {
+            throw new NotVerifiedEmailException(ErrorCode.INVALID_EMAIL.getMessage());
+        }
 
         log.debug("User found: {}", email);
 

--- a/src/main/java/com/example/runningservice/service/AuthService.java
+++ b/src/main/java/com/example/runningservice/service/AuthService.java
@@ -17,6 +17,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,14 +42,12 @@ public class AuthService {
 
             log.debug("Authentication successful");
 
-        } catch (CustomException e) {
-            if (e.getErrorCode() == ErrorCode.INVALID_EMAIL) {
+        } catch (UsernameNotFoundException e) {
+            throw new CustomException(ErrorCode.NOT_FOUND_USER);
+        } catch (AuthenticationException e) {
+            if (e.getMessage().equals(ErrorCode.INVALID_EMAIL.getMessage())) {
                 throw new CustomException(ErrorCode.INVALID_EMAIL);
             }
-            if (e.getErrorCode() == ErrorCode.NOT_FOUND_USER) {
-                throw new CustomException(ErrorCode.NOT_FOUND_USER);
-            }
-        } catch (AuthenticationException e) {
             throw new CustomException(ErrorCode.INVALID_LOGIN);
         }
 


### PR DESCRIPTION

### 이 PR을 통해 해결하려는 문제
- Login 시 인증되지 않은 이메일로 로그인할 경우 INVALID_EMAIL 예외코드를 출력하도록 했지만 정상동작하지 않아 수정

### 이 PR에서 변경된 사항
- NotVerifiedEmailException : AuthenticationException을 상속하는 예외 클래스 생성
- CustomUserDetailsService 에서 이메일이 인증되지 않았을 시 NotVerifiedEmailException 던지도록 설정
- AuthService : AuthenticationException 잡아내고 메세지가 이메일 미인증 내용일 때 CustomException(ErrorCode.INVALID_EMAIL) 던지도록 처리

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
