### PR TITLE
Fix: run record 006 - RunRecord resDto 내 컬럼 제거, Entity에 @DateTimeFormat 추가

### DIFF
--- a/src/main/java/com/example/runningservice/controller/RunRecordController.java
+++ b/src/main/java/com/example/runningservice/controller/RunRecordController.java
@@ -55,7 +55,7 @@ public class RunRecordController {
     /**
      * 러닝 기록 생성
       */
-    @PostMapping("/")
+    @PostMapping("")
     public ResponseEntity<RunRecordResponseDto> createRunRecord(@LoginUser Long userId, @RequestBody RunRecordRequestDto runRecord) {
         RunRecordResponseDto createdRecord = runRecordService.createRunRecord(userId, runRecord);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdRecord); // 201 Created 반환

--- a/src/main/java/com/example/runningservice/dto/runRecord/RunRecordResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/runRecord/RunRecordResponseDto.java
@@ -9,14 +9,10 @@ import lombok.Getter;
 public class RunRecordResponseDto {
     private Long id;
     private Long userId;
-    private Integer totalDistance;
-    private Integer totalRunningTime;
-    private String averagePace;
     private Double distance;
     private Integer runningTime;
     private Integer pace;
     private Integer isPublic;
-    private Integer runCount;
     private LocalDateTime runningDate;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/example/runningservice/entity/RunRecordEntity.java
+++ b/src/main/java/com/example/runningservice/entity/RunRecordEntity.java
@@ -16,6 +16,7 @@ import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Getter
 @Builder
@@ -41,7 +42,7 @@ public class RunRecordEntity {
     private Integer pace;
 
     private Integer runningTime;
-
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime runningDate;
     @CreatedDate
     private LocalDateTime createdAt;


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- RunRecord resDto 내 컬럼 제거, Entity에 @DateTimeFormat 추가
### 이 PR에서 변경된 사항
- RunRecord resDto 내 컬럼 제거, Entity에 @DateTimeFormat 추가
### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [ ] API 테스트
