### PR TITLE
fix : Crew-UpdateImage Image 외 다른 데이터를 수정했을 때 Image가 디폴트이미지로 변경되는 문제 해결

### DIFF
--- a/src/main/java/com/example/runningservice/service/CrewService.java
+++ b/src/main/java/com/example/runningservice/service/CrewService.java
@@ -104,8 +104,10 @@ public class CrewService {
 
         crewEntity.updateFromDto(updateCrew);
 
-        crewEntity.updateCrewImageUrl(uploadFileAndReturnFileName(crewEntity.getId(),
-            updateCrew.getCrewImage()));
+        if (updateCrew.getCrewImage() != null) {
+            crewEntity.updateCrewImageUrl(uploadFileAndReturnFileName(crewEntity.getId(),
+                updateCrew.getCrewImage()));
+        }
 
         return CrewBaseResponseDto.fromEntity(crewEntity, s3FileUtil);
     }


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 이미지 외 다른 데이터들만 수정했을 때 이미지값이 Null이 되는데, 이에 따라 디폴트이미지로 저장되는 문제 해결

### 이 PR에서 변경된 사항
- null 체크 추가
```
    @Transactional
    public CrewBaseResponseDto updateCrew(CrewUpdateRequestDto updateCrew, Long crewId) {
        CrewEntity crewEntity = crewRepository.findById(crewId)
            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CREW));

        crewEntity.updateFromDto(updateCrew);

        if (updateCrew.getCrewImage() != null) {
            crewEntity.updateCrewImageUrl(uploadFileAndReturnFileName(crewEntity.getId(),
                updateCrew.getCrewImage()));
        }

        return CrewBaseResponseDto.fromEntity(crewEntity, s3FileUtil);
    }
```

- 테스트코드 수정


### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
