### PR TITLE
fix : Security-oauth Oauth로그인을 위해 SecurityConfig 수정

### DIFF
--- a/src/main/java/com/example/runningservice/security/SecurityConfig.java
+++ b/src/main/java/com/example/runningservice/security/SecurityConfig.java
@@ -4,9 +4,9 @@ import com.example.runningservice.service.LogoutService;
 import com.example.runningservice.util.JwtUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
-import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -15,6 +15,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -47,21 +48,19 @@ public class SecurityConfig {
         http.authorizeHttpRequests(
                 request -> request.requestMatchers(
                         "/",
-                        "/login/**",
-                        "/oauth/login",
                         "/user/signup/**",
                         "/api.mailgun.net/v3/**",
+                        "/login/**",
+                        "/oauth/login",
+                        "/oauth/token",
                         "/h2-console/**",
-                        "/css/**",
-                        "/ws/**",
-                        "/images/**",
-                        "/js/**",
                         "/region",
-                        "/posts/**",
                         "/crew",
                         "/comments/**",
-                        "/token/refresh/**")
-                    .permitAll().requestMatchers(
+                        "/token/refresh/**",
+                        "/posts/**")
+                    .permitAll()
+                    .requestMatchers(
                         HttpMethod.GET, "/crew/*")
                     .permitAll().requestMatchers(
                         HttpMethod.GET, "**/regular/**")
@@ -112,6 +111,12 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring()
+            .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
     }
 
     @Bean


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- oauth 로그인을 위한 securityConfig 파일 수정

### 이 PR에서 변경된 사항
- "/oauth/token"  permitAll() 처리
- 정적 페이지는 Security 필터링 생략
### 참고 스크린샷

### 기타
- Mixed-Content 에러는 application.yml에서 해결
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
