### PR TITLE
fix : signup-oauth : 추가 필수정보 불러오기, 저장하기, 토큰발행

### DIFF
--- a/src/main/java/com/example/runningservice/controller/AuthController.java
+++ b/src/main/java/com/example/runningservice/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.example.runningservice.controller;
 
-import com.example.runningservice.dto.JwtResponse;
-import com.example.runningservice.dto.LoginRequestDto;
+import com.example.runningservice.dto.auth.JwtResponse;
+import com.example.runningservice.dto.auth.LoginRequestDto;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.service.AuthService;

--- a/src/main/java/com/example/runningservice/controller/OAuthController.java
+++ b/src/main/java/com/example/runningservice/controller/OAuthController.java
@@ -1,14 +1,20 @@
 package com.example.runningservice.controller;
 
-import com.example.runningservice.dto.JwtResponse;
+import com.example.runningservice.dto.auth.AdditionalInfoRequestDto;
+import com.example.runningservice.dto.auth.JwtResponse;
+import com.example.runningservice.dto.auth.Oauth2DataDto;
 import com.example.runningservice.dto.googleToken.GoogleAccountProfileResponseDto;
 import com.example.runningservice.service.OAuth2Service;
 import com.example.runningservice.service.Oauth2ProcessService;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,17 +26,42 @@ public class OAuthController {
     private final Oauth2ProcessService oauth2ProcessService;
 
     @GetMapping("login/oauth")
-    public ResponseEntity<JwtResponse> googleAccountProfileRes(@RequestParam String code,
-        HttpServletResponse response) {
+    public ResponseEntity<String> googleAccountProfileRes(
+        @RequestParam String code, HttpServletResponse response) throws IOException {
 
-        GoogleAccountProfileResponseDto googleAccountProfileResponseDto = oAuth2Service.getGoogleAccountProfile(
+        GoogleAccountProfileResponseDto googleAccountProfile = oAuth2Service.getGoogleAccountProfile(
             code);
+
         JwtResponse jwtResponse = oauth2ProcessService.processOauth2Info(
-            googleAccountProfileResponseDto);
+            googleAccountProfile, response);
+
+        if (response.isCommitted()) {
+            // 리디렉트가 발생했으면 메서드를 종료함
+            return null;
+        }
 
         setResponseHeader(response, jwtResponse);
 
-        return ResponseEntity.ok(jwtResponse);
+        return ResponseEntity.ok(jwtResponse.getAccessJwt());
+    }
+
+    //필수정보 확인
+    @GetMapping("/user/signup/saved-info")
+    public ResponseEntity<Oauth2DataDto> showAdditionalInfoForm(
+        @RequestParam String email) {
+        return ResponseEntity.ok(oauth2ProcessService.getOauthData(email));
+    }
+
+    //채워지지 않은 필수정보 입력
+    @PostMapping("/user/signup/additional-info")
+    public ResponseEntity<String> completeOauth(
+        @ModelAttribute @Valid AdditionalInfoRequestDto form, HttpServletResponse response) {
+
+        JwtResponse jwtResponse = oauth2ProcessService.completeSignup(form);
+
+        setResponseHeader(response, jwtResponse);
+
+        return ResponseEntity.ok(jwtResponse.getAccessJwt());
     }
 
     private void setResponseHeader(HttpServletResponse response, JwtResponse jwtResponse) {
@@ -38,15 +69,13 @@ public class OAuthController {
             createRefreshTokenCookie(jwtResponse.getRefreshJwt()).toString());
     }
 
-
     private ResponseCookie createRefreshTokenCookie(String refreshToken) {
         return ResponseCookie.from("refreshToken", refreshToken)
             .maxAge(7 * 24 * 60 * 60) // 7알
             .path("/")
-            .secure(true)
+            .secure(false)
             .sameSite("None")
             .httpOnly(true)
             .build();
     }
-
 }

--- a/src/main/java/com/example/runningservice/controller/SignupController.java
+++ b/src/main/java/com/example/runningservice/controller/SignupController.java
@@ -1,11 +1,7 @@
 package com.example.runningservice.controller;
 
-import com.example.runningservice.dto.Oauth2DataDto;
-import com.example.runningservice.dto.SignupRequestDto;
+import com.example.runningservice.dto.auth.SignupRequestDto;
 import com.example.runningservice.dto.member.MemberResponseDto;
-import com.example.runningservice.entity.MemberEntity;
-import com.example.runningservice.exception.CustomException;
-import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.MemberRepository;
 import com.example.runningservice.service.SignupService;
 import jakarta.validation.Valid;
@@ -50,31 +46,5 @@ public class SignupController {
 
         signupService.verifyNickName(nickname);
         return ResponseEntity.ok().build();
-    }
-
-    //필수정보 확인
-    //채워지지 않은 필수정보 입력하도록 함
-    @GetMapping("/additional-info")
-    public ResponseEntity<Oauth2DataDto> showAdditionalInfoForm(
-        @RequestParam("email") String email) {
-        // 이메일을 통해 기존 회원 정보를 가져옴
-        MemberEntity memberEntity = memberRepository.findByEmail(email)
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
-
-        // DTO 초기화 및 기본 값 설정
-        Oauth2DataDto form = Oauth2DataDto.builder()
-            .email(email)
-            .name(memberEntity.getName())
-            .image(memberEntity.getProfileImageUrl())
-            .build();
-
-        return ResponseEntity.ok(form);
-    }
-
-    @PostMapping("/additional-info")
-    public ResponseEntity<MemberResponseDto> processAdditionalInfo(
-        @ModelAttribute @Valid SignupRequestDto form) {
-
-        return ResponseEntity.ok(signupService.saveAdditionalInfo(form));
     }
 }

--- a/src/main/java/com/example/runningservice/dto/auth/AdditionalInfoRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/auth/AdditionalInfoRequestDto.java
@@ -1,0 +1,60 @@
+package com.example.runningservice.dto.auth;
+
+import com.example.runningservice.enums.Gender;
+import com.example.runningservice.enums.Region;
+import com.example.runningservice.enums.Visibility;
+import com.example.runningservice.util.validator.ValidYear;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class AdditionalInfoRequestDto {
+    //이메일 형식
+    @NotBlank
+    @Email
+    @Size(max = 50)
+    private String email;
+
+    //숫자만 포함
+    @NotBlank
+    @Pattern(regexp = "^01[016789]\\d{7,8}$", message = "휴대전화번호 형식이 올바르지 않습니다.")
+    private String phoneNumber;
+
+    @NotBlank(message = "이름을 입력해주세요.")
+    @Size(min = 2, max = 12)
+    private String name;
+
+    //2~12자
+    @NotBlank
+    @Size(min = 2, max = 12)
+    private String nickName;
+
+    @NotNull
+    private Gender gender;
+
+    @NotNull
+    @ValidYear
+    private Integer birthYear;
+    private Region activityRegion;
+    private MultipartFile profileImage;
+
+    @NotNull
+    private Visibility nameVisibility = Visibility.PRIVATE;
+    @NotNull
+    private Visibility phoneNumberVisibility = Visibility.PRIVATE;
+    @NotNull
+    private Visibility genderVisibility = Visibility.PRIVATE;
+    @NotNull
+    private Visibility birthYearVisibility = Visibility.PRIVATE;
+}

--- a/src/main/java/com/example/runningservice/dto/auth/JwtResponse.java
+++ b/src/main/java/com/example/runningservice/dto/auth/JwtResponse.java
@@ -1,4 +1,4 @@
-package com.example.runningservice.dto;
+package com.example.runningservice.dto.auth;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/runningservice/dto/auth/LoginRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/auth/LoginRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.runningservice.dto;
+package com.example.runningservice.dto.auth;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/example/runningservice/dto/auth/Oauth2DataDto.java
+++ b/src/main/java/com/example/runningservice/dto/auth/Oauth2DataDto.java
@@ -1,8 +1,10 @@
-package com.example.runningservice.dto;
+package com.example.runningservice.dto.auth;
 
 import lombok.Builder;
+import lombok.Getter;
 
 @Builder
+@Getter
 public class Oauth2DataDto {
     String email;
     String name;

--- a/src/main/java/com/example/runningservice/dto/auth/SignupRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/auth/SignupRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.runningservice.dto;
+package com.example.runningservice.dto.auth;
 
 import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.enums.Gender;

--- a/src/main/java/com/example/runningservice/entity/MemberEntity.java
+++ b/src/main/java/com/example/runningservice/entity/MemberEntity.java
@@ -1,6 +1,6 @@
 package com.example.runningservice.entity;
 
-import com.example.runningservice.dto.SignupRequestDto;
+import com.example.runningservice.dto.auth.AdditionalInfoRequestDto;
 import com.example.runningservice.dto.member.UpdateMemberRequestDto;
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Notification;
@@ -49,15 +49,13 @@ public class MemberEntity extends BaseEntity {
     private String verificationCode;
     private boolean emailVerified;
     private LocalDateTime verifiedAt;
-    @Column(nullable = false)
     private String password;
-    @Column(nullable = false)
+    @Column(unique = true)
     private String phoneNumber;
-    @Column(nullable = false, unique = true)
+    @Column(unique = true)
     private String phoneNumberHash;
-    @Column(nullable = false)
     private String name;
-    @Column(nullable = false)
+    @Column(unique = true)
     private String nickName;
     private Integer birthYear;
     //성별값을 코드로 변환
@@ -131,7 +129,7 @@ public class MemberEntity extends BaseEntity {
         this.birthYearVisibility = form.getBirthYearVisibility();
     }
 
-    public void updateAdditionalInfo(SignupRequestDto form, AESUtil aesUtil) {
+    public void updateAdditionalInfo(AdditionalInfoRequestDto form, AESUtil aesUtil) {
         this.name = form.getName();
         this.phoneNumber = form.getPhoneNumber();
         this.phoneNumberHash = aesUtil.generateHash(form.getPhoneNumber());

--- a/src/main/java/com/example/runningservice/service/AuthService.java
+++ b/src/main/java/com/example/runningservice/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.example.runningservice.service;
 
-import com.example.runningservice.dto.JwtResponse;
-import com.example.runningservice.dto.LoginRequestDto;
+import com.example.runningservice.dto.auth.JwtResponse;
+import com.example.runningservice.dto.auth.LoginRequestDto;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.security.CustomUserDetails;

--- a/src/main/java/com/example/runningservice/service/Oauth2ProcessService.java
+++ b/src/main/java/com/example/runningservice/service/Oauth2ProcessService.java
@@ -1,17 +1,25 @@
 package com.example.runningservice.service;
 
-import com.example.runningservice.dto.JwtResponse;
+import com.example.runningservice.dto.auth.AdditionalInfoRequestDto;
+import com.example.runningservice.dto.auth.JwtResponse;
+import com.example.runningservice.dto.auth.Oauth2DataDto;
 import com.example.runningservice.dto.googleToken.GoogleAccountProfileResponseDto;
 import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.enums.Role;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.MemberRepository;
+import com.example.runningservice.util.AESUtil;
 import com.example.runningservice.util.JwtUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
@@ -19,14 +27,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class Oauth2ProcessService {
 
     private final MemberRepository memberRepository;
     private final JwtUtil jwtUtil;
+    private final AESUtil aesUtil;
 
     @Transactional
-    public JwtResponse processOauth2Info(GoogleAccountProfileResponseDto googleProfile) {
-
+    public JwtResponse processOauth2Info(GoogleAccountProfileResponseDto googleProfile,
+        HttpServletResponse response) throws IOException {
         String email = googleProfile.getEmail();
         String name = googleProfile.getName();
         String profileImage = googleProfile.getPicture();
@@ -39,11 +49,46 @@ public class Oauth2ProcessService {
                     .profileImageUrl(profileImage)
                     .roles(new ArrayList<>(List.of(Role.ROLE_USER)))
                     .build())));
+            if (!isInfoComplete(memberEntity)) {
 
-        if (!isInfoComplete(memberEntity)) {
-            throw new CustomException(ErrorCode.MISSING_REQUIRED_INFORMATION);
-        }
+            log.info("소셜 계정 회원가입 요청 후 필수정보가 누락된 상태로 저장되었습니다");
 
+            String redirectUrl = String.format("/user/signup/saved-info?email=%s",
+                URLEncoder.encode(memberEntity.getEmail(), StandardCharsets.UTF_8));
+            response.sendRedirect(redirectUrl);
+            response.sendRedirect("/user/signup/saved-info");
+            return null;
+            }
+        //필수정보가 다 채워져있으면 토큰 발행
+        return getJwtResponse(memberEntity);
+    }
+
+    @Transactional
+    public Oauth2DataDto getOauthData(String email) {
+        // 이메일을 통해 기존 회원 정보를 가져옴
+        MemberEntity memberEntity = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        // DTO 초기화 및 기본 값 설정
+        return Oauth2DataDto.builder()
+            .email(email)
+            .name(memberEntity.getName())
+            .image(memberEntity.getProfileImageUrl())
+            .build();
+    }
+
+    @Transactional
+    public JwtResponse completeSignup(AdditionalInfoRequestDto form) {
+        // 기존 회원 정보 업데이트
+        MemberEntity memberEntity = memberRepository.findByEmail(form.getEmail())
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        memberEntity.updateAdditionalInfo(form, aesUtil);
+
+        return getJwtResponse(memberEntity);
+    }
+
+    private JwtResponse getJwtResponse(MemberEntity memberEntity) {
         List<GrantedAuthority> authorities = memberEntity.getRoles().stream()
             .map(role -> new SimpleGrantedAuthority(role.name())).collect(
                 Collectors.toList());
@@ -52,12 +97,11 @@ public class Oauth2ProcessService {
             authorities);
         String refreshToken = jwtUtil.generateRefreshToken(memberEntity.getEmail(),
             memberEntity.getId(), authorities);
-        JwtResponse jwtResponse = JwtResponse.builder()
+
+        return JwtResponse.builder()
             .accessJwt(accessToken)
             .refreshJwt(refreshToken)
             .build();
-
-        return jwtResponse;
     }
 
     private boolean isInfoComplete(MemberEntity member) {

--- a/src/main/java/com/example/runningservice/service/SignupService.java
+++ b/src/main/java/com/example/runningservice/service/SignupService.java
@@ -2,7 +2,7 @@ package com.example.runningservice.service;
 
 import com.example.runningservice.client.MailgunClient;
 import com.example.runningservice.dto.member.MemberResponseDto;
-import com.example.runningservice.dto.SignupRequestDto;
+import com.example.runningservice.dto.auth.SignupRequestDto;
 import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
@@ -124,16 +124,5 @@ public class SignupService {
         if (memberRepository.existsByNickName(nickname)) {
             throw new CustomException(ErrorCode.ALREADY_EXIST_NICKNAME);
         }
-    }
-
-    @Transactional
-    public MemberResponseDto saveAdditionalInfo(SignupRequestDto form) {
-        // 기존 회원 정보 업데이트
-        MemberEntity memberEntity = memberRepository.findByEmail(form.getEmail())
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
-
-        memberEntity.updateAdditionalInfo(form, aesUtil);
-
-        return MemberResponseDto.of(memberRepository.save(memberEntity), aesUtil, s3FileUtil);
     }
 }

--- a/src/main/java/com/example/runningservice/util/validator/PasswordMatchesValidator.java
+++ b/src/main/java/com/example/runningservice/util/validator/PasswordMatchesValidator.java
@@ -1,6 +1,6 @@
 package com.example.runningservice.util.validator;
 
-import com.example.runningservice.dto.SignupRequestDto;
+import com.example.runningservice.dto.auth.SignupRequestDto;
 import com.example.runningservice.dto.member.PasswordRequestDto;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;

--- a/src/test/java/com/example/runningservice/dto/SignupRequestDtoTest.java
+++ b/src/test/java/com/example/runningservice/dto/SignupRequestDtoTest.java
@@ -3,6 +3,7 @@ package com.example.runningservice.dto;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.example.runningservice.dto.auth.SignupRequestDto;
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Region;
 import com.example.runningservice.enums.Visibility;

--- a/src/test/java/com/example/runningservice/service/AuthServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/AuthServiceTest.java
@@ -9,8 +9,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.example.runningservice.dto.JwtResponse;
-import com.example.runningservice.dto.LoginRequestDto;
+import com.example.runningservice.dto.auth.JwtResponse;
+import com.example.runningservice.dto.auth.LoginRequestDto;
 import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.enums.Role;
 import com.example.runningservice.exception.CustomException;

--- a/src/test/java/com/example/runningservice/service/SignupServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/SignupServiceTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.example.runningservice.client.MailgunClient;
-import com.example.runningservice.dto.SignupRequestDto;
+import com.example.runningservice.dto.auth.SignupRequestDto;
 import com.example.runningservice.dto.member.MemberResponseDto;
 import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.enums.Gender;


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 소셜 계정으로 로그인 했을 때 필요한 필수정보 추가로 받는 로직 구현/수정

### 이 PR에서 변경된 사항
- OAuthController : api 수정
- Oauth2ProcessService : 구글에서 받아온 정보로 일부 데이터 저장 후 조회되도록 redirect 설정
- AdditionalInfoRequestDto: 추가정보 다는 dto 추가

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
