### PR TITLE
Fix get image 001 : 이미지 조회 관련 기능 수정

### DIFF
--- a/src/main/java/com/example/runningservice/controller/ActivityController.java
+++ b/src/main/java/com/example/runningservice/controller/ActivityController.java
@@ -76,7 +76,7 @@ public class ActivityController {
     public ResponseEntity<ActivityResponseDto> getActivity(@LoginUser Long userId,
         @PathVariable("crewId") Long crewId, @PathVariable("activityId") Long activityId) {
 
-        return ResponseEntity.ok(activityService.getActivity(activityId));
+        return ResponseEntity.ok(activityService.getActivity(activityId, userId));
     }
 
     /**
@@ -90,7 +90,7 @@ public class ActivityController {
         @RequestParam(value = "endDate", required = false) LocalDate endDate,
         @RequestParam(value = "category", required = false) ActivityCategory category) {
 
-        return ResponseEntity.ok(activityService.getCrewActivityByDate(crewId,
+        return ResponseEntity.ok(activityService.getCrewActivityByDate(crewId, userId,
             ActivityFilterDto.builder()
                 .startDate(startDate)
                 .endDate(endDate)
@@ -106,6 +106,6 @@ public class ActivityController {
         @PathVariable("crewId") Long crewId, Pageable pageable,
         @RequestParam(value = "category", required = false) ActivityCategory category) {
 
-        return ResponseEntity.ok(activityService.getCrewActivity(crewId, category, pageable));
+        return ResponseEntity.ok(activityService.getCrewActivity(crewId, userId, category, pageable));
     }
 }

--- a/src/main/java/com/example/runningservice/controller/CrewMemberController.java
+++ b/src/main/java/com/example/runningservice/controller/CrewMemberController.java
@@ -11,6 +11,7 @@ import com.example.runningservice.dto.crewMember.CrewMemberResponseDto;
 import com.example.runningservice.service.CrewMemberService;
 import com.example.runningservice.util.AESUtil;
 import com.example.runningservice.util.LoginUser;
+import com.example.runningservice.util.S3FileUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -35,6 +36,7 @@ public class CrewMemberController {
 
     private final CrewMemberService crewMemberService;
     private final AESUtil aesUtil;
+    private final S3FileUtil s3FileUtil;
 
     /**
      * 크루원 리스트 조회
@@ -48,7 +50,7 @@ public class CrewMemberController {
         @PageableDefault(page = 0, size = 10, sort = "joinedAt", direction = Direction.ASC) Pageable pageable) {
 
         Page<CrewMemberResponseDto> pageDto = crewMemberService.getCrewMembers(crewId, filterDto,
-            pageable).map(CrewMemberResponseDto::of);
+            pageable).map(entity -> CrewMemberResponseDto.of(entity, s3FileUtil));
 
         return ResponseEntity.ok(pageDto);
     }

--- a/src/main/java/com/example/runningservice/dto/activity/ActivityResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/activity/ActivityResponseDto.java
@@ -30,8 +30,9 @@ public class ActivityResponseDto {
     private String memo;
     private String location;
     private int participant;
+    private boolean isAuthor;
 
-    public static ActivityResponseDto fromEntity(ActivityEntity activityEntity) {
+    public static ActivityResponseDto fromEntity(ActivityEntity activityEntity, Long loginId) {
         return ActivityResponseDto.builder()
             .activityId(activityEntity.getId())
             .author(activityEntity.getAuthor().getNickName())
@@ -47,6 +48,11 @@ public class ActivityResponseDto {
             .participant(
                 (activityEntity.getParticipant() != null) ?
                     activityEntity.getParticipant().size() : 0)
+            .isAuthor(activityEntity.getAuthor().getId().equals(loginId))
             .build();
+    }
+
+    public boolean getIsAuthor() {
+        return isAuthor;
     }
 }

--- a/src/main/java/com/example/runningservice/dto/crew/CrewBaseResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/crew/CrewBaseResponseDto.java
@@ -2,6 +2,7 @@ package com.example.runningservice.dto.crew;
 
 import com.example.runningservice.entity.CrewEntity;
 import com.example.runningservice.enums.Region;
+import com.example.runningservice.util.S3FileUtil;
 import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
@@ -23,12 +24,12 @@ public class CrewBaseResponseDto {
     private Integer crewOccupancy;
     private String activityRegion;
 
-    public static CrewBaseResponseDto fromEntity(CrewEntity crewEntity) {
+    public static CrewBaseResponseDto fromEntity(CrewEntity crewEntity, S3FileUtil s3FileUtil) {
         return CrewBaseResponseDto.builder()
             .crewId(crewEntity.getId())
             .leader(crewEntity.getLeader().getNickName())
             .crewName(crewEntity.getCrewName())
-            .crewImage(crewEntity.getCrewImage())
+            .crewImage(s3FileUtil.createPresignedUrl(crewEntity.getCrewImage()))
             .crewCapacity(crewEntity.getCrewCapacity())
             .crewOccupancy(Optional.ofNullable(crewEntity.getCrewMember())
                 .map(List::size)

--- a/src/main/java/com/example/runningservice/dto/crew/CrewCreateRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/crew/CrewCreateRequestDto.java
@@ -26,6 +26,7 @@ public class CrewCreateRequestDto {
     private final String description;
     @Min(value = 1, message = "크루 정원은 1 이상 입력해야 합니다.")
     private final Integer crewCapacity;
+    @NotNull(message = "활동 지역은 필수 선택입니다.")
     private final Region activityRegion;
     private final MultipartFile crewImage;
     @NotNull(message = "러닝 공개 여부는 필수 선택입니다.")

--- a/src/main/java/com/example/runningservice/dto/crewMember/CrewMemberResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/crewMember/CrewMemberResponseDto.java
@@ -2,6 +2,7 @@ package com.example.runningservice.dto.crewMember;
 
 import com.example.runningservice.entity.CrewMemberEntity;
 import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.util.S3FileUtil;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
@@ -12,11 +13,11 @@ public class CrewMemberResponseDto {
     private String memberNickName;
     private String memberProfileImage;
 
-    public static CrewMemberResponseDto of(CrewMemberEntity crewMemberEntity) {
+    public static CrewMemberResponseDto of(CrewMemberEntity crewMemberEntity, S3FileUtil s3FileUtil) {
         MemberEntity member = crewMemberEntity.getMember();
         return CrewMemberResponseDto.builder()
             .memberNickName(member.getNickName())
-            .memberProfileImage(member.getProfileImageUrl())
+            .memberProfileImage(s3FileUtil.createPresignedUrl(member.getProfileImageUrl()))
             .build();
     }
 }

--- a/src/main/java/com/example/runningservice/dto/member/UpdateMemberRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/member/UpdateMemberRequestDto.java
@@ -8,6 +8,7 @@ import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/example/runningservice/service/ActivityService.java
+++ b/src/main/java/com/example/runningservice/service/ActivityService.java
@@ -67,7 +67,7 @@ public class ActivityService {
                 .relatedId(activityEntity.getId())
                 .build());*/
 
-        return ActivityResponseDto.fromEntity(activityEntity);
+        return ActivityResponseDto.fromEntity(activityEntity, userId);
     }
 
     // 번개 러닝 일정 생성
@@ -93,7 +93,7 @@ public class ActivityService {
                 .relatedId(activityEntity.getId())
                 .build());*/
 
-        return ActivityResponseDto.fromEntity(activityEntity);
+        return ActivityResponseDto.fromEntity(activityEntity, userId);
     }
 
     // 리더 또는 스탭 권한이 없는지 확인한다.
@@ -124,7 +124,7 @@ public class ActivityService {
 
         activityEntity.update(activityDto);
 
-        return ActivityResponseDto.fromEntity(activityEntity);
+        return ActivityResponseDto.fromEntity(activityEntity, userId);
     }
 
     private boolean isRegularRun(ActivityEntity activityEntity) {
@@ -145,7 +145,7 @@ public class ActivityService {
             }
         }
 
-        ActivityResponseDto response = ActivityResponseDto.fromEntity(activityEntity);
+        ActivityResponseDto response = ActivityResponseDto.fromEntity(activityEntity, userId);
 
         activityRepository.delete(activityEntity);
 
@@ -155,17 +155,17 @@ public class ActivityService {
     /**
      * 특정 (정기/번개)러닝 일정 조회
      */
-    public ActivityResponseDto getActivity(Long activityId) {
+    public ActivityResponseDto getActivity(Long activityId, Long userId) {
         ActivityEntity activityEntity = activityRepository.findById(activityId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ACTIVITY));
 
-        return ActivityResponseDto.fromEntity(activityEntity);
+        return ActivityResponseDto.fromEntity(activityEntity, userId);
     }
 
     /**
      * 날짜별 크루 (정기/번개)러닝 일정 조회
      */
-    public Page<ActivityResponseDto> getCrewActivityByDate(Long crewId,
+    public Page<ActivityResponseDto> getCrewActivityByDate(Long crewId, Long userId,
         ActivityFilterDto activityFilter, Pageable pageable) {
         if (!validateDate(activityFilter.getStartDate(), activityFilter.getEndDate())) {
             throw new CustomException(ErrorCode.INVALID_DATE_RANGE);
@@ -175,19 +175,19 @@ public class ActivityService {
             crewId, activityFilter.getCategory(), activityFilter.getStartDate(),
             activityFilter.getEndDate(), pageable);
 
-        return activityPage.map(ActivityResponseDto::fromEntity);
+        return activityPage.map(entity -> ActivityResponseDto.fromEntity(entity, userId));
     }
 
     /**
      * 다가오는 크루 (정기/번개)러닝 일정 조회
      */
-    public Page<ActivityResponseDto> getCrewActivity(Long crewId, ActivityCategory category,
-        Pageable pageable) {
+    public Page<ActivityResponseDto> getCrewActivity(Long crewId, Long userId,
+        ActivityCategory category, Pageable pageable) {
         Page<ActivityEntity> activityPage = activityRepository
             .findByCrew_IdAndCategoryAndDateGreaterThanEqualOrderByDate(
                 crewId, category, pageable);
 
-        return activityPage.map(ActivityResponseDto::fromEntity);
+        return activityPage.map(entity -> ActivityResponseDto.fromEntity(entity, userId));
     }
 
     // 시작 날짜가 종료 날짜보다 빠르거나 같은지 체크한다.

--- a/src/main/java/com/example/runningservice/service/CrewApplicantService.java
+++ b/src/main/java/com/example/runningservice/service/CrewApplicantService.java
@@ -14,6 +14,7 @@ import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.JoinApplicationRepository;
 import com.example.runningservice.repository.crewMember.CrewMemberRepository;
 import com.example.runningservice.util.PageUtil;
+import com.example.runningservice.util.S3FileUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +28,7 @@ public class CrewApplicantService {
 
     private final CrewMemberRepository crewMemberRepository;
     private final JoinApplicationRepository joinApplicationRepository;
+    private final S3FileUtil s3FileUtil;
 
     @Transactional
     public Page<CrewApplicantResponseDto> getAllJoinApplications(Long crewId,
@@ -73,7 +75,7 @@ public class CrewApplicantService {
         CrewMemberEntity newMember = CrewMemberEntity.of(memberEntity, crewEntity);
         //DTO 변환
         CrewMemberEntity savedCrewMember = crewMemberRepository.save(newMember);
-        return CrewMemberResponseDto.of(savedCrewMember);
+        return CrewMemberResponseDto.of(savedCrewMember, s3FileUtil);
     }
 
 

--- a/src/main/java/com/example/runningservice/service/CrewService.java
+++ b/src/main/java/com/example/runningservice/service/CrewService.java
@@ -77,7 +77,7 @@ public class CrewService {
         chatRoomService.createChatRoom(crewEntity.getId(),
             crewEntity.getCrewName(), ChatRoom.CREW_STAFF);
 
-        return CrewBaseResponseDto.fromEntity(crewEntity);
+        return CrewBaseResponseDto.fromEntity(crewEntity, s3FileUtil);
     }
 
     /**
@@ -107,7 +107,7 @@ public class CrewService {
         crewEntity.updateCrewImageUrl(uploadFileAndReturnFileName(crewEntity.getId(),
             updateCrew.getCrewImage()));
 
-        return CrewBaseResponseDto.fromEntity(crewEntity);
+        return CrewBaseResponseDto.fromEntity(crewEntity, s3FileUtil);
     }
 
     /**
@@ -119,7 +119,7 @@ public class CrewService {
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW));
 
         // 삭제하기 전에 리턴하기 위한 데이터를 미리 저장해둔다.
-        CrewBaseResponseDto crewData = CrewBaseResponseDto.fromEntity(crewEntity);
+        CrewBaseResponseDto crewData = CrewBaseResponseDto.fromEntity(crewEntity, s3FileUtil);
 
         // 이미지가 디폴트가 아닌 경우에만 삭제
         String fileName = findLastPath(crewEntity.getCrewImage());

--- a/src/main/java/com/example/runningservice/service/SignupService.java
+++ b/src/main/java/com/example/runningservice/service/SignupService.java
@@ -33,13 +33,14 @@ public class SignupService {
 
         // 사용자 엔티티 생성 및 저장(비밀번호와 전화번호는 암호화)
         MemberEntity memberEntity = registerForm.toEntity(passwordEncoder, aesUtil);
+        memberRepository.save(memberEntity);
 
         //imageUrl을 엔티티에 저장
         String imageUrl = uploadFileAndReturnFileName(memberEntity.getId(),
             registerForm.getProfileImage());
         memberEntity.updateProfileImageUrl(imageUrl);
 
-        return MemberResponseDto.of(memberRepository.save(memberEntity), aesUtil, s3FileUtil);
+        return MemberResponseDto.of(memberEntity, aesUtil, s3FileUtil);
     }
 
     @Transactional

--- a/src/test/java/com/example/runningservice/service/ActivityServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/ActivityServiceTest.java
@@ -131,7 +131,7 @@ class ActivityServiceTest {
         ActivityRequestDto.Create activityDto = mock(ActivityRequestDto.Create.class);
         when(activityDto.getCategory()).thenReturn(ActivityCategory.ON_DEMAND);
 
-        MemberEntity memberEntity = MemberEntity.builder().build();
+        MemberEntity memberEntity = MemberEntity.builder().id(userId).build();
 
         given(crewRepository.findById(crewId)).willReturn(Optional.of(mock(CrewEntity.class)));
         given(memberRepository.findById(userId)).willReturn(Optional.of(memberEntity));
@@ -292,9 +292,10 @@ class ActivityServiceTest {
     void getActivity() {
         // given
         Long activityId = 1L;
+        Long userId = 11L;
         List<ParticipantEntity> participants = List.of(
             mock(ParticipantEntity.class), mock(ParticipantEntity.class));
-        MemberEntity memberEntity = MemberEntity.builder().nickName("nick").build();
+        MemberEntity memberEntity = MemberEntity.builder().id(userId).nickName("nick").build();
         ActivityEntity activityEntity = ActivityEntity.builder()
             .participant(participants)
             .author(memberEntity)
@@ -304,7 +305,7 @@ class ActivityServiceTest {
         given(activityRepository.findById(activityId)).willReturn(Optional.of(activityEntity));
 
         // when
-        ActivityResponseDto response = activityService.getActivity(activityId);
+        ActivityResponseDto response = activityService.getActivity(activityId, userId);
 
         // then
         assertEquals(response.getParticipant(), participants.size());
@@ -316,6 +317,7 @@ class ActivityServiceTest {
     void getCrewActivity_FailedValidateDate() {
         // given
         Long crewId = 1L;
+        Long userId = 11L;
         ActivityFilterDto wrongDate = ActivityFilterDto.builder()
             .startDate(LocalDate.now().plusDays(1))
             .endDate(LocalDate.now().minusDays(1))
@@ -323,7 +325,7 @@ class ActivityServiceTest {
 
         // when
         CustomException customException = assertThrows(CustomException.class,
-            () -> activityService.getCrewActivityByDate(crewId, wrongDate, Pageable.ofSize(1)));
+            () -> activityService.getCrewActivityByDate(crewId, userId, wrongDate, Pageable.ofSize(1)));
 
         // then
         assertEquals(customException.getErrorCode(), ErrorCode.INVALID_DATE_RANGE);
@@ -334,12 +336,13 @@ class ActivityServiceTest {
     void getCrewActivity_SuccessValidateDate() {
         // given
         Long crewId = 1L;
+        Long userId = 11L;
         ActivityFilterDto equalDate = ActivityFilterDto.builder()
             .startDate(LocalDate.now())
             .endDate(LocalDate.now())
             .category(ActivityCategory.ON_DEMAND)
             .build();
-        MemberEntity memberEntity = MemberEntity.builder().nickName("nick").build();
+        MemberEntity memberEntity = MemberEntity.builder().id(userId).nickName("nick").build();
         Pageable pageable = mock(Pageable.class);
         Page<ActivityEntity> activityList = new PageImpl<>(
             List.of(ActivityEntity.builder().author(memberEntity).build(),
@@ -350,7 +353,7 @@ class ActivityServiceTest {
             .willReturn(activityList);
 
         // when
-        Page<ActivityResponseDto> response = activityService.getCrewActivityByDate(crewId,
+        Page<ActivityResponseDto> response = activityService.getCrewActivityByDate(crewId, userId,
             equalDate, pageable);
 
         // then

--- a/src/test/java/com/example/runningservice/service/CrewApplicantServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/CrewApplicantServiceTest.java
@@ -21,6 +21,7 @@ import com.example.runningservice.repository.JoinApplicationRepository;
 import com.example.runningservice.repository.crewMember.CrewMemberRepository;
 import com.example.runningservice.util.AESUtil;
 import com.example.runningservice.util.PageUtil;
+import com.example.runningservice.util.S3FileUtil;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +47,9 @@ class CrewApplicantServiceTest {
 
     @Mock
     private AESUtil aesUtil;
+
+    @Mock
+    private S3FileUtil s3FileUtil;
 
     @InjectMocks
     private CrewApplicantService crewApplicantService;
@@ -126,6 +130,7 @@ class CrewApplicantServiceTest {
     void approveJoinApplication_Success() {
         // given
         Long joinApplyId = 1L;
+        String signedUrl = "signedUrl";
 
         MemberEntity memberEntity = MemberEntity.builder()
             .nickName("testNick")
@@ -157,13 +162,15 @@ class CrewApplicantServiceTest {
         when(crewMemberRepository.save(any(CrewMemberEntity.class)))
             .thenReturn(newCrewMember);
 
+        when(s3FileUtil.createPresignedUrl(memberEntity.getProfileImageUrl())).thenReturn(signedUrl);
+
         // when
         CrewMemberResponseDto result = crewApplicantService.approveJoinApplication(joinApplyId);
 
         // then
         assertNotNull(result);
         assertEquals(memberEntity.getNickName(), result.getMemberNickName());
-        assertEquals(memberEntity.getProfileImageUrl(), result.getMemberProfileImage());
+        assertEquals(signedUrl, result.getMemberProfileImage());
     }
 
     @Test


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 크루원 조회에서 이미지가 보이지 않는 문제 해결
- 회원 가입 시 user-null 이미지가 저장되는 문제 해결

### 이 PR에서 변경된 사항
- CrewBase, Applicant, CrewMember에 서명된 이미지를 리턴하도록 dto 수정
- 회원가입 시 이미지 이름을 지정하기 전에 entity가 먼저 저장되어 id 값이 생성되도록 함

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
