### PR TITLE
fix : CrewMember-004

### DIFF
--- a/src/main/java/com/example/runningservice/controller/CrewApplicantController.java
+++ b/src/main/java/com/example/runningservice/controller/CrewApplicantController.java
@@ -1,22 +1,26 @@
 package com.example.runningservice.controller;
 
 import com.example.runningservice.aop.CrewRoleCheck;
-import com.example.runningservice.dto.crewMember.CrewMemberResponseDto;
+import com.example.runningservice.dto.crewMember.CrewMemberResponseDetailDto;
 import com.example.runningservice.dto.join.CrewApplicantDetailResponseDto;
-import com.example.runningservice.dto.join.CrewApplicantResponseDto;
+import com.example.runningservice.dto.join.CrewApplicantSimpleResponseDto;
 import com.example.runningservice.dto.join.GetApplicantsRequestDto;
 import com.example.runningservice.enums.JoinStatus;
 import com.example.runningservice.service.CrewApplicantService;
+import com.example.runningservice.service.CrewMemberService;
+import com.example.runningservice.service.ProfileWithRunService;
 import com.example.runningservice.util.LoginUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,13 +32,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class CrewApplicantController {
 
     private final CrewApplicantService crewApplicantService;
+    private final CrewMemberService crewMemberService;
+    private final ProfileWithRunService profileWithRunService;
 
+    /**
+     * 크루 신청자 조회
+     */
     @GetMapping("/{crew_id}/join/list")
     @CrewRoleCheck(role = {"LEADER", "STAFF"})
-    public ResponseEntity<Page<CrewApplicantResponseDto>> getJoinApplications(
+    public ResponseEntity<Page<CrewApplicantSimpleResponseDto>> getJoinApplications(
         @LoginUser Long userId,
         @PathVariable("crew_id") Long crewId,
-        @RequestParam JoinStatus status, Pageable pageable) {
+        @RequestParam(required = false) JoinStatus status,
+        @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Direction.ASC) Pageable pageable) {
 
         GetApplicantsRequestDto requestDto = GetApplicantsRequestDto.builder()
             .status(status)
@@ -45,6 +55,9 @@ public class CrewApplicantController {
             crewApplicantService.getAllJoinApplications(crewId, requestDto));
     }
 
+    /**
+     * 크루 가입신청 개별 조회
+     */
     @GetMapping("/{crew_id}/join")
     @CrewRoleCheck(role = {"LEADER", "STAFF"})
     public ResponseEntity<CrewApplicantDetailResponseDto> getJoinApplication(
@@ -56,20 +69,27 @@ public class CrewApplicantController {
             crewApplicantService.getJoinApplicationDetail(crewId, joinApplyId));
     }
 
-    @PostMapping("/{crew_id}/join-approval")
+    /**
+     * 크루 가입 승인
+     */
+    @PostMapping("/{crew_id}/approve-join")
     @CrewRoleCheck(role = {"LEADER", "STAFF"})
-    public ResponseEntity<CrewMemberResponseDto> approveJoin(@LoginUser Long userId,
+    public ResponseEntity<CrewMemberResponseDetailDto> approveJoin(@LoginUser Long userId,
         @PathVariable("crew_id") Long crewId, @RequestParam Long joinApplyId) {
 
-        return ResponseEntity.ok(
-            crewApplicantService.approveJoinApplication(joinApplyId));
+        return ResponseEntity.ok(profileWithRunService.getCrewMemberWithEntity(
+            crewApplicantService.approveJoinApplication(joinApplyId)));
     }
 
-    @PutMapping("/{crew_id}/join-reject")
+    /**
+     * 크루 가입 거부
+     */
+    @PatchMapping("/{crew_id}/reject-join")
     @CrewRoleCheck(role = {"LEADER", "STAFF"})
-    public ResponseEntity<String> rejectJoin(@LoginUser Long userId,
+    public ResponseEntity<CrewApplicantDetailResponseDto> rejectJoin(@LoginUser Long userId,
         @PathVariable("crew_id") Long crewId, @RequestParam Long joinApplyId) {
 
-        return ResponseEntity.ok(crewApplicantService.rejectJoinApplication(joinApplyId));
+        return ResponseEntity.ok(CrewApplicantDetailResponseDto.of(
+            crewApplicantService.rejectJoinApplication(joinApplyId)));
     }
 }

--- a/src/main/java/com/example/runningservice/controller/CrewMemberController.java
+++ b/src/main/java/com/example/runningservice/controller/CrewMemberController.java
@@ -83,7 +83,7 @@ public class CrewMemberController {
      */
     @PatchMapping("/{crew_id}/change-role")
     @CrewRoleCheck(role = {"LEADER", "STAFF"})
-    public ResponseEntity<ChangeCrewRoleResponseDto> changeRole(@LoginUser Long userID,
+    public ResponseEntity<ChangeCrewRoleResponseDto> changeRole(@LoginUser Long userId,
         @PathVariable("crew_id") Long crewId,
         @RequestBody @Valid ChangeCrewRoleRequestDto requestDto) {
 

--- a/src/main/java/com/example/runningservice/dto/crewMember/ChangeCrewRoleRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/crewMember/ChangeCrewRoleRequestDto.java
@@ -1,7 +1,7 @@
 package com.example.runningservice.dto.crewMember;
 
 import com.example.runningservice.enums.CrewRole;
-import com.example.runningservice.util.validator.CrewRoleValid;
+import com.example.runningservice.util.validator.CrewRoleChangeValid;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +12,7 @@ public class ChangeCrewRoleRequestDto {
 
     private Long crewMemberId;
     @NotNull
-    @CrewRoleValid(roles = {"STAFF", "MEMBER"})
+    @CrewRoleChangeValid(roles = {"STAFF", "MEMBER"})
     private CrewRole newRole;
 
 }

--- a/src/main/java/com/example/runningservice/dto/crewMember/ChangedLeaderResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/crewMember/ChangedLeaderResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.runningservice.dto.crewMember;
 
+import com.example.runningservice.entity.CrewMemberEntity;
 import com.example.runningservice.enums.CrewRole;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,4 +13,13 @@ public class ChangedLeaderResponseDto {
     private CrewRole oldLeaderRole;
     private String newLeaderNickName;
     private CrewRole newLeaderRole;
+
+    public static ChangedLeaderResponseDto of(CrewMemberEntity oldLeader, CrewMemberEntity newLeader) {
+        return ChangedLeaderResponseDto.builder()
+            .oldLeaderNickName(oldLeader.getMember().getNickName())
+            .oldLeaderRole(oldLeader.getRole())
+            .newLeaderNickName(newLeader.getMember().getNickName())
+            .newLeaderRole(newLeader.getRole())
+            .build();
+    }
 }

--- a/src/main/java/com/example/runningservice/dto/crewMember/CrewMemberResponseDetailDto.java
+++ b/src/main/java/com/example/runningservice/dto/crewMember/CrewMemberResponseDetailDto.java
@@ -1,9 +1,8 @@
 package com.example.runningservice.dto.crewMember;
 
-import com.example.runningservice.dto.runRecord.RunRecordResponseDto;
+import com.example.runningservice.dto.runProfile.RunProfile;
 import com.example.runningservice.entity.CrewMemberEntity;
 import com.example.runningservice.entity.MemberEntity;
-import com.example.runningservice.entity.RunGoalEntity;
 import com.example.runningservice.enums.CrewRole;
 import com.example.runningservice.enums.Gender;
 import com.example.runningservice.enums.Region;
@@ -11,9 +10,7 @@ import com.example.runningservice.enums.Visibility;
 import com.example.runningservice.util.AESUtil;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
@@ -29,21 +26,6 @@ public class CrewMemberResponseDetailDto extends CrewMemberResponseDto {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime joinedAt;
     private RunProfile runProfile;
-
-    @Builder
-    @Getter
-    @Setter
-    private static class RunProfile {
-        private Double totalDistanceGoal;
-        private Integer totalRunningTimeGoal;
-        private Integer averagePaceGoal;
-        private Integer runCountGoal;
-
-        private Double totalDistance;
-        private Integer totalRunningTime;
-        private Integer averagePace;
-        private Integer runCount;
-    }
 
     public static CrewMemberResponseDetailDto of(CrewMemberEntity crewMemberEntity,
         AESUtil aesUtil) {
@@ -76,18 +58,7 @@ public class CrewMemberResponseDetailDto extends CrewMemberResponseDto {
         return dtoBuilder.build();
     }
 
-    public void addRunProfile(RunGoalEntity runGoal,
-        RunRecordResponseDto runRecord) {
-
-        this.runProfile = RunProfile.builder()
-            .totalDistanceGoal(runGoal.getTotalDistance())
-            .runCountGoal(runGoal.getRunCount())
-            .averagePaceGoal(runGoal.getAveragePace())
-            .totalRunningTimeGoal(runGoal.getTotalRunningTime())
-            .totalDistance(runRecord.getDistance())
-            .totalRunningTime(runRecord.getRunningTime())
-            .averagePace(runRecord.getPace())
-            .runCount(runRecord.getRunCount())
-            .build();
+    public void addRunProfile(RunProfile runProfile) {
+        this.runProfile = runProfile;
     }
 }

--- a/src/main/java/com/example/runningservice/dto/join/CrewApplicantDetailResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/join/CrewApplicantDetailResponseDto.java
@@ -1,27 +1,35 @@
 package com.example.runningservice.dto.join;
 
+import com.example.runningservice.dto.runProfile.RunProfile;
 import com.example.runningservice.entity.JoinApplyEntity;
+import com.example.runningservice.enums.JoinStatus;
+import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
-public class CrewApplicantDetailResponseDto extends CrewApplicantResponseDto {
+@Getter
+public class CrewApplicantDetailResponseDto extends CrewApplicantSimpleResponseDto {
 
-    //RunRecordDto, RunGoalDto 추가
+    private JoinStatus status;
+    private RunProfile runProfile;
 
     public static CrewApplicantDetailResponseDto of(JoinApplyEntity entity) {
 
-        CrewApplicantDetailResponseDto crewApplicantDetailResponseDto = CrewApplicantDetailResponseDto.builder()
-            .nickName(entity.getMember().getNickName())
-            .profileImage(entity.getMember().getProfileImageUrl())
-            .message(entity.getMessage())
-            .appliedAt(entity.getCreatedAt())
+        CrewApplicantSimpleResponseDto simpleDto = CrewApplicantSimpleResponseDto.of(entity);
+
+        return CrewApplicantDetailResponseDto.builder()
+            .id(simpleDto.getId())
+            .nickName(simpleDto.getNickName())
+            .profileImage(simpleDto.getProfileImage())
+            .message(simpleDto.getMessage())
+            .appliedAt(simpleDto.getAppliedAt())
+            .status(entity.getStatus())
             .build();
-        //setRunRecordDto(runRecordDto, runGoalDto)
-        return crewApplicantDetailResponseDto;
     }
 
-    //private void setRunRecordDto(RunRecordDto runRecordDto, RunGoalDto runGoalDto) {
-    //      this.runRecordDto = runRecordDto;
-    //      this.runGoalDto = runGoalDto;
-    // }
+    public void addRunProfile(RunProfile runProfile) {
+        this.runProfile = runProfile;
+    }
+
+
 }

--- a/src/main/java/com/example/runningservice/dto/join/CrewApplicantSimpleResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/join/CrewApplicantSimpleResponseDto.java
@@ -1,7 +1,6 @@
 package com.example.runningservice.dto.join;
 
 import com.example.runningservice.entity.JoinApplyEntity;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,16 +11,17 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CrewApplicantResponseDto {
+public class CrewApplicantSimpleResponseDto {
 
+    private Long id;
     private String nickName;
     private String profileImage;
     private String message;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime appliedAt;
 
-    public static CrewApplicantResponseDto of(JoinApplyEntity entity) {
-        return CrewApplicantResponseDto.builder()
+    public static CrewApplicantSimpleResponseDto of(JoinApplyEntity entity) {
+        return CrewApplicantSimpleResponseDto.builder()
+            .id(entity.getId())
             .nickName(entity.getMember().getNickName())
             .profileImage(entity.getMember().getProfileImageUrl())
             .message(entity.getMessage())

--- a/src/main/java/com/example/runningservice/dto/runProfile/RunProfile.java
+++ b/src/main/java/com/example/runningservice/dto/runProfile/RunProfile.java
@@ -1,0 +1,38 @@
+package com.example.runningservice.dto.runProfile;
+
+import com.example.runningservice.dto.runRecord.RunRecordResponseDto;
+import com.example.runningservice.entity.RunGoalEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class RunProfile {
+    private Double totalDistanceGoal;
+    private Integer totalRunningTimeGoal;
+    private Integer averagePaceGoal;
+    private Integer runCountGoal;
+
+    private Double totalDistance;
+    private Integer totalRunningTime;
+    private Integer averagePace;
+    private Integer runCount;
+
+
+    public static RunProfile of(RunGoalEntity runGoal,
+        RunRecordResponseDto runRecord) {
+
+        return RunProfile.builder()
+            .totalDistanceGoal(runGoal.getTotalDistance())
+            .runCountGoal(runGoal.getRunCount())
+            .averagePaceGoal(runGoal.getAveragePace())
+            .totalRunningTimeGoal(runGoal.getTotalRunningTime())
+            .totalDistance(runRecord.getDistance())
+            .totalRunningTime(runRecord.getRunningTime())
+            .averagePace(runRecord.getPace())
+            .runCount(runRecord.getRunCount())
+            .build();
+    }
+}

--- a/src/main/java/com/example/runningservice/entity/CrewMemberEntity.java
+++ b/src/main/java/com/example/runningservice/entity/CrewMemberEntity.java
@@ -70,8 +70,12 @@ public class CrewMemberEntity {
 
     public void changeRoleTo(CrewRole newRole) {
         if (newRole == this.role) {
-            throw new CustomException(ErrorCode.ROLE_NOT_CHANGED);
+            throw new CustomException(ErrorCode.NOT_ALLOWED_CHANGE_TO_SAME_ROLE);
         }
+        if (newRole == CrewRole.LEADER) {
+            throw new CustomException(ErrorCode.NOT_ALLOWED_CHANGE_TO_LEADER);
+        }
+
         this.role = newRole;
         this.roleOrder = newRole.getOrder();
     }

--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -27,7 +27,7 @@ public enum ErrorCode {
     UNAUTHORIZED_CREW_ACCESS(HttpStatus.FORBIDDEN, "크루 접근 권한이 없습니다."),
     DECRYPTION_ERROR(HttpStatus.BAD_REQUEST, "복호화 과정 중 에러가 발생하였습니다."),
     NOT_FOUND_CREW_MEMBER(HttpStatus.BAD_REQUEST, "해당 크루원을 찾을 수 없습니다."),
-    ROLE_NOT_CHANGED(HttpStatus.BAD_REQUEST, "새로운 역할이 현재 역할과 동일합니다."),
+    NOT_ALLOWED_CHANGE_TO_SAME_ROLE(HttpStatus.BAD_REQUEST, "새로운 역할이 현재 역할과 동일합니다."),
     UNAUTHORIZED_REGULAR_ACCESS(HttpStatus.FORBIDDEN, "정기러닝 접근 권한이 없습니다."),
     NOT_FOUND_ACTIVITY(HttpStatus.BAD_REQUEST, "활동이 존재하지 않습니다."),
     UNAUTHORIZED_ACTIVITY(HttpStatus.FORBIDDEN, "활동 접근 권한이 없습니다."),
@@ -44,6 +44,7 @@ public enum ErrorCode {
     NOT_FOUND_RUN_RECORD(HttpStatus.NOT_FOUND, "러닝 기록을 찾을 수 없습니다."),
     NOT_FOUND_RUN_GOAL(HttpStatus.NOT_FOUND, "러닝 목표를 찾을 수 없습니다."),
     INVALID_RUN_ARGUMENT(HttpStatus.BAD_REQUEST, "러닝 기록이 없거나 유저정보가 없습니다."),
+    NOT_ALLOWED_CHANGE_TO_LEADER(HttpStatus.BAD_REQUEST, "리더로 권한을 변경할 수 없습니다."),
 
     //크루가입
     ALREADY_EXIST_PENDING_JOIN_APPLY(HttpStatus.BAD_REQUEST, "이미 거압 숭안 대기중입니다."),

--- a/src/main/java/com/example/runningservice/repository/crewMember/CrewMemberRepositoryCustom.java
+++ b/src/main/java/com/example/runningservice/repository/crewMember/CrewMemberRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.example.runningservice.repository.crewMember;
 
 import com.example.runningservice.dto.crewMember.GetCrewMemberRequestDto;
 import com.example.runningservice.entity.CrewMemberEntity;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -9,4 +10,6 @@ public interface CrewMemberRepositoryCustom {
 
     Page<CrewMemberEntity> findAllByCrewIdAndFilter(Long crewId,
         GetCrewMemberRequestDto.Filter filter, Pageable pageable);
+
+    List<CrewMemberEntity> findNewLeaderAndOldLeader(Long crewMemberId, Long userId, Long crewId);
 }

--- a/src/main/java/com/example/runningservice/repository/crewMember/CrewMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/example/runningservice/repository/crewMember/CrewMemberRepositoryCustomImpl.java
@@ -1,5 +1,7 @@
 package com.example.runningservice.repository.crewMember;
 
+import static com.example.runningservice.entity.QCrewMemberEntity.crewMemberEntity;
+
 import com.example.runningservice.dto.crewMember.GetCrewMemberRequestDto;
 import com.example.runningservice.entity.CrewMemberEntity;
 import com.example.runningservice.entity.QCrewMemberEntity;
@@ -24,7 +26,7 @@ public class CrewMemberRepositoryCustomImpl implements CrewMemberRepositoryCusto
         GetCrewMemberRequestDto.Filter filterDto,
         Pageable pageable) {
 
-        QCrewMemberEntity crewMember = QCrewMemberEntity.crewMemberEntity;
+        QCrewMemberEntity crewMember = crewMemberEntity;
         // 쿼리 작성
 
         List<CrewMemberEntity> crewMembers = queryFactory.selectFrom(crewMember)
@@ -56,29 +58,39 @@ public class CrewMemberRepositoryCustomImpl implements CrewMemberRepositoryCusto
         return new PageImpl<>(crewMembers, pageable, total != null ? total : 0);
     }
 
+    @Override
+    public List<CrewMemberEntity> findNewLeaderAndOldLeader(Long crewMemberId, Long userId,
+        Long crewId) {
+        return queryFactory.selectFrom(crewMemberEntity)
+            .where(crewMemberEntity.id.eq(crewMemberId)
+                .or(crewMemberEntity.member.id.eq(userId)
+                    .and(crewMemberEntity.crew.id.eq(crewId))))
+            .fetch();
+    }
+
     private BooleanExpression crewIdEq(Long crewId) {
-        return crewId != null ? QCrewMemberEntity.crewMemberEntity.crew.id.eq(crewId) : null;
+        return crewId != null ? crewMemberEntity.crew.id.eq(crewId) : null;
     }
 
     private BooleanExpression genderEq(Gender gender) {
-        return gender != null ? QCrewMemberEntity.crewMemberEntity.member.gender.eq(gender) : null;
+        return gender != null ? crewMemberEntity.member.gender.eq(gender) : null;
     }
 
     private BooleanExpression roleEq(CrewRole crewRole) {
-        return crewRole != null ? QCrewMemberEntity.crewMemberEntity.role.eq(crewRole) : null;
+        return crewRole != null ? crewMemberEntity.role.eq(crewRole) : null;
     }
 
     private BooleanExpression birthYearGoe(Integer maxYear) {
         if (maxYear == null) {
             return null;
         }
-        return QCrewMemberEntity.crewMemberEntity.member.birthYear.goe(maxYear);
+        return crewMemberEntity.member.birthYear.goe(maxYear);
     }
 
     private BooleanExpression birthYearLoe(Integer minYear) {
         if (minYear == null) {
             return null;
         }
-        return QCrewMemberEntity.crewMemberEntity.member.birthYear.loe(minYear);
+        return crewMemberEntity.member.birthYear.loe(minYear);
     }
 }

--- a/src/main/java/com/example/runningservice/service/CrewApplicantService.java
+++ b/src/main/java/com/example/runningservice/service/CrewApplicantService.java
@@ -1,24 +1,18 @@
 package com.example.runningservice.service;
 
-import com.example.runningservice.dto.crewMember.CrewMemberResponseDto;
 import com.example.runningservice.dto.join.CrewApplicantDetailResponseDto;
-import com.example.runningservice.dto.join.CrewApplicantResponseDto;
+import com.example.runningservice.dto.join.CrewApplicantSimpleResponseDto;
 import com.example.runningservice.dto.join.GetApplicantsRequestDto;
-import com.example.runningservice.entity.CrewEntity;
 import com.example.runningservice.entity.CrewMemberEntity;
 import com.example.runningservice.entity.JoinApplyEntity;
-import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.enums.JoinStatus;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.JoinApplicationRepository;
 import com.example.runningservice.repository.crewMember.CrewMemberRepository;
-import com.example.runningservice.util.PageUtil;
-import com.example.runningservice.util.S3FileUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,19 +22,14 @@ public class CrewApplicantService {
 
     private final CrewMemberRepository crewMemberRepository;
     private final JoinApplicationRepository joinApplicationRepository;
-    private final S3FileUtil s3FileUtil;
+    private final ProfileWithRunService profileWithRunService;
 
     @Transactional
-    public Page<CrewApplicantResponseDto> getAllJoinApplications(Long crewId,
+    public Page<CrewApplicantSimpleResponseDto> getAllJoinApplications(Long crewId,
         GetApplicantsRequestDto request) {
 
-        // 기본 정렬 기준 및 방향 설정 (기본값은 신청일자(appliedAt) 기준 내림차순)
         // 정렬 순서는 조정 가능. 정렬 기준은 신청일자로 고정
-        String defaultSortBy = "createdAt";
-        int defaultNumber = 0;
-        int defaultPage = 10;
-        Pageable sortedPageable = PageUtil.getSortedPageable(request.getPageable(), defaultSortBy,
-            Direction.ASC, defaultNumber, defaultPage);
+        Pageable sortedPageable = request.getPageable();
 
         JoinStatus status = request.getStatus();
         Page<JoinApplyEntity> joinApplyEntityPage =
@@ -48,7 +37,7 @@ public class CrewApplicantService {
                 : joinApplicationRepository.findAllByCrew_IdAndStatus(crewId, status,
                     sortedPageable);
 
-        return joinApplyEntityPage.map(CrewApplicantResponseDto::of);
+        return joinApplyEntityPage.map(CrewApplicantSimpleResponseDto::of);
     }
 
     @Transactional
@@ -56,13 +45,11 @@ public class CrewApplicantService {
         JoinApplyEntity joinApplyEntity = joinApplicationRepository.findByIdAndCrew_Id(
             joinApplyId, crewId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_APPLY));
 
-        //runGoalResponseDto 를 조회기능에서 받아옴
-        //runRecordResponseDto 를 조회기능에서 받아옴
-        return CrewApplicantDetailResponseDto.of(joinApplyEntity);
+        return profileWithRunService.getJoinApplicationDetail(joinApplyEntity);
     }
 
     @Transactional
-    public CrewMemberResponseDto approveJoinApplication(Long joinApplyId) {
+    public CrewMemberEntity approveJoinApplication(Long joinApplyId) {
 
         //변경하려는 신청 내역 데이터 가져오기(상태 -> Pending)
         JoinApplyEntity joinApplyEntity = joinApplicationRepository.findByIdAndStatus(joinApplyId,
@@ -70,24 +57,21 @@ public class CrewApplicantService {
         //상태 변경(Pending -> Approved)
         joinApplyEntity.markAsJoinApproved();
         //CrewMemberEntity 생성 후 저장
-        MemberEntity memberEntity = joinApplyEntity.getMember();
-        CrewEntity crewEntity = joinApplyEntity.getCrew();
-        CrewMemberEntity newMember = CrewMemberEntity.of(memberEntity, crewEntity);
+        CrewMemberEntity newMember = CrewMemberEntity.of(joinApplyEntity.getMember(),
+            joinApplyEntity.getCrew());
         //DTO 변환
-        CrewMemberEntity savedCrewMember = crewMemberRepository.save(newMember);
-        return CrewMemberResponseDto.of(savedCrewMember, s3FileUtil);
+        return crewMemberRepository.save(newMember);
     }
 
 
     @Transactional
-    public String rejectJoinApplication(Long joinApplyId) {
+    public JoinApplyEntity rejectJoinApplication(Long joinApplyId) {
+        // 대기 상태인 신청 데이터 가져오기
         JoinApplyEntity joinApplyEntity = joinApplicationRepository.findByIdAndStatus(joinApplyId,
             JoinStatus.PENDING).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_APPLY));
-
+        // 신청 상태를 "REJECTED"로 수정
         joinApplyEntity.markAsRejected();
 
-        StringBuilder sb = new StringBuilder();
-        sb.append(joinApplyEntity.getMember().getEmail()).append("님의 가입신청이 거부되었습니다.");
-        return new String(sb);
+        return joinApplyEntity;
     }
 }

--- a/src/main/java/com/example/runningservice/service/ProfileWithRunService.java
+++ b/src/main/java/com/example/runningservice/service/ProfileWithRunService.java
@@ -1,0 +1,77 @@
+package com.example.runningservice.service;
+
+import com.example.runningservice.dto.crewMember.CrewMemberResponseDetailDto;
+import com.example.runningservice.dto.join.CrewApplicantDetailResponseDto;
+import com.example.runningservice.dto.runProfile.RunProfile;
+import com.example.runningservice.dto.runRecord.RunRecordResponseDto;
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.entity.JoinApplyEntity;
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.entity.RunGoalEntity;
+import com.example.runningservice.enums.Visibility;
+import com.example.runningservice.repository.RunGoalRepository;
+import com.example.runningservice.util.AESUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileWithRunService {
+
+    private final AESUtil aesUtil;
+    private final RunGoalRepository runGoalRepository;
+    private final RunRecordService runRecordService;
+
+    /**
+     * entity를 인자로 받아 crewMember 가져오기
+     */
+    @Transactional
+    public CrewMemberResponseDetailDto getCrewMemberWithEntity(CrewMemberEntity crewMemberEntity) {
+
+        MemberEntity memberEntity = crewMemberEntity.getMember();
+        if (memberEntity.getRunProfileVisibility() == Visibility.PRIVATE) {
+            return CrewMemberResponseDetailDto.of(crewMemberEntity, aesUtil);
+        }
+
+        Long userId = memberEntity.getId();
+        //ResponseDto 생성
+        CrewMemberResponseDetailDto crewMemberResponseDetailDto = CrewMemberResponseDetailDto.of(
+            crewMemberEntity, aesUtil);
+        //RunGoal 확인(없을 시 Null로 생성)
+        RunGoalEntity runGoalEntity = runGoalRepository.findFirstByUserId_IdOrderByCreatedAtDesc(
+            userId).orElseGet(RunGoalEntity::new);
+
+        RunRecordResponseDto runRecordResponseDto = runRecordService.calculateTotalRunRecords(
+            userId);
+
+        crewMemberResponseDetailDto.addRunProfile(
+            RunProfile.of(runGoalEntity, runRecordResponseDto));
+
+        return crewMemberResponseDetailDto;
+    }
+
+    @Transactional
+    public CrewApplicantDetailResponseDto getJoinApplicationDetail(JoinApplyEntity joinApplyEntity) {
+
+        MemberEntity memberEntity = joinApplyEntity.getMember();
+        if (memberEntity.getRunProfileVisibility() == Visibility.PRIVATE) {
+            return CrewApplicantDetailResponseDto.of(joinApplyEntity);
+        }
+
+        Long userId = memberEntity.getId();
+        //RunGoal 확인(없을 시 Null로 생성)
+        RunGoalEntity runGoalEntity = runGoalRepository.findFirstByUserId_IdOrderByCreatedAtDesc(
+            userId).orElseGet(RunGoalEntity::new);
+
+        RunRecordResponseDto runRecordResponseDto = runRecordService.calculateTotalRunRecords(
+            userId);
+
+        CrewApplicantDetailResponseDto crewApplicantDetailResponseDto = CrewApplicantDetailResponseDto.of(
+            joinApplyEntity);
+
+        crewApplicantDetailResponseDto.addRunProfile(
+            RunProfile.of(runGoalEntity, runRecordResponseDto));
+        return crewApplicantDetailResponseDto;
+    }
+}

--- a/src/main/java/com/example/runningservice/util/validator/CrewRoleChangeValid.java
+++ b/src/main/java/com/example/runningservice/util/validator/CrewRoleChangeValid.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = CrewRoleValidator.class)
-public @interface CrewRoleValid {
+public @interface CrewRoleChangeValid {
 
     String message() default "Invalid role";
 

--- a/src/main/java/com/example/runningservice/util/validator/CrewRoleValidator.java
+++ b/src/main/java/com/example/runningservice/util/validator/CrewRoleValidator.java
@@ -6,11 +6,11 @@ import jakarta.validation.ConstraintValidatorContext;
 import java.util.Arrays;
 import java.util.List;
 
-public class CrewRoleValidator implements ConstraintValidator<CrewRoleValid,CrewRole> {
+public class CrewRoleValidator implements ConstraintValidator<CrewRoleChangeValid,CrewRole> {
     private List<String> acceptedRoles;
 
     @Override
-    public void initialize(CrewRoleValid annotation) {
+    public void initialize(CrewRoleChangeValid annotation) {
         acceptedRoles = Arrays.asList(annotation.roles());
     }
 

--- a/src/test/java/com/example/runningservice/dto/crewMember/ChangeCrewRoleRequestDtoTest.java
+++ b/src/test/java/com/example/runningservice/dto/crewMember/ChangeCrewRoleRequestDtoTest.java
@@ -1,0 +1,57 @@
+package com.example.runningservice.dto.crewMember;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.example.runningservice.enums.CrewRole;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ChangeCrewRoleRequestDtoTest {
+    private Validator validator;
+
+    @BeforeEach
+    public void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    public void testValidRole() {
+        // Given
+        ChangeCrewRoleRequestDto dto = ChangeCrewRoleRequestDto.builder()
+            .crewMemberId(1L)
+            .newRole(CrewRole.STAFF)
+            .build();
+
+        // When
+        Set<ConstraintViolation<ChangeCrewRoleRequestDto>> violations = validator.validate(dto);
+
+        // Then
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("리더로 권한 변경 시 실패")
+    public void testInvalidRole_LEADER() {
+        // Given
+        ChangeCrewRoleRequestDto dto = ChangeCrewRoleRequestDto.builder()
+            .crewMemberId(1L)
+            .newRole(CrewRole.LEADER)
+            .build();
+
+        // When
+        Set<ConstraintViolation<ChangeCrewRoleRequestDto>> violations = validator.validate(dto);
+
+        // Then
+        assertFalse(violations.isEmpty());  // Validation error expected
+        assertEquals("Invalid role", violations.iterator().next().getMessage());
+    }
+}

--- a/src/test/java/com/example/runningservice/service/ProfileWithRunServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/ProfileWithRunServiceTest.java
@@ -1,0 +1,116 @@
+package com.example.runningservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.example.runningservice.dto.crewMember.CrewMemberResponseDetailDto;
+import com.example.runningservice.dto.join.CrewApplicantDetailResponseDto;
+import com.example.runningservice.dto.runRecord.RunRecordResponseDto;
+import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.entity.JoinApplyEntity;
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.entity.RunGoalEntity;
+import com.example.runningservice.repository.RunGoalRepository;
+import com.example.runningservice.util.AESUtil;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileWithRunServiceTest {
+
+    @Mock
+    private RunGoalRepository runGoalRepository;
+
+    @Mock
+    private RunRecordService runRecordService;
+
+    @Mock
+    private AESUtil aesUtil;
+
+    @InjectMocks
+    private ProfileWithRunService profileWithRunService;
+
+    @Test
+    void getCrewMemberWithEntity_success() {
+        //given
+        Long userId = 1L;
+        Long crewId = 1L;
+
+        CrewMemberEntity crewMember = CrewMemberEntity.builder()
+            .id(1L)
+            .member(MemberEntity.builder().id(userId).nickName("testNick").build())
+            .crew(CrewEntity.builder().id(crewId).crewName("crew1").build())
+            .build();
+
+        RunGoalEntity runGoalEntity = RunGoalEntity.builder()
+            .runCount(10)
+            .totalDistance(10.5)
+            .totalRunningTime(10000)
+            .averagePace(1000)
+            .build();
+
+        RunRecordResponseDto runRecordResponseDto = RunRecordResponseDto.builder()
+            .runCount(10)
+            .runningTime(10000)
+            .distance(10.0)
+            .pace(1000)
+            .build();
+
+        when(runGoalRepository.findFirstByUserId_IdOrderByCreatedAtDesc(userId)).thenReturn(
+            Optional.of(runGoalEntity));
+        when(runRecordService.calculateTotalRunRecords(userId)).thenReturn(runRecordResponseDto);
+
+        //when
+        CrewMemberResponseDetailDto result = profileWithRunService.getCrewMemberWithEntity(
+            crewMember);
+
+        //then
+        assertEquals(10.0, result.getRunProfile().getTotalDistance());
+        assertEquals("testNick", result.getMemberNickName());
+    }
+
+
+    @Test
+    void getJoinApplicantWithEntity_success() {
+        //given
+        Long userId = 1L;
+        Long crewId = 1L;
+
+        JoinApplyEntity joinApplyEntity = JoinApplyEntity.builder()
+            .id(1L)
+            .member(MemberEntity.builder().id(userId).nickName("testNick").build())
+            .crew(CrewEntity.builder().id(crewId).crewName("crew1").build())
+            .build();
+
+        RunGoalEntity runGoalEntity = RunGoalEntity.builder()
+            .runCount(10)
+            .totalDistance(10.5)
+            .totalRunningTime(10000)
+            .averagePace(1000)
+            .build();
+
+        RunRecordResponseDto runRecordResponseDto = RunRecordResponseDto.builder()
+            .runCount(10)
+            .runningTime(10000)
+            .distance(10.0)
+            .pace(1000)
+            .build();
+
+        when(runGoalRepository.findFirstByUserId_IdOrderByCreatedAtDesc(userId)).thenReturn(
+            Optional.of(runGoalEntity));
+        when(runRecordService.calculateTotalRunRecords(userId)).thenReturn(runRecordResponseDto);
+
+        //when
+        CrewApplicantDetailResponseDto result = profileWithRunService.getJoinApplicationDetail(
+            joinApplyEntity);
+
+        //then
+        assertEquals(10.0, result.getRunProfile().getTotalDistance());
+        assertEquals("testNick", result.getNickName());
+    }
+}


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 크루가입 기능(가입승인, 가입 거절, 가입신청자 조회)
- 크루원 조회(개별 조회)
- 가입신청자 개별조회, 크루원 개별조회 시 러닝프로필도 함께 보이도록 수정

### 이 PR에서 변경된 사항
- CrewMemberService getCrewMember()
  - runGoal이 없을 때 예외 대신 null로 runProfile에 저장
  - getCrewMemberWithEntity()로 리팩토링
- CrewMemberService transferLeaderRole()
  - 리팩토링
- CrewRoleChangeValid : 이름 변경(CrewRoleValid -> CrewRoleChangeValid)
- CrewMemberRepositoryCustomImpl
  - findOldLeaderAndNewLeader() 메서드 추가
- CrewApplicantController
  - rejectJoin() : 응답값 수정(CrewApplicantDetailResponseDto)
  - approveJoin() : 응답값 수정(크루원 개별 조회와 같은 응답값 반환)
  - getJoinApplicantions() : status 선택값으로 설정
- ProfileWithRunService 생성
  - entity를 받아 러닝프로필이 포함된 dto를 반환하는 메서드를 가짐
  - CrewApplicantService, CrewMemberService 에서 개별 회원조회 시 사용
```
      @Transactional
    public CrewMemberResponseDetailDto getCrewMemberWithEntity(CrewMemberEntity crewMemberEntity) {

        MemberEntity memberEntity = crewMemberEntity.getMember();
        if (memberEntity.getRunProfileVisibility() == Visibility.PRIVATE) {
            return CrewMemberResponseDetailDto.of(crewMemberEntity, aesUtil);
        }

        Long userId = memberEntity.getId();
        //ResponseDto 생성
        CrewMemberResponseDetailDto crewMemberResponseDetailDto = CrewMemberResponseDetailDto.of(
            crewMemberEntity, aesUtil);
        //RunGoal 확인(없을 시 Null로 생성)
        RunGoalEntity runGoalEntity = runGoalRepository.findFirstByUserId_IdOrderByCreatedAtDesc(
            userId).orElseGet(RunGoalEntity::new);

        RunRecordResponseDto runRecordResponseDto = runRecordService.calculateTotalRunRecords(
            userId);

        crewMemberResponseDetailDto.addRunProfile(
            RunProfile.of(runGoalEntity, runRecordResponseDto));

        return crewMemberResponseDetailDto;
    }
```

```
    /**
     * 크루원 개별조회(상세조회)
     */
    @Transactional
    public CrewMemberResponseDetailDto getCrewMember(Long crewMemberId) {
        CrewMemberEntity crewMemberEntity = crewMemberRepository.findById(crewMemberId)
            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW_MEMBER));

        return profileWithRunService.getCrewMemberWithEntity(crewMemberEntity);
    }

```
DTO / Entity
- ChangeCrewRoleRequestDto
  - CrewRoleValid 어노테이션 -> CrewRoleChangeValid
- ChangedLeaderResponseDto(리더 변경 후 응답)
  - of 메서드 추가
- CrewApplicantResponseDto : 응답값에 Id 추가
- RunProfile : 생성. 크루원 조회 시 포함되는 객체
```
@Builder
@Getter
@Setter
public class RunProfile {
    private Double totalDistanceGoal;
    private Integer totalRunningTimeGoal;
    private Integer averagePaceGoal;
    private Integer runCountGoal;

    private Double totalDistance;
    private Integer totalRunningTime;
    private Integer averagePace;
    private Integer runCount;


    public static RunProfile of(RunGoalEntity runGoal,
        RunRecordResponseDto runRecord) {

        return RunProfile.builder()
            .totalDistanceGoal(runGoal.getTotalDistance())
            .runCountGoal(runGoal.getRunCount())
            .averagePaceGoal(runGoal.getAveragePace())
            .totalRunningTimeGoal(runGoal.getTotalRunningTime())
            .totalDistance(runRecord.getDistance())
            .totalRunningTime(runRecord.getRunningTime())
            .averagePace(runRecord.getPace())
            .runCount(runRecord.getRunCount())
            .build();
    }
}
```
- CrewMemberEntity : changeRoleTo() 에서 leader로는 수정 못하도록 제한

테스트
- CrewMemberService : 같은 권한으로 권한변경 시 실패
- ChangeCrewRoleRequestDto : Leader로 권한변경 요청 시 실패
- ProfileWithRunServiceTest

### 참고 스크린샷

### 기타
- 러닝 프로필 관련 서비스 코드, dto 수정 되는 내용에 따라 코드 변경될 수 있음

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [ ] API 테스트
