### PR TITLE
fix - RunRecord에서 빌더패턴 및 CRUD 구조 변경

### DIFF
--- a/src/main/java/com/example/runningservice/dto/runRecord/RunRecordRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/runRecord/RunRecordRequestDto.java
@@ -1,6 +1,12 @@
 package com.example.runningservice.dto.runRecord;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.entity.RunGoalEntity;
+import com.example.runningservice.entity.RunRecordEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,5 +21,33 @@ public class RunRecordRequestDto {
     private Double distance = 0.0;
     private String runningTime = "00:00:00";
     private String pace = "00:00";
-    private LocalDateTime runningDate;
+    private LocalDate runningDate;
+
+    public RunRecordEntity toEntity(MemberEntity member, RunGoalEntity goal) {
+        // transformDTO 메소드를 통해 runningTime과 pace를 정수형으로 변환
+        Map<String, Integer> timeMap = transformDTO();
+        return RunRecordEntity.builder()
+                .userId(member)
+                .goalId(goal)
+                .distance(this.distance)
+                .runningTime(timeMap.get("runningTime"))
+                .pace(timeMap.get("pace"))
+                .runningDate(this.runningDate)
+                .build();
+    }
+
+    private Map<String, Integer> transformDTO() {
+        Map<String, Integer> map = new HashMap<>();
+        // runningTime 시:분:초 -> sec 변환
+        String[] runningTimes = this.runningTime.split(":");
+        int runningTime = Integer.parseInt(runningTimes[0]) * 3600 + Integer.parseInt(runningTimes[1]) * 60 + Integer.parseInt(runningTimes[2]);
+        map.put("runningTime", runningTime);
+
+        // pace 분:초 -> sec 변환
+        String[] paces = this.pace.split(":");
+        int pace = Integer.parseInt(paces[0]) * 60 + Integer.parseInt(paces[1]);
+        map.put("pace", pace);
+
+        return map;
+    }
 }

--- a/src/main/java/com/example/runningservice/dto/runRecord/RunRecordResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/runRecord/RunRecordResponseDto.java
@@ -1,6 +1,9 @@
 package com.example.runningservice.dto.runRecord;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+
+import com.example.runningservice.entity.RunRecordEntity;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,7 +16,20 @@ public class RunRecordResponseDto {
     private Integer runningTime;
     private Integer pace;
     private Integer runCount;
-    private LocalDateTime runningDate;
+    private LocalDate runningDate;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    public static RunRecordResponseDto fromEntity(RunRecordEntity entity) {
+        return RunRecordResponseDto.builder()
+                .id(entity.getId())
+                .userId(entity.getUserId().getId())
+                .distance(entity.getDistance())
+                .runningTime(entity.getRunningTime())
+                .pace(entity.getPace())
+                .runningDate(entity.getRunningDate())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/example/runningservice/entity/RunRecordEntity.java
+++ b/src/main/java/com/example/runningservice/entity/RunRecordEntity.java
@@ -7,6 +7,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -42,9 +44,11 @@ public class RunRecordEntity {
 
     private Integer runningTime;
 
-    private LocalDateTime runningDate;
+    private LocalDate runningDate;
     @CreatedDate
+    @Setter
     private LocalDateTime createdAt;
     @LastModifiedDate
+    @Setter
     private LocalDateTime updatedAt;
 }


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
RunRecord에서 빌더패턴 및 req/resp dto로 toEntity FromEntity 메소드를 이동하여 CRUD 구조 변경
### 이 PR에서 변경된 사항
req/resp dto - 생성자및 @Builder 추가, toEntity FromEntity 이동
### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
