### PR TITLE
feat : Post-Create 게시물 CRUD 도메인 생성 및 게시물 생성 로직 구현

### DIFF
--- a/src/main/java/com/example/runningservice/controller/post/PostController.java
+++ b/src/main/java/com/example/runningservice/controller/post/PostController.java
@@ -1,0 +1,44 @@
+package com.example.runningservice.controller.post;
+
+import com.example.runningservice.aop.CrewRoleCheck;
+import com.example.runningservice.dto.post.CreatePostRequestDto;
+import com.example.runningservice.dto.post.PostResponseDto;
+import com.example.runningservice.service.post.PostService;
+import com.example.runningservice.util.LoginUser;
+import com.example.runningservice.util.S3FileUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/crew")
+public class PostController {
+
+    private final PostService postService;
+    private final S3FileUtil s3FileUtil;
+
+    @PostMapping("/{crewId}/post")
+    public ResponseEntity<PostResponseDto> createPost(@LoginUser Long userId,
+        @PathVariable Long crewId,
+        @ModelAttribute @Valid CreatePostRequestDto createPostRequestDto) {
+
+        return ResponseEntity.ok(PostResponseDto.of(
+            postService.savePost(userId, crewId, createPostRequestDto), s3FileUtil));
+    }
+
+    @PutMapping("/{crewId}/post")
+    @CrewRoleCheck(role = {"LEADER", "STAFF", "MEMBER"})
+    public ResponseEntity<?> updatePost(@LoginUser Long userId,
+        @PathVariable("crewId") Long crewId) {
+
+        return null;
+    }
+
+}

--- a/src/main/java/com/example/runningservice/dto/post/CreatePostRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/post/CreatePostRequestDto.java
@@ -1,0 +1,47 @@
+package com.example.runningservice.dto.post;
+
+import com.example.runningservice.enums.PostCategory;
+import com.example.runningservice.util.validator.RequiredActivityId;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@RequiredActivityId(categoryType = PostCategory.class, category = "postCategory", idType = Long.class, id = "activityId")
+public class CreatePostRequestDto {
+
+    @NotBlank
+    @Size(max = 50)
+    private String title;
+
+    @NotNull
+    private PostCategory postCategory;
+
+    private Long activityId;
+
+    @NotBlank
+    @Size(max = 500)
+    private String content;
+
+    private List<MultipartFile> images = new ArrayList<>();
+
+    private Boolean isNotice = false;
+
+    public void setActivityIdNullNotWithActivityReview() {
+        if (this.postCategory == null || !this.postCategory.equals(PostCategory.ACTIVITY_REVIEW)) {
+            this.activityId = null;
+        }
+    }
+}

--- a/src/main/java/com/example/runningservice/dto/post/PostResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/post/PostResponseDto.java
@@ -1,0 +1,42 @@
+package com.example.runningservice.dto.post;
+
+import com.example.runningservice.entity.post.CommentEntity;
+import com.example.runningservice.entity.post.PostEntity;
+import com.example.runningservice.enums.PostCategory;
+import com.example.runningservice.util.S3FileUtil;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PostResponseDto {
+
+    private Long postId;
+    private Long memberId;
+    private Long crewId;
+    private Long activityId;
+    private String title;
+    private PostCategory postCategory;
+    private String content;
+    private List<String> imageUrls;
+    private Boolean isNotice;
+    private List<CommentEntity> comment;
+
+    public static PostResponseDto of(PostEntity postEntity, S3FileUtil s3FileUtil) {
+        return PostResponseDto.builder()
+            .postId(postEntity.getId())
+            .memberId(postEntity.getMemberId())
+            .crewId(postEntity.getCrewId())
+            .activityId(postEntity.getActivityId())
+            .title(postEntity.getTitle())
+            .postCategory(postEntity.getPostCategory())
+            .content(postEntity.getContent())
+            .imageUrls(postEntity.getImageUrls().stream().map(s3FileUtil::createPresignedUrl).collect(
+                Collectors.toList()))
+            .isNotice(postEntity.getIsNotice())
+            .comment(postEntity.getComment())
+            .build();
+    }
+}

--- a/src/main/java/com/example/runningservice/entity/post/CommentEntity.java
+++ b/src/main/java/com/example/runningservice/entity/post/CommentEntity.java
@@ -1,0 +1,33 @@
+package com.example.runningservice.entity.post;
+
+import com.example.runningservice.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.envers.AuditOverride;
+
+@Entity(name = "comment")
+@Getter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+public class CommentEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private Long postId;
+    @NotNull
+    private Long memberId;
+    @NotNull
+    private String content;
+}

--- a/src/main/java/com/example/runningservice/entity/post/PostEntity.java
+++ b/src/main/java/com/example/runningservice/entity/post/PostEntity.java
@@ -1,0 +1,84 @@
+package com.example.runningservice.entity.post;
+
+import com.example.runningservice.dto.post.CreatePostRequestDto;
+import com.example.runningservice.entity.BaseEntity;
+import com.example.runningservice.enums.PostCategory;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.envers.AuditOverride;
+
+@Entity(name = "post")
+@Getter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+public class PostEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private Long memberId;
+    @NotNull
+    private Long crewId;
+    @Nullable
+    private Long activityId;
+
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private PostCategory postCategory;
+
+    private String content;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "post_images", joinColumns = @JoinColumn(name = "post_id"))
+    @Column(name = "images")
+    private List<String> imageUrls = new ArrayList<>();
+
+    private Boolean isNotice;
+
+    @OneToMany
+    @JoinColumn(name = "comment_id")
+    private List<CommentEntity> comment = new ArrayList<>();
+
+
+    public static PostEntity of(Long memberId, Long crewId, CreatePostRequestDto createPostRequestDto) {
+        return PostEntity.builder()
+            .title(createPostRequestDto.getTitle())
+            .memberId(memberId)
+            .crewId(crewId)
+            .postCategory(createPostRequestDto.getPostCategory())
+            .activityId(createPostRequestDto.getActivityId())
+            .content(createPostRequestDto.getContent())
+            .isNotice(createPostRequestDto.getIsNotice())
+            .build();
+    }
+
+    public void savePostImages(List<String> imageUrls) {
+        if (this.imageUrls == null) {
+            this.imageUrls = new ArrayList<>(); // 명시적으로 다시 초기화
+        }
+        this.imageUrls.addAll(imageUrls);
+    }
+}

--- a/src/main/java/com/example/runningservice/enums/PostCategory.java
+++ b/src/main/java/com/example/runningservice/enums/PostCategory.java
@@ -1,0 +1,8 @@
+package com.example.runningservice.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum PostCategory {
+    PERSONAL, ACTIVITY_REVIEW, OTHERS
+}

--- a/src/main/java/com/example/runningservice/repository/post/CommentRepository.java
+++ b/src/main/java/com/example/runningservice/repository/post/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.example.runningservice.repository.post;
+
+import com.example.runningservice.entity.post.CommentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
+
+}

--- a/src/main/java/com/example/runningservice/repository/post/PostRepository.java
+++ b/src/main/java/com/example/runningservice/repository/post/PostRepository.java
@@ -1,0 +1,10 @@
+package com.example.runningservice.repository.post;
+
+import com.example.runningservice.entity.post.PostEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<PostEntity, Long> {
+
+}

--- a/src/main/java/com/example/runningservice/service/post/PostService.java
+++ b/src/main/java/com/example/runningservice/service/post/PostService.java
@@ -1,0 +1,55 @@
+package com.example.runningservice.service.post;
+
+import com.example.runningservice.dto.post.CreatePostRequestDto;
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.entity.post.PostEntity;
+import com.example.runningservice.enums.CrewRole;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.crewMember.CrewMemberRepository;
+import com.example.runningservice.repository.post.PostRepository;
+import com.example.runningservice.util.S3FileUtil;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final CrewMemberRepository crewMemberRepository;
+    private final S3FileUtil s3FileUtil;
+
+    @Transactional
+    public PostEntity savePost(Long userId, Long crewId, CreatePostRequestDto createPostRequestDto) {
+        validateCrewRole(userId, crewId, createPostRequestDto);
+
+        createPostRequestDto.setActivityIdNullNotWithActivityReview();
+
+        PostEntity postEntity = PostEntity.of(userId, crewId, createPostRequestDto);
+
+        postEntity = postRepository.save(postEntity);
+
+        postEntity.savePostImages(
+            s3FileUtil.uploadFilesAndReturnFileNames("post", postEntity.getId(),
+                createPostRequestDto.getImages()));
+
+        return postEntity;
+    }
+
+
+    private void validateCrewRole(Long userId, Long crewId, CreatePostRequestDto createPostRequestDto) {
+        //크루 회원이어야 함
+        CrewMemberEntity crewMemberEntity = crewMemberRepository.findByMember_IdAndCrew_Id(userId,
+                crewId)
+            .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
+
+        //크루게시물의 공지여부(Leader, Staff 만 가능)
+        if (!List.of(CrewRole.LEADER, CrewRole.STAFF).contains(crewMemberEntity.getRole())
+            && createPostRequestDto.getIsNotice()) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/example/runningservice/util/S3FileUtil.java
+++ b/src/main/java/com/example/runningservice/util/S3FileUtil.java
@@ -5,7 +5,9 @@ import com.example.runningservice.exception.ErrorCode;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -122,4 +124,34 @@ public class S3FileUtil {
         return presignedUrl != null &&
             presignedUrl.expiration.isAfter(LocalDateTime.now().plusMinutes(1));
     }
+
+    public String uploadFileAndReturnFileName(String prefix, Long id, MultipartFile image) {
+
+        String defaultImageName = prefix + "-default";
+
+        if (image != null && !image.isEmpty()) {
+            String fileName = prefix + "-" + id;
+            putObject(fileName, image);
+
+            return getImgUrl(fileName);
+        } else { // 크루 이미지가 없으면 기본 이미지로 사용
+            return getImgUrl(defaultImageName);
+        }
+    }
+
+    public List<String> uploadFilesAndReturnFileNames(String prefix, Long id, List<MultipartFile> images) {
+
+        List<String> fileUrls = new ArrayList<>();
+        if (!images.isEmpty()) {
+
+            for (MultipartFile image : images) {
+                String fileName = prefix + "-" + id + "-" + images.indexOf(image);
+                putObject(fileName, image);
+                fileUrls.add(getImgUrl(fileName));
+            }
+        }
+        return fileUrls;
+    }
+
+
 }

--- a/src/main/java/com/example/runningservice/util/validator/ActivityIdValidator.java
+++ b/src/main/java/com/example/runningservice/util/validator/ActivityIdValidator.java
@@ -1,0 +1,55 @@
+package com.example.runningservice.util.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.lang.reflect.Field;
+
+public class ActivityIdValidator implements ConstraintValidator<RequiredActivityId, Object> {
+
+    private String categoryFieldName;
+    private String idFieldName;
+    private Class<?> categoryFieldType;
+    private Class<?> idFieldType;
+
+    @Override
+    public void initialize(RequiredActivityId constraintAnnotation) {
+        // 어노테이션에서 필드명과 필드 타입 가져오기
+        this.categoryFieldName = constraintAnnotation.category();
+        this.idFieldName = constraintAnnotation.id();
+        this.categoryFieldType = constraintAnnotation.categoryType();
+        this.idFieldType = constraintAnnotation.idType();
+    }
+
+    @Override
+    public boolean isValid(Object dto, ConstraintValidatorContext context) {
+        try {
+            // Reflection으로 필드를 가져옴
+            Field postCategoryField = dto.getClass().getDeclaredField(categoryFieldName);
+            Field activityIdField = dto.getClass().getDeclaredField(idFieldName);
+
+            // 필드에 접근 가능하도록 설정
+            postCategoryField.setAccessible(true);
+            activityIdField.setAccessible(true);
+
+            // 필드 값과 타입 가져오기
+            Object postCategory = postCategoryField.get(dto);
+            Object activityId = activityIdField.get(dto);
+
+            // 필드 타입이 어노테이션에서 지정한 타입과 일치하는지 확인
+            if (!postCategoryField.getType().equals(categoryFieldType) || !activityIdField.getType().equals(idFieldType)) {
+                throw new IllegalArgumentException("Field types do not match the expected types");
+            }
+
+            // PostCategory가 ACTIVITY_REVIEW일 때 activityId가 null이면 유효하지 않음
+            if (postCategory != null && postCategory.toString().equals("ACTIVITY_REVIEW") && activityId == null) {
+                return false;
+            }
+
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // 필드를 찾지 못했거나 접근할 수 없는 경우는 검증 실패로 처리
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/example/runningservice/util/validator/RequiredActivityId.java
+++ b/src/main/java/com/example/runningservice/util/validator/RequiredActivityId.java
@@ -1,0 +1,25 @@
+package com.example.runningservice.util.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = ActivityIdValidator.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequiredActivityId {
+    String message() default "ACTIVITY_REVIEW 게시물 생성 시 Activity Id는 필수입니다.";
+
+    String category(); // PostCategory 필드명
+    String id(); // ActivityId 필드명
+
+    // 필드 타입 속성
+    Class<?> categoryType(); // PostCategory 필드 타입
+    Class<?> idType(); // ActivityId 필드 타입
+
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/test/java/com/example/runningservice/dto/post/CreatePostRequestDtoTest.java
+++ b/src/test/java/com/example/runningservice/dto/post/CreatePostRequestDtoTest.java
@@ -1,0 +1,81 @@
+package com.example.runningservice.dto.post;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.example.runningservice.enums.PostCategory;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CreatePostRequestDtoTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        // Validator 객체를 초기화
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("활동후기 게시판일 때 activityId가 null_실패")
+    void testValidActivityId_WhenPostCategoryIsActivityReview_AndActivityIdIsNull_Failed() {
+        // given
+        CreatePostRequestDto requestDto = CreatePostRequestDto.builder()
+            .title("Test Post")
+            .content("This is a test post.")
+            .postCategory(PostCategory.ACTIVITY_REVIEW) // 활동 리뷰일 때
+            .activityId(null) // ActivityId가 null
+            .build();
+
+        // when
+        Set<ConstraintViolation<CreatePostRequestDto>> violations = validator.validate(requestDto);
+
+        // then
+        assertEquals(1, violations.size()); // 1개의 유효성 검증 실패
+        assertTrue(violations.stream().anyMatch(
+            v -> v.getMessage().contains("ACTIVITY_REVIEW 게시물 생성 시 Activity Id는 필수입니다.")
+        ));
+    }
+
+    @Test
+    void testValidActivityId_WhenPostCategoryIsActivityReview_AndActivityIdIsProvided_Success() {
+        // given
+        CreatePostRequestDto requestDto = CreatePostRequestDto.builder()
+            .title("Test Post")
+            .content("This is a test post.")
+            .postCategory(PostCategory.ACTIVITY_REVIEW) // 활동 리뷰일 때
+            .activityId(100L) // ActivityId가 제공됨
+            .build();
+
+        // when
+        Set<ConstraintViolation<CreatePostRequestDto>> violations = validator.validate(requestDto);
+
+        // then
+        assertTrue(violations.isEmpty()); // 유효성 검증 성공
+    }
+
+    @Test
+    void testValidActivityId_WhenPostCategoryIsNotActivityReview_AndActivityIdIsNull_ShouldPass() {
+        // given
+        CreatePostRequestDto requestDto = CreatePostRequestDto.builder()
+            .title("Test Post")
+            .content("This is a test post.")
+            .postCategory(PostCategory.PERSONAL) // 개인 게시물
+            .activityId(null) // ActivityId가 없어도 됨
+            .build();
+
+        // when
+        Set<ConstraintViolation<CreatePostRequestDto>> violations = validator.validate(requestDto);
+
+        // then
+        assertTrue(violations.isEmpty()); // 유효성 검증 성공
+    }
+}

--- a/src/test/java/com/example/runningservice/service/post/PostServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/post/PostServiceTest.java
@@ -1,0 +1,277 @@
+package com.example.runningservice.service.post;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.when;
+
+import com.example.runningservice.dto.post.CreatePostRequestDto;
+import com.example.runningservice.entity.CrewEntity;
+import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.entity.post.PostEntity;
+import com.example.runningservice.enums.CrewRole;
+import com.example.runningservice.enums.PostCategory;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.crewMember.CrewMemberRepository;
+import com.example.runningservice.repository.post.PostRepository;
+import com.example.runningservice.util.S3FileUtil;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+    @Mock
+    PostRepository postRepository;
+
+    @Mock
+    CrewMemberRepository crewMemberRepository;
+
+    @Mock
+    S3FileUtil s3FileUtil;
+
+    @InjectMocks
+    PostService postService;
+
+    @Test
+    void testCreatePost_Success() {
+        //given
+        Long userId = 1L;
+        Long crewId = 2L;
+        Long postId = 3L;
+        Long crewMemberId = 4L;
+
+        MockMultipartFile mockFile1 = new MockMultipartFile(
+            "file",                         // 필드 이름
+            "testImage1.jpg",                // 파일 이름
+            "image/jpeg",                    // 파일 타입
+            "Test image content 1".getBytes() // 파일 내용
+        );
+
+        MockMultipartFile mockFile2 = new MockMultipartFile(
+            "file",
+            "testImage2.jpg",
+            "image/jpeg",
+            "Test image content 2".getBytes()
+        );
+
+        CreatePostRequestDto requestDto = CreatePostRequestDto.builder()
+            .title("title")
+            .content("content")
+            .postCategory(PostCategory.PERSONAL)
+            .images(List.of(mockFile1, mockFile2))
+            .isNotice(false)
+            .build();
+
+        PostEntity postEntity = PostEntity.builder()
+            .id(postId)
+            .crewId(crewId)
+            .title(requestDto.getTitle())
+            .content(requestDto.getContent())
+            .postCategory(requestDto.getPostCategory())
+            .isNotice(requestDto.getIsNotice())
+            .build();
+
+        CrewMemberEntity crewMember = CrewMemberEntity.builder()
+            .id(crewMemberId)
+            .crew(CrewEntity.builder().id(crewId).build())
+            .member(MemberEntity.builder().id(userId).build())
+            .role(CrewRole.MEMBER)
+            .roleOrder(CrewRole.MEMBER.getOrder())
+            .build();
+
+        when(crewMemberRepository.findByMember_IdAndCrew_Id(userId, crewId)).thenReturn(
+            Optional.of(crewMember));
+        when(postRepository.save(argThat(i -> i.getTitle().equals(postEntity.getTitle()) &&
+            i.getContent().equals(postEntity.getContent()) &&
+            i.getPostCategory().equals(postEntity.getPostCategory()) &&
+            i.getIsNotice().equals(postEntity.getIsNotice())))).thenReturn(postEntity);
+
+        when(s3FileUtil.uploadFilesAndReturnFileNames("post", postId,
+            requestDto.getImages())).thenReturn(List.of("post-1-0", "post-1-1"));
+
+        //when
+        PostEntity result = postService.savePost(userId, crewId, requestDto);
+
+        //then
+        assertEquals(2, result.getImageUrls().size());
+        assertEquals("post-1-0", result.getImageUrls().get(0));
+        assertEquals("post-1-1", result.getImageUrls().get(1));
+        assertEquals("title", result.getTitle());
+        assertEquals("content", result.getContent());
+        assertEquals(PostCategory.PERSONAL, result.getPostCategory());
+        assertEquals(false, result.getIsNotice());
+    }
+
+    @Test
+    @DisplayName("크루원 아님_실패")
+    void testCreatePost_Failed_NotCrewMember() {
+        //given
+        Long userId = 1L;
+        Long crewId = 2L;
+
+        MockMultipartFile mockFile1 = new MockMultipartFile(
+            "file",                         // 필드 이름
+            "testImage1.jpg",                // 파일 이름
+            "image/jpeg",                    // 파일 타입
+            "Test image content 1".getBytes() // 파일 내용
+        );
+
+        MockMultipartFile mockFile2 = new MockMultipartFile(
+            "file",
+            "testImage2.jpg",
+            "image/jpeg",
+            "Test image content 2".getBytes()
+        );
+
+        CreatePostRequestDto requestDto = CreatePostRequestDto.builder()
+            .title("title")
+            .content("content")
+            .postCategory(PostCategory.PERSONAL)
+            .images(List.of(mockFile1, mockFile2))
+            .isNotice(false)
+            .build();
+
+        when(crewMemberRepository.findByMember_IdAndCrew_Id(userId, crewId)).thenReturn(
+            Optional.empty());
+
+        //when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> postService.savePost(userId, crewId, requestDto));
+
+        //then
+        assertEquals(ErrorCode.UNAUTHORIZED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("일반 멤버가 공지사항 등록 시도_실패")
+    void testSavePost_Failed_Unauthorized_Notice() {
+        //given
+        Long userId = 1L;
+        Long crewId = 2L;
+        Long postId = 3L;
+        Long crewMemberId = 4L;
+
+        MockMultipartFile mockFile1 = new MockMultipartFile(
+            "file",                         // 필드 이름
+            "testImage1.jpg",                // 파일 이름
+            "image/jpeg",                    // 파일 타입
+            "Test image content 1".getBytes() // 파일 내용
+        );
+
+        MockMultipartFile mockFile2 = new MockMultipartFile(
+            "file",
+            "testImage2.jpg",
+            "image/jpeg",
+            "Test image content 2".getBytes()
+        );
+
+        CreatePostRequestDto requestDto = CreatePostRequestDto.builder()
+            .title("title")
+            .content("content")
+            .postCategory(PostCategory.PERSONAL)
+            .images(List.of(mockFile1, mockFile2))
+            .isNotice(true)
+            .build();
+
+
+        CrewMemberEntity crewMember = CrewMemberEntity.builder()
+            .id(crewMemberId)
+            .crew(CrewEntity.builder().id(crewId).build())
+            .member(MemberEntity.builder().id(userId).build())
+            .role(CrewRole.MEMBER)
+            .roleOrder(CrewRole.MEMBER.getOrder())
+            .build();
+
+        when(crewMemberRepository.findByMember_IdAndCrew_Id(userId, crewId)).thenReturn(
+            Optional.of(crewMember));
+
+        //when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> postService.savePost(userId, crewId, requestDto));
+
+        //then
+        assertEquals(ErrorCode.UNAUTHORIZED, exception.getErrorCode());
+    }
+
+    @Test
+    void testSavePost_Success_PERSONAL_ActivityIdNull() {
+        //given
+        Long userId = 1L;
+        Long crewId = 2L;
+        Long postId = 3L;
+        Long crewMemberId = 4L;
+
+        MockMultipartFile mockFile1 = new MockMultipartFile(
+            "file",                         // 필드 이름
+            "testImage1.jpg",                // 파일 이름
+            "image/jpeg",                    // 파일 타입
+            "Test image content 1".getBytes() // 파일 내용
+        );
+
+        MockMultipartFile mockFile2 = new MockMultipartFile(
+            "file",
+            "testImage2.jpg",
+            "image/jpeg",
+            "Test image content 2".getBytes()
+        );
+
+        CreatePostRequestDto requestDto = CreatePostRequestDto.builder()
+            .title("title")
+            .content("content")
+            .postCategory(PostCategory.PERSONAL)
+            .activityId(100L)
+            .images(List.of(mockFile1, mockFile2))
+            .isNotice(false)
+            .build();
+
+        PostEntity postEntity = PostEntity.builder()
+            .id(postId)
+            .crewId(crewId)
+            .title(requestDto.getTitle())
+            .content(requestDto.getContent())
+            .postCategory(requestDto.getPostCategory())
+            .isNotice(requestDto.getIsNotice())
+            .build();
+
+        CrewMemberEntity crewMember = CrewMemberEntity.builder()
+            .id(crewMemberId)
+            .crew(CrewEntity.builder().id(crewId).build())
+            .member(MemberEntity.builder().id(userId).build())
+            .role(CrewRole.MEMBER)
+            .roleOrder(CrewRole.MEMBER.getOrder())
+            .build();
+
+        when(crewMemberRepository.findByMember_IdAndCrew_Id(userId, crewId)).thenReturn(
+            Optional.of(crewMember));
+        when(postRepository.save(argThat(i -> i.getTitle().equals(postEntity.getTitle()) &&
+            i.getContent().equals(postEntity.getContent()) &&
+            i.getPostCategory().equals(postEntity.getPostCategory()) &&
+            i.getIsNotice().equals(postEntity.getIsNotice())))).thenReturn(postEntity);
+
+        when(s3FileUtil.uploadFilesAndReturnFileNames("post", postId,
+            requestDto.getImages())).thenReturn(List.of("post-1-0", "post-1-1"));
+
+        //when
+        PostEntity result = postService.savePost(userId, crewId, requestDto);
+
+        //then
+        assertEquals(2, result.getImageUrls().size());
+        assertEquals("post-1-0", result.getImageUrls().get(0));
+        assertEquals("post-1-1", result.getImageUrls().get(1));
+        assertEquals("title", result.getTitle());
+        assertEquals("content", result.getContent());
+        assertEquals(PostCategory.PERSONAL, result.getPostCategory());
+        assertNull(result.getActivityId());
+    }
+}


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 카테고리를 구분(개인, 활동후기, 기타)하여 게시물을 올릴 수 있는 기능 구현
- 자수 제한, 활동후기 게시물의 경우 어떤 활동인지(activityId) 선택하도록 제한
- Leader, Staff 권한의 크루원만 공지를 등록할 수 있도록 구현

### 이 PR에서 변경된 사항
- 게시물 관련 도메인/서비스/컨트롤러 : PostEntity, PostRepository, CommentEntity, CommentRepository, PostService, PostController

게시물 생성 코드
- PostController
  - POST "/crew/{crewId}/post" createPost
  - dto 변환
- PostService
  - savePost() 
    - 크루원 권한체크
  ```
      private void validateCrewRole(Long userId, Long crewId, CreatePostRequestDto createPostRequestDto) {
          //크루 회원이어야 함
          CrewMemberEntity crewMemberEntity = crewMemberRepository.findByMember_IdAndCrew_Id(userId,
                  crewId)
              .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
  
          //크루게시물의 공지여부(Leader, Staff 만 가능)
          if (!List.of(CrewRole.LEADER, CrewRole.STAFF).contains(crewMemberEntity.getRole())
              && createPostRequestDto.getIsNotice()) {
              throw new CustomException(ErrorCode.UNAUTHORIZED);
          }
      }
  ```


    - 활동후기 게시판 아니면 activityId는 null 초기화
    - 이미지파일 저장
      
  ```
      public void setActivityIdNullNotWithActivityReview() {
          if (this.postCategory == null || !this.postCategory.equals(PostCategory.ACTIVITY_REVIEW)) {
              this.activityId = null;
          }
      }
  ```
  ```
  @Transactional
      public PostEntity savePost(Long userId, Long crewId, CreatePostRequestDto createPostRequestDto) {
          validateCrewRole(userId, crewId, createPostRequestDto);
  
          createPostRequestDto.setActivityIdNullNotWithActivityReview();
  
          PostEntity postEntity = PostEntity.of(userId, crewId, createPostRequestDto);
  
          postEntity = postRepository.save(postEntity);
  
          postEntity.savePostImages(
              s3FileUtil.uploadFilesAndReturnFileNames("post", postEntity.getId(),
                  createPostRequestDto.getImages()));
  
          return postEntity;
      }
  ```

Dto
- CreatePostRequestDto : 활동후기 게시물은 ActivityId null 불가, 자수제한
- PostResponseDto : image파일 서명된 Url 형태로 반환

테스트
- api : 기본 게시물 생성 테스트
- 테스트코드 : 게시물 생성, dto validator 테스트

### 참고 스크린샷


### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
