### PR TITLE
feat : Post-Update 게시물 수정 로직 구현

### DIFF
--- a/src/main/java/com/example/runningservice/controller/post/PostController.java
+++ b/src/main/java/com/example/runningservice/controller/post/PostController.java
@@ -1,8 +1,8 @@
 package com.example.runningservice.controller.post;
 
-import com.example.runningservice.aop.CrewRoleCheck;
-import com.example.runningservice.dto.post.CreatePostRequestDto;
+import com.example.runningservice.dto.post.PostRequestDto;
 import com.example.runningservice.dto.post.PostResponseDto;
+import com.example.runningservice.dto.post.UpdatePostRequestDto;
 import com.example.runningservice.service.post.PostService;
 import com.example.runningservice.util.LoginUser;
 import com.example.runningservice.util.S3FileUtil;
@@ -27,18 +27,19 @@ public class PostController {
     @PostMapping("/{crewId}/post")
     public ResponseEntity<PostResponseDto> createPost(@LoginUser Long userId,
         @PathVariable Long crewId,
-        @ModelAttribute @Valid CreatePostRequestDto createPostRequestDto) {
+        @ModelAttribute @Valid PostRequestDto postRequestDto) {
 
         return ResponseEntity.ok(PostResponseDto.of(
-            postService.savePost(userId, crewId, createPostRequestDto), s3FileUtil));
+            postService.savePost(userId, crewId, postRequestDto), s3FileUtil));
     }
 
     @PutMapping("/{crewId}/post")
-    @CrewRoleCheck(role = {"LEADER", "STAFF", "MEMBER"})
-    public ResponseEntity<?> updatePost(@LoginUser Long userId,
-        @PathVariable("crewId") Long crewId) {
+    public ResponseEntity<PostResponseDto> updatePost(@LoginUser Long userId,
+        @PathVariable("crewId") Long crewId,
+        @ModelAttribute @Valid UpdatePostRequestDto requestDto) {
 
-        return null;
+        return ResponseEntity.ok(
+            PostResponseDto.of(postService.updatePost(userId, crewId, requestDto), s3FileUtil));
     }
 
 }

--- a/src/main/java/com/example/runningservice/dto/post/PostRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/post/PostRequestDto.java
@@ -8,19 +8,19 @@ import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 @RequiredActivityId(categoryType = PostCategory.class, category = "postCategory", idType = Long.class, id = "activityId")
-public class CreatePostRequestDto {
+public class PostRequestDto {
 
     @NotBlank
     @Size(max = 50)
@@ -35,7 +35,7 @@ public class CreatePostRequestDto {
     @Size(max = 500)
     private String content;
 
-    private List<MultipartFile> images = new ArrayList<>();
+    private List<MultipartFile> imagesToUpload = new ArrayList<>();
 
     private Boolean isNotice = false;
 

--- a/src/main/java/com/example/runningservice/dto/post/PostResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/post/PostResponseDto.java
@@ -33,7 +33,7 @@ public class PostResponseDto {
             .title(postEntity.getTitle())
             .postCategory(postEntity.getPostCategory())
             .content(postEntity.getContent())
-            .imageUrls(postEntity.getImageUrls().stream().map(s3FileUtil::createPresignedUrl).collect(
+            .imageUrls(postEntity.getImages().stream().map(s3FileUtil::createPresignedUrl).collect(
                 Collectors.toList()))
             .isNotice(postEntity.getIsNotice())
             .comment(postEntity.getComment())

--- a/src/main/java/com/example/runningservice/dto/post/UpdatePostRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/post/UpdatePostRequestDto.java
@@ -1,0 +1,28 @@
+package com.example.runningservice.dto.post;
+
+import com.example.runningservice.enums.PostCategory;
+import com.example.runningservice.util.validator.RequiredActivityId;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@SuperBuilder
+@RequiredActivityId(categoryType = PostCategory.class, category = "postCategory", idType = Long.class, id = "activityId")
+public class UpdatePostRequestDto extends PostRequestDto {
+
+    @NotNull
+    private Long postId;
+    @NotNull
+    private Boolean deleteAllImages;
+    private List<String> imagesToDelete = new ArrayList<>();
+
+}

--- a/src/main/java/com/example/runningservice/entity/post/PostEntity.java
+++ b/src/main/java/com/example/runningservice/entity/post/PostEntity.java
@@ -1,6 +1,7 @@
 package com.example.runningservice.entity.post;
 
-import com.example.runningservice.dto.post.CreatePostRequestDto;
+import com.example.runningservice.dto.post.PostRequestDto;
+import com.example.runningservice.dto.post.UpdatePostRequestDto;
 import com.example.runningservice.entity.BaseEntity;
 import com.example.runningservice.enums.PostCategory;
 import jakarta.annotation.Nullable;
@@ -18,6 +19,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -54,7 +56,7 @@ public class PostEntity extends BaseEntity {
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "post_images", joinColumns = @JoinColumn(name = "post_id"))
     @Column(name = "images")
-    private List<String> imageUrls = new ArrayList<>();
+    private List<String> images = new ArrayList<>();
 
     private Boolean isNotice;
 
@@ -63,22 +65,33 @@ public class PostEntity extends BaseEntity {
     private List<CommentEntity> comment = new ArrayList<>();
 
 
-    public static PostEntity of(Long memberId, Long crewId, CreatePostRequestDto createPostRequestDto) {
+    public static PostEntity of(Long memberId, Long crewId, PostRequestDto postRequestDto) {
         return PostEntity.builder()
-            .title(createPostRequestDto.getTitle())
+            .title(postRequestDto.getTitle())
             .memberId(memberId)
             .crewId(crewId)
-            .postCategory(createPostRequestDto.getPostCategory())
-            .activityId(createPostRequestDto.getActivityId())
-            .content(createPostRequestDto.getContent())
-            .isNotice(createPostRequestDto.getIsNotice())
+            .postCategory(postRequestDto.getPostCategory())
+            .activityId(postRequestDto.getActivityId())
+            .content(postRequestDto.getContent())
+            .isNotice(postRequestDto.getIsNotice())
             .build();
     }
 
-    public void savePostImages(List<String> imageUrls) {
-        if (this.imageUrls == null) {
-            this.imageUrls = new ArrayList<>(); // 명시적으로 다시 초기화
+    public void addPostImages(Collection<String> imageUrls) {
+        if (this.images == null) {
+            this.images = new ArrayList<>(); // 명시적으로 다시 초기화
         }
-        this.imageUrls.addAll(imageUrls);
+        this.images.addAll(imageUrls);
+    }
+
+    public void savePostImages(Collection<String> imageUrls) {
+        this.images = new ArrayList<>(imageUrls);
+    }
+
+    public void updatePost(UpdatePostRequestDto updatePostRequestDto) {
+        this.title = updatePostRequestDto.getTitle();
+        this.content = updatePostRequestDto.getContent();
+        this.activityId = updatePostRequestDto.getActivityId();
+        this.isNotice = updatePostRequestDto.getIsNotice();
     }
 }

--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     NOT_FOUND_RUN_RECORD(HttpStatus.NOT_FOUND, "러닝 기록을 찾을 수 없습니다."),
     NOT_FOUND_RUN_GOAL(HttpStatus.NOT_FOUND, "러닝 목표를 찾을 수 없습니다."),
     INVALID_RUN_ARGUMENT(HttpStatus.BAD_REQUEST, "러닝 기록이 없거나 유저정보가 없습니다."),
+    NOT_FOUND_POST(HttpStatus.NOT_FOUND, "해당 게시물을 찾을 수 없습니다."),
 
     //크루가입
     ALREADY_EXIST_PENDING_JOIN_APPLY(HttpStatus.BAD_REQUEST, "이미 거압 숭안 대기중입니다."),

--- a/src/main/java/com/example/runningservice/repository/post/PostRepository.java
+++ b/src/main/java/com/example/runningservice/repository/post/PostRepository.java
@@ -1,10 +1,11 @@
 package com.example.runningservice.repository.post;
 
 import com.example.runningservice.entity.post.PostEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
-
+    Optional<PostEntity> findByIdAndMemberId(Long id, Long userId);
 }

--- a/src/main/java/com/example/runningservice/service/post/PostService.java
+++ b/src/main/java/com/example/runningservice/service/post/PostService.java
@@ -49,7 +49,7 @@ public class PostService {
 
         requestDto.setActivityIdNullNotWithActivityReview();
 
-        PostEntity postEntity = postRepository.findById(requestDto.getPostId())
+        PostEntity postEntity = postRepository.findByIdAndMemberId(requestDto.getPostId(), userId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
 
         postEntity.updatePost(requestDto);

--- a/src/main/java/com/example/runningservice/service/post/PostService.java
+++ b/src/main/java/com/example/runningservice/service/post/PostService.java
@@ -1,6 +1,7 @@
 package com.example.runningservice.service.post;
 
-import com.example.runningservice.dto.post.CreatePostRequestDto;
+import com.example.runningservice.dto.post.PostRequestDto;
+import com.example.runningservice.dto.post.UpdatePostRequestDto;
 import com.example.runningservice.entity.CrewMemberEntity;
 import com.example.runningservice.entity.post.PostEntity;
 import com.example.runningservice.enums.CrewRole;
@@ -9,7 +10,10 @@ import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.crewMember.CrewMemberRepository;
 import com.example.runningservice.repository.post.PostRepository;
 import com.example.runningservice.util.S3FileUtil;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,24 +27,58 @@ public class PostService {
     private final S3FileUtil s3FileUtil;
 
     @Transactional
-    public PostEntity savePost(Long userId, Long crewId, CreatePostRequestDto createPostRequestDto) {
-        validateCrewRole(userId, crewId, createPostRequestDto);
+    public PostEntity savePost(Long userId, Long crewId, PostRequestDto postRequestDto) {
+        validateCrewRole(userId, crewId, postRequestDto);
 
-        createPostRequestDto.setActivityIdNullNotWithActivityReview();
+        postRequestDto.setActivityIdNullNotWithActivityReview();
 
-        PostEntity postEntity = PostEntity.of(userId, crewId, createPostRequestDto);
+        PostEntity postEntity = PostEntity.of(userId, crewId, postRequestDto);
 
         postEntity = postRepository.save(postEntity);
 
-        postEntity.savePostImages(
+        postEntity.addPostImages(
             s3FileUtil.uploadFilesAndReturnFileNames("post", postEntity.getId(),
-                createPostRequestDto.getImages()));
+                postRequestDto.getImagesToUpload()));
+
+        return postEntity;
+    }
+
+    @Transactional
+    public PostEntity updatePost(Long userId, Long crewId, UpdatePostRequestDto requestDto) {
+        validateCrewRole(userId, crewId, requestDto);
+
+        requestDto.setActivityIdNullNotWithActivityReview();
+
+        PostEntity postEntity = postRepository.findById(requestDto.getPostId())
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
+
+        postEntity.updatePost(requestDto);
+
+        //저체삭제 요청일 때
+        if (Boolean.TRUE.equals(requestDto.getDeleteAllImages())) {
+            List<String> images = new ArrayList<>(postEntity.getImages());
+            images.forEach(s3FileUtil::deleteObject);
+            images.clear();
+            postEntity.savePostImages(images);
+        } else if (requestDto.getImagesToDelete() != null) { //일부 이미지 delete 요청
+            Set<String> images = new HashSet<>(postEntity.getImages());
+            requestDto.getImagesToDelete().forEach(e -> {
+                s3FileUtil.deleteObject(e);
+                images.remove(e);
+            });
+            postEntity.savePostImages(images);
+        }
+        //일부 이미지 추가 요청
+        if (requestDto.getImagesToUpload() != null) {
+            postEntity.addPostImages(s3FileUtil.uploadFilesAndReturnFileNames("post",
+                requestDto.getPostId(), requestDto.getImagesToUpload()));
+        }
 
         return postEntity;
     }
 
 
-    private void validateCrewRole(Long userId, Long crewId, CreatePostRequestDto createPostRequestDto) {
+    private void validateCrewRole(Long userId, Long crewId, PostRequestDto postRequestDto) {
         //크루 회원이어야 함
         CrewMemberEntity crewMemberEntity = crewMemberRepository.findByMember_IdAndCrew_Id(userId,
                 crewId)
@@ -48,7 +86,7 @@ public class PostService {
 
         //크루게시물의 공지여부(Leader, Staff 만 가능)
         if (!List.of(CrewRole.LEADER, CrewRole.STAFF).contains(crewMemberEntity.getRole())
-            && createPostRequestDto.getIsNotice()) {
+            && postRequestDto.getIsNotice()) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
     }

--- a/src/main/java/com/example/runningservice/util/S3FileUtil.java
+++ b/src/main/java/com/example/runningservice/util/S3FileUtil.java
@@ -143,7 +143,6 @@ public class S3FileUtil {
 
         List<String> fileUrls = new ArrayList<>();
         if (!images.isEmpty()) {
-
             for (MultipartFile image : images) {
                 String fileName = prefix + "-" + id + "-" + images.indexOf(image);
                 putObject(fileName, image);

--- a/src/test/java/com/example/runningservice/dto/post/PostRequestDtoTest.java
+++ b/src/test/java/com/example/runningservice/dto/post/PostRequestDtoTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class CreatePostRequestDtoTest {
+class PostRequestDtoTest {
 
     private Validator validator;
 
@@ -28,7 +28,7 @@ class CreatePostRequestDtoTest {
     @DisplayName("활동후기 게시판일 때 activityId가 null_실패")
     void testValidActivityId_WhenPostCategoryIsActivityReview_AndActivityIdIsNull_Failed() {
         // given
-        CreatePostRequestDto requestDto = CreatePostRequestDto.builder()
+        PostRequestDto requestDto = PostRequestDto.builder()
             .title("Test Post")
             .content("This is a test post.")
             .postCategory(PostCategory.ACTIVITY_REVIEW) // 활동 리뷰일 때
@@ -36,7 +36,7 @@ class CreatePostRequestDtoTest {
             .build();
 
         // when
-        Set<ConstraintViolation<CreatePostRequestDto>> violations = validator.validate(requestDto);
+        Set<ConstraintViolation<PostRequestDto>> violations = validator.validate(requestDto);
 
         // then
         assertEquals(1, violations.size()); // 1개의 유효성 검증 실패
@@ -48,7 +48,7 @@ class CreatePostRequestDtoTest {
     @Test
     void testValidActivityId_WhenPostCategoryIsActivityReview_AndActivityIdIsProvided_Success() {
         // given
-        CreatePostRequestDto requestDto = CreatePostRequestDto.builder()
+        PostRequestDto requestDto = PostRequestDto.builder()
             .title("Test Post")
             .content("This is a test post.")
             .postCategory(PostCategory.ACTIVITY_REVIEW) // 활동 리뷰일 때
@@ -56,7 +56,7 @@ class CreatePostRequestDtoTest {
             .build();
 
         // when
-        Set<ConstraintViolation<CreatePostRequestDto>> violations = validator.validate(requestDto);
+        Set<ConstraintViolation<PostRequestDto>> violations = validator.validate(requestDto);
 
         // then
         assertTrue(violations.isEmpty()); // 유효성 검증 성공
@@ -65,7 +65,7 @@ class CreatePostRequestDtoTest {
     @Test
     void testValidActivityId_WhenPostCategoryIsNotActivityReview_AndActivityIdIsNull_ShouldPass() {
         // given
-        CreatePostRequestDto requestDto = CreatePostRequestDto.builder()
+        PostRequestDto requestDto = PostRequestDto.builder()
             .title("Test Post")
             .content("This is a test post.")
             .postCategory(PostCategory.PERSONAL) // 개인 게시물
@@ -73,7 +73,7 @@ class CreatePostRequestDtoTest {
             .build();
 
         // when
-        Set<ConstraintViolation<CreatePostRequestDto>> violations = validator.validate(requestDto);
+        Set<ConstraintViolation<PostRequestDto>> violations = validator.validate(requestDto);
 
         // then
         assertTrue(violations.isEmpty()); // 유효성 검증 성공


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 게시물 정보를 수정하는 기능 구현
- 수정 시 이미지 데이터의 일관성/무결성 유의
- 크루원 권한 체크(크루원이어야 하며, 자기 자신의 게시물만 수정 가능, 공지사항 등록은 Member 권한으로는 불가)

### 이 PR에서 변경된 사항
- PostController
  - PUT "/crew/{crewId}/post" updatePost
  - dto 변환
- PostService
  - updatePost() : 크루원 권한체크, 활동후기 게시판 아니면 activityId는 null 초기화, 저장된 Post 데이터 가져오기, 이미지파일 삭제 / 추가 로직
- PostEntity
  - updatePost() : dto로 전달받은 수정사항 업데이트
  - savePostImages() : 이미지 저장
  - addPostImages() : 이미지 추가

Dto
- PostRequestDto : CreatePostRequestDto 명칭 변경
- UpdatePostRequestDto : PostRequestDto 상속
- PostResponseDto : image파일 서명된 Url 형태로 반환

기타
- ActivityIdValidator : 상위계층의 클래스의 필드값도 찾아올 수 있도록 수정

테스트
- api : 기본 게시물 수정 테스트
- 테스트코드 : 게시물 수정 테스트(이미지 전체 삭제, 일부 삭제, 추가, 이미지 제외 수정)
### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
