### PR TITLE
Feat post read&delete

### DIFF
--- a/src/main/java/com/example/runningservice/controller/post/PostController.java
+++ b/src/main/java/com/example/runningservice/controller/post/PostController.java
@@ -1,8 +1,8 @@
 package com.example.runningservice.controller.post;
 
-import com.example.runningservice.aop.CrewRoleCheck;
-import com.example.runningservice.dto.post.CreatePostRequestDto;
+import com.example.runningservice.dto.post.PostRequestDto;
 import com.example.runningservice.dto.post.PostResponseDto;
+import com.example.runningservice.dto.post.UpdatePostRequestDto;
 import com.example.runningservice.service.post.PostService;
 import com.example.runningservice.util.LoginUser;
 import com.example.runningservice.util.S3FileUtil;
@@ -27,18 +27,19 @@ public class PostController {
     @PostMapping("/{crewId}/post")
     public ResponseEntity<PostResponseDto> createPost(@LoginUser Long userId,
         @PathVariable Long crewId,
-        @ModelAttribute @Valid CreatePostRequestDto createPostRequestDto) {
+        @ModelAttribute @Valid PostRequestDto postRequestDto) {
 
         return ResponseEntity.ok(PostResponseDto.of(
-            postService.savePost(userId, crewId, createPostRequestDto), s3FileUtil));
+            postService.savePost(userId, crewId, postRequestDto), s3FileUtil));
     }
 
     @PutMapping("/{crewId}/post")
-    @CrewRoleCheck(role = {"LEADER", "STAFF", "MEMBER"})
-    public ResponseEntity<?> updatePost(@LoginUser Long userId,
-        @PathVariable("crewId") Long crewId) {
+    public ResponseEntity<PostResponseDto> updatePost(@LoginUser Long userId,
+        @PathVariable("crewId") Long crewId,
+        @ModelAttribute @Valid UpdatePostRequestDto requestDto) {
 
-        return null;
+        return ResponseEntity.ok(
+            PostResponseDto.of(postService.updatePost(userId, crewId, requestDto), s3FileUtil));
     }
 
 }

--- a/src/main/java/com/example/runningservice/controller/post/PostController.java
+++ b/src/main/java/com/example/runningservice/controller/post/PostController.java
@@ -1,29 +1,54 @@
 package com.example.runningservice.controller.post;
 
+import com.example.runningservice.aop.CrewRoleCheck;
+import com.example.runningservice.dto.post.GetPostDetailResponseDto;
+import com.example.runningservice.dto.post.GetPostRequestDto;
+import com.example.runningservice.dto.post.GetPostSimpleResponseDto;
 import com.example.runningservice.dto.post.PostRequestDto;
 import com.example.runningservice.dto.post.PostResponseDto;
 import com.example.runningservice.dto.post.UpdatePostRequestDto;
+import com.example.runningservice.entity.post.PostEntity;
+import com.example.runningservice.exception.CustomException;
+import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.service.post.PostService;
 import com.example.runningservice.util.LoginUser;
 import com.example.runningservice.util.S3FileUtil;
 import jakarta.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/crew")
+@Slf4j
 public class PostController {
 
     private final PostService postService;
     private final S3FileUtil s3FileUtil;
 
+    private static final int MAX_POST_IDS = 20;  // 삭제할 수 있는 최대 게시물 수
+
+    /**
+     * 게시물 생성
+     */
     @PostMapping("/{crewId}/post")
     public ResponseEntity<PostResponseDto> createPost(@LoginUser Long userId,
         @PathVariable Long crewId,
@@ -33,6 +58,9 @@ public class PostController {
             postService.savePost(userId, crewId, postRequestDto), s3FileUtil));
     }
 
+    /**
+     * 게시물 수정
+     */
     @PutMapping("/{crewId}/post")
     public ResponseEntity<PostResponseDto> updatePost(@LoginUser Long userId,
         @PathVariable("crewId") Long crewId,
@@ -42,4 +70,77 @@ public class PostController {
             PostResponseDto.of(postService.updatePost(userId, crewId, requestDto), s3FileUtil));
     }
 
+    /**
+     * 게시물 목록조회
+     */
+    @GetMapping("/{crewId}/posts")
+    @CrewRoleCheck(role = {"LEADER", "STAFF", "MEMBER"})
+    public ResponseEntity<Page<GetPostSimpleResponseDto>> getPosts(@LoginUser Long userId,
+        @PathVariable Long crewId,
+        @PageableDefault(page = 0, size = 10, direction = Direction.DESC, sort = "createdAt") Pageable pageable,
+        @ModelAttribute
+        GetPostRequestDto.Filter filter) {
+
+        // 공지사항 가져오기
+        Page<PostEntity> noticePosts = postService.getNoticePost(crewId);
+
+        // 일반 게시물 가져오기, 공지사항 수만큼 페이지 사이즈 조정
+        Pageable adjustedPageable = PageRequest.of(pageable.getPageNumber(),
+            pageable.getPageSize() - noticePosts.getSize(), pageable.getSort());
+        Page<PostEntity> posts = postService.getPosts(crewId, adjustedPageable, filter);
+
+        // 공지사항과 일반 게시물 합치기
+        List<GetPostSimpleResponseDto> combinedPosts = new ArrayList<>();
+        combinedPosts.addAll(noticePosts.stream().map(GetPostSimpleResponseDto::of).toList());
+        combinedPosts.addAll(posts.stream().map(GetPostSimpleResponseDto::of).toList());
+
+        // 페이지 정보를 유지하기 위해 PageImpl을 사용하여 반환
+        Page<GetPostSimpleResponseDto> resultPage = new PageImpl<>(combinedPosts, pageable,
+            posts.getTotalElements() + noticePosts.getTotalElements());
+
+        return ResponseEntity.ok(resultPage);
+    }
+
+    /**
+     * 게시물 상세조회
+     */
+    @GetMapping("/{crewId}/post")
+    @CrewRoleCheck(role = {"LEADER", "STAFF", "MEMBER"})
+    public ResponseEntity<GetPostDetailResponseDto> getPost(@LoginUser Long userID,
+        @PathVariable Long crewId,
+        @RequestParam Long postId) {
+
+        PostEntity post = postService.getPost(postId);
+        log.info("post: {}", post);
+
+        return ResponseEntity.ok(
+            GetPostDetailResponseDto.of(post, s3FileUtil));
+    }
+
+    /**
+     * 나의 게시물 삭제
+     */
+    @DeleteMapping("/{crewId}/post")
+    @CrewRoleCheck(role = {"LEADER", "STAFF", "MEMBER"})
+    public ResponseEntity<Void> deletePost(@LoginUser Long userId, @PathVariable Long crewId,
+        @RequestParam Long postId) {
+        postService.deleteMyPost(userId, postId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 여러 게시물 삭제(운영진의 게시판 관리)
+     */
+    @DeleteMapping("/{crewId}/posts")
+    @CrewRoleCheck(role = {"LEADER", "STAFF"})
+    public ResponseEntity<Void> deletePosts(@LoginUser Long userId, @PathVariable Long crewId,
+        @RequestParam List<Long> postIds) {
+
+        if (postIds.size() > MAX_POST_IDS) {
+            throw new CustomException(ErrorCode.MAX_DELETE_SIZE_OVER);
+        }
+
+        postService.deletePosts(postIds);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/runningservice/dto/post/GetPostDetailResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/post/GetPostDetailResponseDto.java
@@ -1,0 +1,52 @@
+package com.example.runningservice.dto.post;
+
+import com.example.runningservice.entity.post.CommentEntity;
+import com.example.runningservice.entity.post.PostEntity;
+import com.example.runningservice.enums.PostCategory;
+import com.example.runningservice.util.S3FileUtil;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetPostDetailResponseDto {
+
+    private Long id;
+    private String memberNickName;
+    private Long crewId;
+    private String title;
+    private PostCategory postCategory;
+    private Long activityId;
+    private String content;
+    private List<String> images = new ArrayList<>();
+    private Boolean isNotice;
+    private List<CommentEntity> comment = new ArrayList<>();
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static GetPostDetailResponseDto of(PostEntity postEntity, S3FileUtil s3FileUtil) {
+        return GetPostDetailResponseDto.builder()
+            .id(postEntity.getId())
+            .crewId(postEntity.getCrewId())
+            .memberNickName(postEntity.getMember().getNickName())
+            .title(postEntity.getTitle())
+            .postCategory(postEntity.getPostCategory())
+            .activityId(postEntity.getActivityId())
+            .content(postEntity.getContent())
+            .images(postEntity.getImages().stream().map(s3FileUtil::createPresignedUrl).collect(
+                Collectors.toList()))
+            .isNotice(postEntity.getIsNotice())
+            .comment(postEntity.getComment())
+            .createdAt(postEntity.getCreatedAt())
+            .updatedAt(postEntity.getUpdatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/example/runningservice/dto/post/GetPostRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/post/GetPostRequestDto.java
@@ -1,0 +1,18 @@
+package com.example.runningservice.dto.post;
+
+import com.example.runningservice.enums.PostCategory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GetPostRequestDto {
+
+    @Getter
+    @Builder
+    public static class Filter {
+        private PostCategory postCategory;
+    }
+}

--- a/src/main/java/com/example/runningservice/dto/post/GetPostSimpleResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/post/GetPostSimpleResponseDto.java
@@ -1,0 +1,31 @@
+package com.example.runningservice.dto.post;
+
+import com.example.runningservice.entity.post.PostEntity;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetPostSimpleResponseDto {
+
+    private Long postId;
+    private String postTitle;
+    private String writerName;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static GetPostSimpleResponseDto of(PostEntity postEntity) {
+        return GetPostSimpleResponseDto.builder()
+            .postId(postEntity.getId())
+            .postTitle(postEntity.getTitle())
+            .writerName(postEntity.getMember().getNickName())
+            .createdAt(postEntity.getCreatedAt())
+            .updatedAt(postEntity.getUpdatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/example/runningservice/dto/post/PostRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/post/PostRequestDto.java
@@ -8,19 +8,19 @@ import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 @RequiredActivityId(categoryType = PostCategory.class, category = "postCategory", idType = Long.class, id = "activityId")
-public class CreatePostRequestDto {
+public class PostRequestDto {
 
     @NotBlank
     @Size(max = 50)
@@ -35,7 +35,7 @@ public class CreatePostRequestDto {
     @Size(max = 500)
     private String content;
 
-    private List<MultipartFile> images = new ArrayList<>();
+    private List<MultipartFile> imagesToUpload = new ArrayList<>();
 
     private Boolean isNotice = false;
 

--- a/src/main/java/com/example/runningservice/dto/post/PostRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/post/PostRequestDto.java
@@ -25,6 +25,7 @@ public class PostRequestDto {
     @NotBlank
     @Size(max = 50)
     private String title;
+    private String memberNickName;
 
     @NotNull
     private PostCategory postCategory;

--- a/src/main/java/com/example/runningservice/dto/post/PostResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/post/PostResponseDto.java
@@ -33,7 +33,7 @@ public class PostResponseDto {
             .title(postEntity.getTitle())
             .postCategory(postEntity.getPostCategory())
             .content(postEntity.getContent())
-            .imageUrls(postEntity.getImageUrls().stream().map(s3FileUtil::createPresignedUrl).collect(
+            .imageUrls(postEntity.getImages().stream().map(s3FileUtil::createPresignedUrl).collect(
                 Collectors.toList()))
             .isNotice(postEntity.getIsNotice())
             .comment(postEntity.getComment())

--- a/src/main/java/com/example/runningservice/dto/post/PostResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/post/PostResponseDto.java
@@ -27,7 +27,7 @@ public class PostResponseDto {
     public static PostResponseDto of(PostEntity postEntity, S3FileUtil s3FileUtil) {
         return PostResponseDto.builder()
             .postId(postEntity.getId())
-            .memberId(postEntity.getMemberId())
+            .memberId(postEntity.getMember().getId())
             .crewId(postEntity.getCrewId())
             .activityId(postEntity.getActivityId())
             .title(postEntity.getTitle())

--- a/src/main/java/com/example/runningservice/dto/post/UpdatePostRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/post/UpdatePostRequestDto.java
@@ -1,0 +1,28 @@
+package com.example.runningservice.dto.post;
+
+import com.example.runningservice.enums.PostCategory;
+import com.example.runningservice.util.validator.RequiredActivityId;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@SuperBuilder
+@RequiredActivityId(categoryType = PostCategory.class, category = "postCategory", idType = Long.class, id = "activityId")
+public class UpdatePostRequestDto extends PostRequestDto {
+
+    @NotNull
+    private Long postId;
+    @NotNull
+    private Boolean deleteAllImages;
+    private List<String> imagesToDelete = new ArrayList<>();
+
+}

--- a/src/main/java/com/example/runningservice/entity/post/PostEntity.java
+++ b/src/main/java/com/example/runningservice/entity/post/PostEntity.java
@@ -1,6 +1,7 @@
 package com.example.runningservice.entity.post;
 
-import com.example.runningservice.dto.post.CreatePostRequestDto;
+import com.example.runningservice.dto.post.PostRequestDto;
+import com.example.runningservice.dto.post.UpdatePostRequestDto;
 import com.example.runningservice.entity.BaseEntity;
 import com.example.runningservice.enums.PostCategory;
 import jakarta.annotation.Nullable;
@@ -18,6 +19,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -54,7 +56,7 @@ public class PostEntity extends BaseEntity {
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "post_images", joinColumns = @JoinColumn(name = "post_id"))
     @Column(name = "images")
-    private List<String> imageUrls = new ArrayList<>();
+    private List<String> images = new ArrayList<>();
 
     private Boolean isNotice;
 
@@ -63,22 +65,33 @@ public class PostEntity extends BaseEntity {
     private List<CommentEntity> comment = new ArrayList<>();
 
 
-    public static PostEntity of(Long memberId, Long crewId, CreatePostRequestDto createPostRequestDto) {
+    public static PostEntity of(Long memberId, Long crewId, PostRequestDto postRequestDto) {
         return PostEntity.builder()
-            .title(createPostRequestDto.getTitle())
+            .title(postRequestDto.getTitle())
             .memberId(memberId)
             .crewId(crewId)
-            .postCategory(createPostRequestDto.getPostCategory())
-            .activityId(createPostRequestDto.getActivityId())
-            .content(createPostRequestDto.getContent())
-            .isNotice(createPostRequestDto.getIsNotice())
+            .postCategory(postRequestDto.getPostCategory())
+            .activityId(postRequestDto.getActivityId())
+            .content(postRequestDto.getContent())
+            .isNotice(postRequestDto.getIsNotice())
             .build();
     }
 
-    public void savePostImages(List<String> imageUrls) {
-        if (this.imageUrls == null) {
-            this.imageUrls = new ArrayList<>(); // 명시적으로 다시 초기화
+    public void addPostImages(Collection<String> imageUrls) {
+        if (this.images == null) {
+            this.images = new ArrayList<>(); // 명시적으로 다시 초기화
         }
-        this.imageUrls.addAll(imageUrls);
+        this.images.addAll(imageUrls);
+    }
+
+    public void savePostImages(Collection<String> imageUrls) {
+        this.images = new ArrayList<>(imageUrls);
+    }
+
+    public void updatePost(UpdatePostRequestDto updatePostRequestDto) {
+        this.title = updatePostRequestDto.getTitle();
+        this.content = updatePostRequestDto.getContent();
+        this.activityId = updatePostRequestDto.getActivityId();
+        this.isNotice = updatePostRequestDto.getIsNotice();
     }
 }

--- a/src/main/java/com/example/runningservice/entity/post/PostEntity.java
+++ b/src/main/java/com/example/runningservice/entity/post/PostEntity.java
@@ -3,6 +3,7 @@ package com.example.runningservice.entity.post;
 import com.example.runningservice.dto.post.PostRequestDto;
 import com.example.runningservice.dto.post.UpdatePostRequestDto;
 import com.example.runningservice.entity.BaseEntity;
+import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.enums.PostCategory;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.CollectionTable;
@@ -16,6 +17,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
@@ -39,8 +41,9 @@ public class PostEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
-    private Long memberId;
+    @JoinColumn(name = "member_id")
+    @ManyToOne
+    private MemberEntity member;
     @NotNull
     private Long crewId;
     @Nullable
@@ -65,10 +68,10 @@ public class PostEntity extends BaseEntity {
     private List<CommentEntity> comment = new ArrayList<>();
 
 
-    public static PostEntity of(Long memberId, Long crewId, PostRequestDto postRequestDto) {
+    public static PostEntity of(Long crewId, PostRequestDto postRequestDto, MemberEntity memberEntity) {
         return PostEntity.builder()
             .title(postRequestDto.getTitle())
-            .memberId(memberId)
+            .member(memberEntity)
             .crewId(crewId)
             .postCategory(postRequestDto.getPostCategory())
             .activityId(postRequestDto.getActivityId())

--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     NOT_FOUND_RUN_RECORD(HttpStatus.NOT_FOUND, "러닝 기록을 찾을 수 없습니다."),
     NOT_FOUND_RUN_GOAL(HttpStatus.NOT_FOUND, "러닝 목표를 찾을 수 없습니다."),
     INVALID_RUN_ARGUMENT(HttpStatus.BAD_REQUEST, "러닝 기록이 없거나 유저정보가 없습니다."),
+    NOT_FOUND_POST(HttpStatus.NOT_FOUND, "해당 게시물을 찾을 수 없습니다."),
 
     //크루가입
     ALREADY_EXIST_PENDING_JOIN_APPLY(HttpStatus.BAD_REQUEST, "이미 거압 숭안 대기중입니다."),

--- a/src/main/java/com/example/runningservice/exception/ErrorCode.java
+++ b/src/main/java/com/example/runningservice/exception/ErrorCode.java
@@ -45,6 +45,8 @@ public enum ErrorCode {
     NOT_FOUND_RUN_GOAL(HttpStatus.NOT_FOUND, "러닝 목표를 찾을 수 없습니다."),
     INVALID_RUN_ARGUMENT(HttpStatus.BAD_REQUEST, "러닝 기록이 없거나 유저정보가 없습니다."),
     NOT_FOUND_POST(HttpStatus.NOT_FOUND, "해당 게시물을 찾을 수 없습니다."),
+    NOT_FOUND_SOME_POST(HttpStatus.BAD_REQUEST, "일부 게시물을 찾을 수 없습니다."),
+    MAX_DELETE_SIZE_OVER(HttpStatus.BAD_REQUEST, "삭제할 수 있는 게시물 최대 개수를 초과했습니다"),
 
     //크루가입
     ALREADY_EXIST_PENDING_JOIN_APPLY(HttpStatus.BAD_REQUEST, "이미 거압 숭안 대기중입니다."),

--- a/src/main/java/com/example/runningservice/repository/post/PostRepository.java
+++ b/src/main/java/com/example/runningservice/repository/post/PostRepository.java
@@ -1,10 +1,11 @@
 package com.example.runningservice.repository.post;
 
 import com.example.runningservice.entity.post.PostEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
-
+    Optional<PostEntity> findByIdAndMemberId(Long id, Long userId);
 }

--- a/src/main/java/com/example/runningservice/repository/post/PostRepository.java
+++ b/src/main/java/com/example/runningservice/repository/post/PostRepository.java
@@ -2,10 +2,17 @@ package com.example.runningservice.repository.post;
 
 import com.example.runningservice.entity.post.PostEntity;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PostRepository extends JpaRepository<PostEntity, Long> {
-    Optional<PostEntity> findByIdAndMemberId(Long id, Long userId);
+public interface PostRepository extends JpaRepository<PostEntity, Long>, PostRepositoryCustom {
+
+    Optional<PostEntity> findByIdAndMember_Id(Long id, Long userId);
+
+    Page<PostEntity> findAllByCrewIdAndIsNoticeOrderByCreatedAtDesc(Long crewId, Boolean isNotice,
+        Pageable pageable);
+
 }

--- a/src/main/java/com/example/runningservice/repository/post/PostRepositoryCustom.java
+++ b/src/main/java/com/example/runningservice/repository/post/PostRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.example.runningservice.repository.post;
+
+import com.example.runningservice.dto.post.GetPostRequestDto;
+import com.example.runningservice.entity.post.PostEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostRepositoryCustom {
+
+    Page<PostEntity> findAllNotNoticeByCrewIdAndFilter(Long crewId, GetPostRequestDto.Filter filter,
+        Pageable pageable);
+}

--- a/src/main/java/com/example/runningservice/repository/post/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/runningservice/repository/post/PostRepositoryCustomImpl.java
@@ -1,0 +1,56 @@
+package com.example.runningservice.repository.post;
+
+import com.example.runningservice.dto.post.GetPostRequestDto.Filter;
+import com.example.runningservice.entity.post.PostEntity;
+import com.example.runningservice.entity.post.QPostEntity;
+import com.example.runningservice.enums.PostCategory;
+import com.example.runningservice.util.QueryDslUtil;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class PostRepositoryCustomImpl implements PostRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public Page<PostEntity> findAllNotNoticeByCrewIdAndFilter(Long crewId, Filter filter,
+        Pageable pageable) {
+
+        QPostEntity post = QPostEntity.postEntity;
+
+        List<PostEntity> posts = queryFactory.selectFrom(post)
+            .where(
+                post.crewId.eq(crewId),
+                postCategoryEq(filter.getPostCategory()),
+                post.isNotice.eq(false)
+            )
+            .orderBy(QueryDslUtil.getAllOrderSpecifiers(pageable,
+                "postEntity")) //page -> orderSpecifier
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+        // 총 개수 계산
+
+        Long total = queryFactory.select(post.count())
+            .from(post)
+            .where(
+                post.crewId.eq(crewId),
+                postCategoryEq(filter.getPostCategory()),
+                post.isNotice.eq(false)
+            )
+            .fetchOne();
+
+        return new PageImpl<>(posts, pageable, total != null ? total : 0);
+    }
+
+    private BooleanExpression postCategoryEq(PostCategory postCategory) {
+        return postCategory != null ? QPostEntity.postEntity.postCategory.eq(postCategory) : null;
+    }
+}

--- a/src/main/java/com/example/runningservice/service/post/PostService.java
+++ b/src/main/java/com/example/runningservice/service/post/PostService.java
@@ -49,7 +49,7 @@ public class PostService {
 
         requestDto.setActivityIdNullNotWithActivityReview();
 
-        PostEntity postEntity = postRepository.findById(requestDto.getPostId())
+        PostEntity postEntity = postRepository.findByIdAndMemberId(requestDto.getPostId(), userId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
 
         postEntity.updatePost(requestDto);

--- a/src/main/java/com/example/runningservice/service/post/PostService.java
+++ b/src/main/java/com/example/runningservice/service/post/PostService.java
@@ -1,12 +1,15 @@
 package com.example.runningservice.service.post;
 
+import com.example.runningservice.dto.post.GetPostRequestDto;
 import com.example.runningservice.dto.post.PostRequestDto;
 import com.example.runningservice.dto.post.UpdatePostRequestDto;
 import com.example.runningservice.entity.CrewMemberEntity;
+import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.entity.post.PostEntity;
 import com.example.runningservice.enums.CrewRole;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.MemberRepository;
 import com.example.runningservice.repository.crewMember.CrewMemberRepository;
 import com.example.runningservice.repository.post.PostRepository;
 import com.example.runningservice.util.S3FileUtil;
@@ -15,24 +18,37 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PostService {
 
     private final PostRepository postRepository;
     private final CrewMemberRepository crewMemberRepository;
+    private final MemberRepository memberRepository;
     private final S3FileUtil s3FileUtil;
+
+    private static final List<String> ALLOWED_SORT_FIELD = new ArrayList<>(List.of("createdAt"));
 
     @Transactional
     public PostEntity savePost(Long userId, Long crewId, PostRequestDto postRequestDto) {
         validateCrewRole(userId, crewId, postRequestDto);
 
+        //활동후기가 아닌 경우 activityId를 null로 저장
         postRequestDto.setActivityIdNullNotWithActivityReview();
 
-        PostEntity postEntity = PostEntity.of(userId, crewId, postRequestDto);
+        MemberEntity memberEntity = memberRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        PostEntity postEntity = PostEntity.of(crewId, postRequestDto, memberEntity);
 
         postEntity = postRepository.save(postEntity);
 
@@ -49,7 +65,7 @@ public class PostService {
 
         requestDto.setActivityIdNullNotWithActivityReview();
 
-        PostEntity postEntity = postRepository.findByIdAndMemberId(requestDto.getPostId(), userId)
+        PostEntity postEntity = postRepository.findByIdAndMember_Id(requestDto.getPostId(), userId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
 
         postEntity.updatePost(requestDto);
@@ -77,6 +93,49 @@ public class PostService {
         return postEntity;
     }
 
+    @Transactional
+    public Page<PostEntity> getPosts(Long crewId, Pageable pageable,
+        GetPostRequestDto.Filter filter) {
+
+        //정렬기준 검증(정해진 정렬기준만 요청 가능)
+        validateSort(pageable);
+
+        //필터값 반영하여 공지사항이 아닌 게시글 가져오기
+        return postRepository.findAllNotNoticeByCrewIdAndFilter(crewId, filter, pageable);
+    }
+
+    @Transactional
+    public Page<PostEntity> getNoticePost(Long crewId) {
+        Pageable topFive = PageRequest.of(0, 5, Sort.by("createdAt").descending());
+
+        return postRepository.findAllByCrewIdAndIsNoticeOrderByCreatedAtDesc(
+            crewId, true, topFive);
+    }
+
+    @Transactional
+    public PostEntity getPost(Long postId) {
+        return postRepository.findById(postId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
+    }
+
+    @Transactional
+    public void deleteMyPost(Long userId, Long postId) {
+        PostEntity postEntity = postRepository.findByIdAndMember_Id(postId, userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
+
+        postRepository.delete(postEntity);
+    }
+
+    @Transactional
+    public void deletePosts(List<Long> postIds) {
+        List<PostEntity> postEntities = postRepository.findAllById(postIds);
+
+        if (postEntities.size() != postIds.size()) {
+            throw new CustomException(ErrorCode.NOT_FOUND_SOME_POST);
+        }
+
+        postRepository.deleteAllById(postIds);
+    }
 
     private void validateCrewRole(Long userId, Long crewId, PostRequestDto postRequestDto) {
         //크루 회원이어야 함
@@ -89,5 +148,13 @@ public class PostService {
             && postRequestDto.getIsNotice()) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
+    }
+
+    private void validateSort(Pageable pageable) {
+        pageable.getSort().stream().forEach(order -> {
+            if (!ALLOWED_SORT_FIELD.contains(order.getProperty())) {
+                throw new CustomException(ErrorCode.INVALID_SORT);
+            }
+        });
     }
 }

--- a/src/main/java/com/example/runningservice/service/post/PostService.java
+++ b/src/main/java/com/example/runningservice/service/post/PostService.java
@@ -1,6 +1,7 @@
 package com.example.runningservice.service.post;
 
-import com.example.runningservice.dto.post.CreatePostRequestDto;
+import com.example.runningservice.dto.post.PostRequestDto;
+import com.example.runningservice.dto.post.UpdatePostRequestDto;
 import com.example.runningservice.entity.CrewMemberEntity;
 import com.example.runningservice.entity.post.PostEntity;
 import com.example.runningservice.enums.CrewRole;
@@ -9,7 +10,10 @@ import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.crewMember.CrewMemberRepository;
 import com.example.runningservice.repository.post.PostRepository;
 import com.example.runningservice.util.S3FileUtil;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,24 +27,58 @@ public class PostService {
     private final S3FileUtil s3FileUtil;
 
     @Transactional
-    public PostEntity savePost(Long userId, Long crewId, CreatePostRequestDto createPostRequestDto) {
-        validateCrewRole(userId, crewId, createPostRequestDto);
+    public PostEntity savePost(Long userId, Long crewId, PostRequestDto postRequestDto) {
+        validateCrewRole(userId, crewId, postRequestDto);
 
-        createPostRequestDto.setActivityIdNullNotWithActivityReview();
+        postRequestDto.setActivityIdNullNotWithActivityReview();
 
-        PostEntity postEntity = PostEntity.of(userId, crewId, createPostRequestDto);
+        PostEntity postEntity = PostEntity.of(userId, crewId, postRequestDto);
 
         postEntity = postRepository.save(postEntity);
 
-        postEntity.savePostImages(
+        postEntity.addPostImages(
             s3FileUtil.uploadFilesAndReturnFileNames("post", postEntity.getId(),
-                createPostRequestDto.getImages()));
+                postRequestDto.getImagesToUpload()));
+
+        return postEntity;
+    }
+
+    @Transactional
+    public PostEntity updatePost(Long userId, Long crewId, UpdatePostRequestDto requestDto) {
+        validateCrewRole(userId, crewId, requestDto);
+
+        requestDto.setActivityIdNullNotWithActivityReview();
+
+        PostEntity postEntity = postRepository.findById(requestDto.getPostId())
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
+
+        postEntity.updatePost(requestDto);
+
+        //저체삭제 요청일 때
+        if (Boolean.TRUE.equals(requestDto.getDeleteAllImages())) {
+            List<String> images = new ArrayList<>(postEntity.getImages());
+            images.forEach(s3FileUtil::deleteObject);
+            images.clear();
+            postEntity.savePostImages(images);
+        } else if (requestDto.getImagesToDelete() != null) { //일부 이미지 delete 요청
+            Set<String> images = new HashSet<>(postEntity.getImages());
+            requestDto.getImagesToDelete().forEach(e -> {
+                s3FileUtil.deleteObject(e);
+                images.remove(e);
+            });
+            postEntity.savePostImages(images);
+        }
+        //일부 이미지 추가 요청
+        if (requestDto.getImagesToUpload() != null) {
+            postEntity.addPostImages(s3FileUtil.uploadFilesAndReturnFileNames("post",
+                requestDto.getPostId(), requestDto.getImagesToUpload()));
+        }
 
         return postEntity;
     }
 
 
-    private void validateCrewRole(Long userId, Long crewId, CreatePostRequestDto createPostRequestDto) {
+    private void validateCrewRole(Long userId, Long crewId, PostRequestDto postRequestDto) {
         //크루 회원이어야 함
         CrewMemberEntity crewMemberEntity = crewMemberRepository.findByMember_IdAndCrew_Id(userId,
                 crewId)
@@ -48,7 +86,7 @@ public class PostService {
 
         //크루게시물의 공지여부(Leader, Staff 만 가능)
         if (!List.of(CrewRole.LEADER, CrewRole.STAFF).contains(crewMemberEntity.getRole())
-            && createPostRequestDto.getIsNotice()) {
+            && postRequestDto.getIsNotice()) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
     }

--- a/src/main/java/com/example/runningservice/util/QueryDslUtil.java
+++ b/src/main/java/com/example/runningservice/util/QueryDslUtil.java
@@ -1,6 +1,7 @@
 package com.example.runningservice.util;
 
 import com.example.runningservice.entity.QCrewMemberEntity;
+import com.example.runningservice.entity.post.QPostEntity;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -21,6 +22,7 @@ public class QueryDslUtil {
 
     static {
         ENTITY_PATH_MAP.put("crewMemberEntity", new PathBuilder<>(QCrewMemberEntity.class, "crewMemberEntity"));
+        ENTITY_PATH_MAP.put("postEntity", new PathBuilder<>(QPostEntity.class, "postEntity"));
         // 새로운 엔티티가 추가될 때마다 여기에 추가
     }
 

--- a/src/main/java/com/example/runningservice/util/S3FileUtil.java
+++ b/src/main/java/com/example/runningservice/util/S3FileUtil.java
@@ -143,7 +143,6 @@ public class S3FileUtil {
 
         List<String> fileUrls = new ArrayList<>();
         if (!images.isEmpty()) {
-
             for (MultipartFile image : images) {
                 String fileName = prefix + "-" + id + "-" + images.indexOf(image);
                 putObject(fileName, image);

--- a/src/test/java/com/example/runningservice/controller/post/PostControllerTest.java
+++ b/src/test/java/com/example/runningservice/controller/post/PostControllerTest.java
@@ -1,0 +1,171 @@
+package com.example.runningservice.controller.post;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.entity.post.PostEntity;
+import com.example.runningservice.enums.PostCategory;
+import com.example.runningservice.service.post.PostService;
+import com.example.runningservice.util.JwtUtil;
+import com.example.runningservice.util.S3FileUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(PostController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+class PostControllerTest {
+
+    @MockBean
+    private PostService postService;
+
+    @MockBean
+    private S3FileUtil s3FileUtil;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("게시물 개별 조회 테스트")
+    @WithMockUser("USER")
+    void getPostTest() throws Exception {
+        // Given
+        Long crewId = 1L;
+        Long userId = 3L;
+        Long postId = 2L;
+
+        PostEntity postEntity = PostEntity.builder()
+            .id(postId)
+            .title("게시물1")
+            .member(MemberEntity.builder().id(userId).nickName("nick1").build())
+            .crewId(crewId)
+            .content("content")
+            .postCategory(PostCategory.PERSONAL)
+            .isNotice(false)
+            .images(List.of("image1"))
+            .createdAt(LocalDateTime.of(2024, 1, 1, 1, 1))
+            .updatedAt(LocalDateTime.of(2024, 1, 1, 1, 1))
+            .build();
+
+        when(postService.getPost(postId)).thenReturn(postEntity);
+        when(s3FileUtil.createPresignedUrl("image1")).thenReturn("signed_image1");
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders.get("/crew/{crewId}/post", crewId)
+                .param("postId", "2")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(print())
+            .andExpect(jsonPath("$.content").value("content"))  // 3 notice + 3 general posts
+            .andExpect(jsonPath("$.title").value("게시물1"))
+            .andExpect(jsonPath("$.images.size()").value(1))
+            .andExpect(jsonPath("$.images[0]").value("signed_image1"));
+    }
+
+    @Test
+    @DisplayName("게시물 목록 조회 테스트")
+    @WithMockUser("USER")
+    void getPostsTest() throws Exception {
+        // Given
+        Long crewId = 1L;
+
+        PostEntity postEntity1 = PostEntity.builder().id(1L)
+            .member(MemberEntity.builder().nickName("nick1").build()).title("공지사항1").build();
+        PostEntity postEntity2 = PostEntity.builder().id(2L)
+            .member(MemberEntity.builder().nickName("nick1").build()).title("공지사항2").build();
+        PostEntity postEntity3 = PostEntity.builder().id(3L)
+            .member(MemberEntity.builder().nickName("nick1").build()).title("공지사항3").build();
+
+        // Mocking for notice posts
+        List<PostEntity> noticePosts = List.of(postEntity1, postEntity2, postEntity3);
+        Page<PostEntity> noticePostPage = new PageImpl<>(noticePosts, PageRequest.of(0, 5),
+            noticePosts.size());
+
+        PostEntity postEntity4 = PostEntity.builder().id(1L)
+            .member(MemberEntity.builder().nickName("nick2").build()).title("게시물1").build();
+        PostEntity postEntity5 = PostEntity.builder().id(2L)
+            .member(MemberEntity.builder().nickName("nick2").build()).title("게시물2").build();
+        PostEntity postEntity6 = PostEntity.builder().id(3L)
+            .member(MemberEntity.builder().nickName("nick1").build()).title("게시물3").build();
+
+        // Mocking for general posts
+        List<PostEntity> generalPosts = List.of(postEntity4, postEntity5, postEntity6);
+        Page<PostEntity> generalPostPage = new PageImpl<>(generalPosts,
+            PageRequest.of(0, 10 - noticePosts.size()),
+            generalPosts.size());
+
+        Pageable pageable = PageRequest.of(0, 5, Sort.by("createdAt").descending());
+
+        // Mock PostService responses
+        when(postService.getNoticePost(crewId)).thenReturn(noticePostPage);
+        when(postService.getPosts(eq(crewId), argThat(e -> e.getPageNumber() == 0 &&
+                e.getPageSize() == 5 &&
+                e.getSort().equals(Sort.by("createdAt").descending())),
+            argThat(e -> e.getPostCategory().equals(PostCategory.PERSONAL)))).thenReturn(
+            generalPostPage);
+
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders.get("/crew/{crewId}/posts", crewId)
+                .param("page", "0")
+                .param("size", "10")
+                .param("postCategory", "PERSONAL")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(print())
+            .andExpect(jsonPath("$.content", hasSize(6)))  // 3 notice + 3 general posts
+            .andExpect(jsonPath("$.content[0].postTitle").value("공지사항1"))
+            .andExpect(jsonPath("$.content[1].postTitle").value("공지사항2"))
+            .andExpect(jsonPath("$.content[2].postTitle").value("공지사항3"))
+            .andExpect(jsonPath("$.content[3].postTitle").value("게시물1"))
+            .andExpect(jsonPath("$.content[4].postTitle").value("게시물2"));
+    }
+
+
+    @Test
+    @DisplayName("운영진 게시물 삭제 성공 테스트")
+    @WithMockUser("ROLE_USER")
+    void deletePosts_Success() throws Exception {
+        // Given
+        Long crewId = 1L;
+        List<Long> postIds = List.of(1L, 2L, 3L);
+
+        // When & Then
+        mockMvc.perform(delete("/crew/{crewId}/posts", crewId)
+                .param("postIds", "1", "2", "3")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
+
+        // postService.deletePosts 호출 여부 확인
+        verify(postService).deletePosts(postIds);
+    }
+}

--- a/src/test/java/com/example/runningservice/dto/post/PostRequestDtoTest.java
+++ b/src/test/java/com/example/runningservice/dto/post/PostRequestDtoTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class CreatePostRequestDtoTest {
+class PostRequestDtoTest {
 
     private Validator validator;
 
@@ -28,7 +28,7 @@ class CreatePostRequestDtoTest {
     @DisplayName("활동후기 게시판일 때 activityId가 null_실패")
     void testValidActivityId_WhenPostCategoryIsActivityReview_AndActivityIdIsNull_Failed() {
         // given
-        CreatePostRequestDto requestDto = CreatePostRequestDto.builder()
+        PostRequestDto requestDto = PostRequestDto.builder()
             .title("Test Post")
             .content("This is a test post.")
             .postCategory(PostCategory.ACTIVITY_REVIEW) // 활동 리뷰일 때
@@ -36,7 +36,7 @@ class CreatePostRequestDtoTest {
             .build();
 
         // when
-        Set<ConstraintViolation<CreatePostRequestDto>> violations = validator.validate(requestDto);
+        Set<ConstraintViolation<PostRequestDto>> violations = validator.validate(requestDto);
 
         // then
         assertEquals(1, violations.size()); // 1개의 유효성 검증 실패
@@ -48,7 +48,7 @@ class CreatePostRequestDtoTest {
     @Test
     void testValidActivityId_WhenPostCategoryIsActivityReview_AndActivityIdIsProvided_Success() {
         // given
-        CreatePostRequestDto requestDto = CreatePostRequestDto.builder()
+        PostRequestDto requestDto = PostRequestDto.builder()
             .title("Test Post")
             .content("This is a test post.")
             .postCategory(PostCategory.ACTIVITY_REVIEW) // 활동 리뷰일 때
@@ -56,7 +56,7 @@ class CreatePostRequestDtoTest {
             .build();
 
         // when
-        Set<ConstraintViolation<CreatePostRequestDto>> violations = validator.validate(requestDto);
+        Set<ConstraintViolation<PostRequestDto>> violations = validator.validate(requestDto);
 
         // then
         assertTrue(violations.isEmpty()); // 유효성 검증 성공
@@ -65,7 +65,7 @@ class CreatePostRequestDtoTest {
     @Test
     void testValidActivityId_WhenPostCategoryIsNotActivityReview_AndActivityIdIsNull_ShouldPass() {
         // given
-        CreatePostRequestDto requestDto = CreatePostRequestDto.builder()
+        PostRequestDto requestDto = PostRequestDto.builder()
             .title("Test Post")
             .content("This is a test post.")
             .postCategory(PostCategory.PERSONAL) // 개인 게시물
@@ -73,7 +73,7 @@ class CreatePostRequestDtoTest {
             .build();
 
         // when
-        Set<ConstraintViolation<CreatePostRequestDto>> violations = validator.validate(requestDto);
+        Set<ConstraintViolation<PostRequestDto>> violations = validator.validate(requestDto);
 
         // then
         assertTrue(violations.isEmpty()); // 유효성 검증 성공

--- a/src/test/java/com/example/runningservice/service/post/PostServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/post/PostServiceTest.java
@@ -21,6 +21,7 @@ import com.example.runningservice.enums.CrewRole;
 import com.example.runningservice.enums.PostCategory;
 import com.example.runningservice.exception.CustomException;
 import com.example.runningservice.exception.ErrorCode;
+import com.example.runningservice.repository.MemberRepository;
 import com.example.runningservice.repository.crewMember.CrewMemberRepository;
 import com.example.runningservice.repository.post.PostRepository;
 import com.example.runningservice.util.S3FileUtil;
@@ -48,6 +49,9 @@ class PostServiceTest {
 
     @Mock
     CrewMemberRepository crewMemberRepository;
+
+    @Mock
+    MemberRepository memberRepository;
 
     @Mock
     S3FileUtil s3FileUtil;
@@ -94,10 +98,14 @@ class PostServiceTest {
             .isNotice(requestDto.getIsNotice())
             .build();
 
+        MemberEntity member = MemberEntity.builder()
+            .id(userId)
+            .build();
+
         CrewMemberEntity crewMember = CrewMemberEntity.builder()
             .id(crewMemberId)
             .crew(CrewEntity.builder().id(crewId).build())
-            .member(MemberEntity.builder().id(userId).build())
+            .member(member)
             .role(CrewRole.MEMBER)
             .roleOrder(CrewRole.MEMBER.getOrder())
             .build();
@@ -109,6 +117,7 @@ class PostServiceTest {
             i.getPostCategory().equals(postEntity.getPostCategory()) &&
             i.getIsNotice().equals(postEntity.getIsNotice())))).thenReturn(postEntity);
 
+        when(memberRepository.findById(userId)).thenReturn(Optional.of(member));
         when(s3FileUtil.uploadFilesAndReturnFileNames("post", postId,
             requestDto.getImagesToUpload())).thenReturn(List.of("post-1-0", "post-1-1"));
 
@@ -255,10 +264,12 @@ class PostServiceTest {
             .isNotice(requestDto.getIsNotice())
             .build();
 
+        MemberEntity member = MemberEntity.builder().id(userId).build();
+
         CrewMemberEntity crewMember = CrewMemberEntity.builder()
             .id(crewMemberId)
             .crew(CrewEntity.builder().id(crewId).build())
-            .member(MemberEntity.builder().id(userId).build())
+            .member(member)
             .role(CrewRole.MEMBER)
             .roleOrder(CrewRole.MEMBER.getOrder())
             .build();
@@ -272,6 +283,7 @@ class PostServiceTest {
 
         when(s3FileUtil.uploadFilesAndReturnFileNames("post", postId,
             requestDto.getImagesToUpload())).thenReturn(List.of("post-1-0", "post-1-1"));
+        when(memberRepository.findById(userId)).thenReturn(Optional.of(member));
 
         //when
         PostEntity result = postService.savePost(userId, crewId, requestDto);
@@ -325,7 +337,7 @@ class PostServiceTest {
 
         when(crewMemberRepository.findByMember_IdAndCrew_Id(userId, crewId)).thenReturn(
             Optional.of(crewMember));
-        when(postRepository.findById(postId)).thenReturn(Optional.of(postEntity));
+        when(postRepository.findByIdAndMember_Id(postId, userId)).thenReturn(Optional.of(postEntity));
 
         //when
         PostEntity result = postService.updatePost(userId, crewId, requestDto);
@@ -375,7 +387,7 @@ class PostServiceTest {
 
         when(crewMemberRepository.findByMember_IdAndCrew_Id(userId, crewId)).thenReturn(
             Optional.of(crewMember));
-        when(postRepository.findById(postId)).thenReturn(Optional.of(postEntity));
+        when(postRepository.findByIdAndMember_Id(postId, userId)).thenReturn(Optional.of(postEntity));
 
         //when
         PostEntity result = postService.updatePost(userId, crewId, requestDto);
@@ -433,7 +445,7 @@ class PostServiceTest {
 
         when(crewMemberRepository.findByMember_IdAndCrew_Id(userId, crewId)).thenReturn(
             Optional.of(crewMember));
-        when(postRepository.findById(postId)).thenReturn(Optional.of(postEntity));
+        when(postRepository.findByIdAndMember_Id(postId, userId)).thenReturn(Optional.of(postEntity));
         when(s3FileUtil.uploadFilesAndReturnFileNames("post", postId,
             requestDto.getImagesToUpload())).thenReturn(List.of("test3"));
         //when
@@ -485,7 +497,7 @@ class PostServiceTest {
 
         when(crewMemberRepository.findByMember_IdAndCrew_Id(userId, crewId)).thenReturn(
             Optional.of(crewMember));
-        when(postRepository.findById(postId)).thenReturn(Optional.of(postEntity));
+        when(postRepository.findByIdAndMember_Id(postId, userId)).thenReturn(Optional.of(postEntity));
         //when
         PostEntity result = postService.updatePost(userId, crewId, requestDto);
 


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 페이지네이션 형태로 여러 게시물의 리스트를 조회할 수 있다. 
- 개별 게시물을 상세조회할 수 있다. 
- 개별 게시물을 삭제할 수 있다. 
- 운영진은 여러 게시물을 선택(최대 20개)하여 삭제할 수 있다. 

### 이 PR에서 변경된 사항
- PostController
  - GET "/crew/{crewId}/posts" getPosts
    - 공지사항 데이터, 일반게시글 데이터 가져와서 하나의 dto 페이지로 합쳐서 응답
    <!-- 본 변경사항의 코드 -->
    ```
        // 공지사항 가져오기
        Page<PostEntity> noticePosts = postService.getNoticePost(crewId);

        // 일반 게시물 가져오기, 공지사항 수만큼 페이지 사이즈 조정
        Pageable adjustedPageable = PageRequest.of(pageable.getPageNumber(),
            pageable.getPageSize() - noticePosts.getSize(), pageable.getSort());
        Page<PostEntity> posts = postService.getPosts(crewId, adjustedPageable, filter);

        // 공지사항과 일반 게시물 합치기
        List<GetPostSimpleResponseDto> combinedPosts = new ArrayList<>();
        combinedPosts.addAll(noticePosts.stream().map(GetPostSimpleResponseDto::of).toList());
        combinedPosts.addAll(posts.stream().map(GetPostSimpleResponseDto::of).toList());

        // 페이지 정보를 유지하기 위해 PageImpl을 사용하여 반환
        Page<GetPostSimpleResponseDto> resultPage = new PageImpl<>(combinedPosts, pageable,
            posts.getTotalElements() + noticePosts.getTotalElements());

        return ResponseEntity.ok(resultPage);
    ```
  - GET "/crew/{crewId}/post" getPost
  - DELETE "/crew/{crewId}/post" deletePost
  - DELETE "/crew/{crewId}/posts" deletePosts
  - dto 변환
- PostService
  - getPosts() : 페이지네이션 요청값 반영하여 게시물 가져오기
    - 관련 쿼리
      ```
        public Page<PostEntity> findAllNotNoticeByCrewIdAndFilter(Long crewId, Filter filter,
        Pageable pageable) {

        QPostEntity post = QPostEntity.postEntity;

        List<PostEntity> posts = queryFactory.selectFrom(post)
            .where(
                post.crewId.eq(crewId),
                postCategoryEq(filter.getPostCategory()),
                post.isNotice.eq(false)
            )
            .orderBy(QueryDslUtil.getAllOrderSpecifiers(pageable,
                "postEntity")) //page -> orderSpecifier
            .offset(pageable.getOffset())
            .limit(pageable.getPageSize())
            .fetch();
        // 총 개수 계산

        Long total = queryFactory.select(post.count())
            .from(post)
            .where(
                post.crewId.eq(crewId),
                postCategoryEq(filter.getPostCategory()),
                post.isNotice.eq(false)
            )
            .fetchOne();

        return new PageImpl<>(posts, pageable, total != null ? total : 0);
       }
      ```
  - getNoticePost() : 최대 5개의 공지사항 가져오기      
  - deleteMyPost() : 게시물 삭제(자기 게시물 삭제)
  - deletePosts() : 복수의 게시물 삭제(운영진 권한)
- PostEntity
  - MemberEntity를 필드에 추가
- PostRequestDto, PostResponseDto
  - memberNickName 필드 추가
- GetPostSimpleResponseDto
  - 목록조회용 DTO
- GetPostDetailResponseDto
  - 상세조회용 DTO

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
