### PR TITLE
fix : Crew-UpdateImage Image를 삭제할 경우 고려하여 코드 수정

### DIFF
--- a/src/main/java/com/example/runningservice/dto/crew/CrewUpdateRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/crew/CrewUpdateRequestDto.java
@@ -29,12 +29,13 @@ public class CrewUpdateRequestDto {
     private final Integer minYear;
     private final Integer maxYear;
     private final Gender gender;
+    private final Boolean deleteCrewImage;
 
     @ConstructorProperties({"description", "crewCapacity", "activityRegion", "crewImage",
         "runRecordOpen", "leaderRequired", "minYear", "maxYear", "gender"})
     public CrewUpdateRequestDto(String description, Integer crewCapacity, Region activityRegion,
         MultipartFile crewImage, Boolean runRecordOpen, Boolean leaderRequired,
-        Integer minYear, Integer maxYear, Gender gender) {
+        Integer minYear, Integer maxYear, Gender gender, Boolean deleteCrewImage) {
         this.description = description;
         this.crewCapacity = crewCapacity;
         this.activityRegion = activityRegion;
@@ -44,5 +45,6 @@ public class CrewUpdateRequestDto {
         this.minYear = minYear;
         this.maxYear = maxYear;
         this.gender = gender;
+        this.deleteCrewImage = deleteCrewImage;
     }
 }

--- a/src/main/java/com/example/runningservice/service/CrewService.java
+++ b/src/main/java/com/example/runningservice/service/CrewService.java
@@ -104,7 +104,11 @@ public class CrewService {
 
         crewEntity.updateFromDto(updateCrew);
 
-        if (updateCrew.getCrewImage() != null) {
+        if (Boolean.TRUE.equals(updateCrew.getDeleteCrewImage())) {
+            s3FileUtil.deleteObject("crew-" + crewId);
+            crewEntity.updateCrewImageUrl(
+                uploadFileAndReturnFileName(crewEntity.getId(), updateCrew.getCrewImage()));
+        } else if (updateCrew.getCrewImage() != null) {
             crewEntity.updateCrewImageUrl(uploadFileAndReturnFileName(crewEntity.getId(),
                 updateCrew.getCrewImage()));
         }

--- a/src/test/java/com/example/runningservice/service/CrewServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/CrewServiceTest.java
@@ -185,10 +185,12 @@ class CrewServiceTest {
         when(update.getCrewImage()).thenReturn(null);
 
         MemberEntity memberEntity = MemberEntity.builder().nickName("hi").build();
-        CrewEntity crewEntity = CrewEntity.builder().id(crewId).leader(memberEntity).crewImage("oldImage").build();
+        CrewEntity crewEntity = CrewEntity.builder().id(crewId).leader(memberEntity)
+            .crewImage("oldImage").build();
 
         given(crewRepository.findById(crewId)).willReturn(Optional.of(crewEntity));
-        given(s3FileUtil.createPresignedUrl(crewEntity.getCrewImage())).willReturn("signedOldImage");
+        given(s3FileUtil.createPresignedUrl(crewEntity.getCrewImage())).willReturn(
+            "signedOldImage");
 
         // when
         CrewBaseResponseDto response = crewService.updateCrew(update, crewId);
@@ -196,6 +198,36 @@ class CrewServiceTest {
         // then
         assertEquals(crewEntity.getId(), response.getCrewId());
         assertEquals("signedOldImage", response.getCrewImage());
+    }
+
+    @Test
+    @DisplayName("크루 수정 - 이미지 삭제")
+    public void updateCrew_DeleteImage() {
+        // given
+        Long crewId = 1L;
+
+        CrewUpdateRequestDto update = mock(CrewUpdateRequestDto.class);
+        when(update.getCrewImage()).thenReturn(null);
+        when(update.getDeleteCrewImage()).thenReturn(true);
+
+        MemberEntity memberEntity = MemberEntity.builder().nickName("hi").build();
+        CrewEntity crewEntity = CrewEntity.builder()
+            .id(crewId)
+            .leader(memberEntity)
+            .crewImage("oldImage")
+            .build();
+
+        given(crewRepository.findById(crewId)).willReturn(Optional.of(crewEntity));
+        given(s3FileUtil.getImgUrl("crew-default")).willReturn("http://example.com/default");
+        given(s3FileUtil.createPresignedUrl("http://example.com/default")).willReturn(
+            "signed-defaultUrl");
+
+        // when
+        CrewBaseResponseDto response = crewService.updateCrew(update, crewId);
+
+        // then
+        assertEquals(crewEntity.getId(), response.getCrewId());
+        assertEquals("signed-defaultUrl", response.getCrewImage());
     }
 
     @Test


### PR DESCRIPTION

### 이 PR을 통해 해결하려는 문제
- 이미지 삭제 / 이미지 제외한 수정 케이스를 고려하여 로직 수정

### 이 PR에서 변경된 사항
- CrewUpdateRequestDto : Boolean deleteCrewImage를 추가하여 이미지 삭제 요청 시 true를 입력하여 요청하도록 함
- CrewService : deleteCrewImage == true 케이스에 대해 로직 구현

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [ ] API 테스트
