### PR TITLE
fix & feat - 재정의된 RunGoal

### DIFF
--- a/src/main/java/com/example/runningservice/controller/RunGoalController.java
+++ b/src/main/java/com/example/runningservice/controller/RunGoalController.java
@@ -5,6 +5,7 @@ import com.example.runningservice.dto.runGoal.RunGoalResponseDto;
 import com.example.runningservice.service.RunGoalService;
 import com.example.runningservice.util.LoginUser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,45 +22,43 @@ public class RunGoalController {
      */
     @GetMapping
     public ResponseEntity<List<RunGoalResponseDto>> getAllRunGoals() {
-        List<RunGoalResponseDto> runGoals = runGoalService.findAll();
-        return ResponseEntity.ok(runGoals);
-    }
-
-    /**
-     * 러닝 목표 조회
-     */
-    @GetMapping("/{runGoalId}")
-    public ResponseEntity<RunGoalResponseDto> getRunGoalById(@PathVariable Long runGoalId) {
-        RunGoalResponseDto runGoal = runGoalService.findById(runGoalId);
-        return ResponseEntity.ok(runGoal);
+        List<RunGoalResponseDto> responseDtoList = runGoalService.getAllRunGoals();
+        return ResponseEntity.ok(responseDtoList);
     }
 
     /**
      * 사용자 러닝 목표(전체) 조회
      */
     @GetMapping("/my")
-    public ResponseEntity<List<RunGoalResponseDto>> getRunGoalByUserId(@LoginUser Long loginId) {
-        List<RunGoalResponseDto> runGoals = runGoalService.findByUserId(loginId);
-        return ResponseEntity.ok(runGoals);
+    public ResponseEntity<List<RunGoalResponseDto>> getUserRunGoals(@LoginUser Long userId) {
+        List<RunGoalResponseDto> responseDtoList = runGoalService.getUserRunGoals(userId);
+        return ResponseEntity.ok(responseDtoList);
+    }
+
+    /**
+     * 러닝 목표 조회
+     */
+    @GetMapping("/{runGoalId}")
+    public ResponseEntity<RunGoalResponseDto> getRunGoal(@PathVariable Long runGoalId) {
+        RunGoalResponseDto responseDto = runGoalService.getRunGoal(runGoalId);
+        return ResponseEntity.ok(responseDto);
     }
 
     /**
      * 러닝 목표 생성
      */
-    @PostMapping
-    public ResponseEntity<RunGoalResponseDto> createRunGoal(@LoginUser Long loginId, @RequestBody RunGoalRequestDto runGoalRequestDto) {
-        RunGoalResponseDto runGoal = runGoalService.createRunGoal(loginId, runGoalRequestDto);
-        return ResponseEntity.status(201).body(runGoal);
+    public ResponseEntity<RunGoalResponseDto> createRunGoal(@RequestBody RunGoalRequestDto runGoalRequestDto) {
+        RunGoalResponseDto responseDto = runGoalService.createRunGoal(runGoalRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
     /**
      * 러닝 목표 수정
      */
     @PutMapping("/{runGoalId}")
-    public ResponseEntity<RunGoalResponseDto> updateRunGoal(
-        @PathVariable Long runGoalId, @RequestBody RunGoalRequestDto runGoalRequestDto) {
-        RunGoalResponseDto runGoal = runGoalService.updateRunGoal(runGoalId, runGoalRequestDto);
-        return ResponseEntity.ok(runGoal);
+    public ResponseEntity<RunGoalResponseDto> updateRunGoal(@PathVariable Long runGoalId, @RequestBody RunGoalRequestDto updatedRunGoalDto) {
+        RunGoalResponseDto responseDto = runGoalService.updateRunGoal(runGoalId, updatedRunGoalDto);
+        return ResponseEntity.ok(responseDto);
     }
 
     /**
@@ -67,7 +66,7 @@ public class RunGoalController {
      */
     @DeleteMapping("/{runGoalId}")
     public ResponseEntity<Void> deleteRunGoal(@PathVariable Long runGoalId) {
-        runGoalService.deleteById(runGoalId);
+        runGoalService.deleteRunGoal(runGoalId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/example/runningservice/dto/runGoal/RunGoalRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/runGoal/RunGoalRequestDto.java
@@ -1,18 +1,38 @@
 package com.example.runningservice.dto.runGoal;
 
-import lombok.AllArgsConstructor;
+import com.example.runningservice.entity.RunGoalEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Getter
 @Builder
-@AllArgsConstructor
 @NoArgsConstructor
 public class RunGoalRequestDto {
-    private Long userId;
-    private Double totalDistance = 0.0;
-    private String totalRunningTime = "00:00:00";
-    private String averagePace = "00:00";
-    private Integer runCount = 0;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private double targetDistance;
+    private double targetPace;
+    private int targetTime;
+
+    @Builder
+    public RunGoalRequestDto(LocalDate startDate, LocalDate endDate, double targetDistance, double targetPace, int targetTime) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.targetDistance = targetDistance;
+        this.targetPace = targetPace;
+        this.targetTime = targetTime;
+    }
+
+    public RunGoalEntity toEntity() {
+        return RunGoalEntity.builder()
+                .startDate(startDate)
+                .endDate(endDate)
+                .targetDistance(targetDistance)
+                .targetPace(targetPace)
+                .targetTime(targetTime)
+                .build();
+    }
 }

--- a/src/main/java/com/example/runningservice/dto/runGoal/RunGoalResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/runGoal/RunGoalResponseDto.java
@@ -1,6 +1,9 @@
 package com.example.runningservice.dto.runGoal;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+
+import com.example.runningservice.entity.RunGoalEntity;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,11 +11,36 @@ import lombok.Getter;
 @Builder
 public class RunGoalResponseDto {
     private Long id;
-    private Long userId;
-    private Double totalDistance;
-    private Integer totalRunningTime;
-    private Integer averagePace;
-    private Integer runCount;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private double targetDistance;
+    private double targetPace;
+    private int targetTime;
+    private boolean achieved;
+    private double achievementRate;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    @Builder
+    public RunGoalResponseDto(Long id, LocalDate startDate, LocalDate endDate, double targetDistance, double targetPace, int targetTime, boolean achieved) {
+        this.id = id;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.targetDistance = targetDistance;
+        this.targetPace = targetPace;
+        this.targetTime = targetTime;
+        this.achieved = achieved;
+    }
+
+    public static RunGoalResponseDto fromEntity(RunGoalEntity entity) {
+        return RunGoalResponseDto.builder()
+                .id(entity.getId())
+                .startDate(entity.getStartDate())
+                .endDate(entity.getEndDate())
+                .targetDistance(entity.getTargetDistance())
+                .targetPace(entity.getTargetPace())
+                .targetTime(entity.getTargetTime())
+                .achieved(entity.isAchieved())
+                .build();
+    }
 }

--- a/src/main/java/com/example/runningservice/dto/runRecord/RunRecordRequestDto.java
+++ b/src/main/java/com/example/runningservice/dto/runRecord/RunRecordRequestDto.java
@@ -1,6 +1,12 @@
 package com.example.runningservice.dto.runRecord;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.example.runningservice.entity.MemberEntity;
+import com.example.runningservice.entity.RunGoalEntity;
+import com.example.runningservice.entity.RunRecordEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,5 +21,33 @@ public class RunRecordRequestDto {
     private Double distance = 0.0;
     private String runningTime = "00:00:00";
     private String pace = "00:00";
-    private LocalDateTime runningDate;
+    private LocalDate runningDate;
+
+    public RunRecordEntity toEntity(MemberEntity member, RunGoalEntity goal) {
+        // transformDTO 메소드를 통해 runningTime과 pace를 정수형으로 변환
+        Map<String, Integer> timeMap = transformDTO();
+        return RunRecordEntity.builder()
+                .userId(member)
+                .goalId(goal)
+                .distance(this.distance)
+                .runningTime(timeMap.get("runningTime"))
+                .pace(timeMap.get("pace"))
+                .runningDate(this.runningDate)
+                .build();
+    }
+
+    private Map<String, Integer> transformDTO() {
+        Map<String, Integer> map = new HashMap<>();
+        // runningTime 시:분:초 -> sec 변환
+        String[] runningTimes = this.runningTime.split(":");
+        int runningTime = Integer.parseInt(runningTimes[0]) * 3600 + Integer.parseInt(runningTimes[1]) * 60 + Integer.parseInt(runningTimes[2]);
+        map.put("runningTime", runningTime);
+
+        // pace 분:초 -> sec 변환
+        String[] paces = this.pace.split(":");
+        int pace = Integer.parseInt(paces[0]) * 60 + Integer.parseInt(paces[1]);
+        map.put("pace", pace);
+
+        return map;
+    }
 }

--- a/src/main/java/com/example/runningservice/dto/runRecord/RunRecordResponseDto.java
+++ b/src/main/java/com/example/runningservice/dto/runRecord/RunRecordResponseDto.java
@@ -1,6 +1,9 @@
 package com.example.runningservice.dto.runRecord;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+
+import com.example.runningservice.entity.RunRecordEntity;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,7 +16,20 @@ public class RunRecordResponseDto {
     private Integer runningTime;
     private Integer pace;
     private Integer runCount;
-    private LocalDateTime runningDate;
+    private LocalDate runningDate;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    public static RunRecordResponseDto fromEntity(RunRecordEntity entity) {
+        return RunRecordResponseDto.builder()
+                .id(entity.getId())
+                .userId(entity.getUserId().getId())
+                .distance(entity.getDistance())
+                .runningTime(entity.getRunningTime())
+                .pace(entity.getPace())
+                .runningDate(entity.getRunningDate())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/example/runningservice/entity/RunGoalEntity.java
+++ b/src/main/java/com/example/runningservice/entity/RunGoalEntity.java
@@ -5,14 +5,14 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -26,21 +26,29 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class RunGoalEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Setter
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "member_id", nullable = false)
-    private MemberEntity userId;
+    private LocalDate startDate;
+    private LocalDate endDate;
 
-    private Double totalDistance;
-    private Integer totalRunningTime;
+    private double targetDistance;  // 목표 누적 거리 (km)
+    private double targetPace;      // 목표 평균 페이스 (min/km)
+    private int targetTime;         // 목표 누적 시간 (초 단위)
+
+    // 추가로 목표의 달성 여부를 기록할 수 있는 필드들
+    private boolean achieved = false;
 
     @CreatedDate
     private LocalDateTime createdAt;
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    private Integer averagePace;
-    private Integer runCount;
+    @Builder
+    public RunGoalEntity(LocalDate startDate, LocalDate endDate, double targetDistance, double targetPace, int targetTime) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.targetDistance = targetDistance;
+        this.targetPace = targetPace;
+        this.targetTime = targetTime;
+    }
 }

--- a/src/main/java/com/example/runningservice/entity/RunRecordEntity.java
+++ b/src/main/java/com/example/runningservice/entity/RunRecordEntity.java
@@ -7,6 +7,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -42,9 +44,11 @@ public class RunRecordEntity {
 
     private Integer runningTime;
 
-    private LocalDateTime runningDate;
+    private LocalDate runningDate;
     @CreatedDate
+    @Setter
     private LocalDateTime createdAt;
     @LastModifiedDate
+    @Setter
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/example/runningservice/repository/RunGoalRepository.java
+++ b/src/main/java/com/example/runningservice/repository/RunGoalRepository.java
@@ -1,17 +1,19 @@
 package com.example.runningservice.repository;
 
 import com.example.runningservice.entity.RunGoalEntity;
+
+import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RunGoalRepository extends JpaRepository<RunGoalEntity, Long> {
-    List<RunGoalEntity> findByUserId_Id(Long userId);
 
     void deleteAllByUserId_Id(Long userId);
 
-    Optional<RunGoalEntity> findFirstByUserId_IdOrderByCreatedAtDesc(Long userId);
+    // 특정 기간 내의 목표 조회 (startDate와 endDate 사이에 속하는 목표들)
+    List<RunGoalEntity> findByStartDateBeforeAndEndDateAfter(LocalDate currentDate);
+    List<RunGoalEntity> findByUserId(Long userId);
 
 }

--- a/src/main/java/com/example/runningservice/service/RunGoalService.java
+++ b/src/main/java/com/example/runningservice/service/RunGoalService.java
@@ -3,125 +3,65 @@ package com.example.runningservice.service;
 import com.example.runningservice.dto.runGoal.RunGoalRequestDto;
 import com.example.runningservice.dto.runGoal.RunGoalResponseDto;
 import com.example.runningservice.entity.RunGoalEntity;
-import com.example.runningservice.exception.CustomException;
-import com.example.runningservice.exception.ErrorCode;
 import com.example.runningservice.repository.RunGoalRepository;
-import com.example.runningservice.repository.MemberRepository;
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class RunGoalService {
 
-    private final RunGoalRepository runGoalRepository;
-    private final MemberRepository memberRepository;
+    @Autowired
+    private RunGoalRepository runGoalRepository;
 
-    public List<RunGoalResponseDto> findAll() {
-        return runGoalRepository.findAll().stream()
-            .map(this::entityToDto)
-            .collect(Collectors.toList());
+    // RunGoal 생성
+    public RunGoalResponseDto createRunGoal(RunGoalRequestDto runGoalRequestDTO) {
+        RunGoalEntity runGoalEntity = runGoalRequestDTO.toEntity();
+        runGoalEntity = runGoalRepository.save(runGoalEntity);
+        return RunGoalResponseDto.fromEntity(runGoalEntity);
     }
 
-    public RunGoalResponseDto findById(Long id) {
-        RunGoalEntity entity = runGoalRepository.findById(id)
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RUN_GOAL));
+    // RunGoal 업데이트
+    public RunGoalResponseDto updateRunGoal(Long id, RunGoalRequestDto updatedRunGoalDTO) {
+        RunGoalEntity existingGoal = runGoalRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Goal not found"));
 
-        return entityToDto(entity);
+        RunGoalEntity updatedGoal = updatedRunGoalDTO.toEntity();
+        updatedGoal = runGoalRepository.save(updatedGoal);
+        return RunGoalResponseDto.fromEntity(updatedGoal);
     }
 
-
-    public List<RunGoalResponseDto> findByUserId(Long id) {
-        List<RunGoalEntity> runGoals = runGoalRepository.findByUserId_Id(id);
-        return runGoals.stream()
-            .map(this::entityToDto)
-            .collect(Collectors.toList());
-    }
-
-    public RunGoalResponseDto createRunGoal(Long userId, RunGoalRequestDto requestDto) {
-        Map<String, Integer> map = transformDTO(requestDto);
-
-        RunGoalEntity runGoalEntity = RunGoalEntity.builder()
-
-            .userId(memberRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER)))
-            .totalDistance(requestDto.getTotalDistance())
-            .totalRunningTime(map.get("totalRunningTime"))
-            .averagePace(map.get("averagePace"))
-            .runCount(requestDto.getRunCount())
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
-            .build();
-
-        RunGoalEntity savedEntity = runGoalRepository.save(runGoalEntity);
-        return entityToDto(savedEntity);
-    }
-
-    public RunGoalResponseDto updateRunGoal(Long id, RunGoalRequestDto requestDto) {
-        RunGoalEntity existingEntity = runGoalRepository.findById(id)
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RUN_GOAL));
-
-        Map<String, Integer> map = transformDTO(requestDto);
-
-        RunGoalEntity updatedEntity = RunGoalEntity.builder()
-            .id(existingEntity.getId())
-            .userId(existingEntity.getUserId())
-            .totalDistance(requestDto.getTotalDistance())
-            .totalRunningTime(map.get("totalRunningTime"))
-            .averagePace(map.get("averagePace"))
-            .runCount(requestDto.getRunCount())
-            .createdAt(existingEntity.getCreatedAt())
-            .updatedAt(LocalDateTime.now())
-            .build();
-
-        RunGoalEntity savedEntity = runGoalRepository.save(updatedEntity);
-        return entityToDto(savedEntity);
-    }
-
-
-    public void deleteById(Long id) {
+    // RunGoal 삭제
+    public void deleteRunGoal(Long id) {
         runGoalRepository.deleteById(id);
     }
 
-    private RunGoalResponseDto entityToDto(RunGoalEntity entity) {
-        if (entity == null) {
-            throw new IllegalArgumentException("러닝목표 엔티티는 빈 값일 수 없습니다.");
-        }
-
-        return RunGoalResponseDto.builder()
-            .id(entity.getId())
-            .userId(
-                entity.getUserId() != null ? entity.getUserId().getId() : null) // Null check added
-            .totalDistance(entity.getTotalDistance())
-            .totalRunningTime(entity.getTotalRunningTime())
-            .averagePace(entity.getAveragePace())
-            .runCount(entity.getRunCount())
-            .createdAt(entity.getCreatedAt())
-            .updatedAt(entity.getUpdatedAt())
-            .build();
+    // RunGoal 조회
+    public RunGoalResponseDto getRunGoal(Long id) {
+        RunGoalEntity runGoal = runGoalRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Goal not found"));
+        return RunGoalResponseDto.fromEntity(runGoal);
     }
 
-    public Map<String,Integer> transformDTO (RunGoalRequestDto runGoalRequestDto) {
+    // 전체 러닝 목표 조회
+    public List<RunGoalResponseDto> getAllRunGoals() {
+        List<RunGoalEntity> runGoals = runGoalRepository.findAll();
+        return runGoals.stream()
+                .map(RunGoalResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
 
-        Map<String,Integer> map = new HashMap<>();
-        // runningTime 시:분:초 -> sec 변환
-        String[] runningTimes = runGoalRequestDto.getTotalRunningTime().split(":");
-        int runningTime = Integer.parseInt(runningTimes[0])*3600+Integer.parseInt(runningTimes[1])*60+Integer.parseInt(runningTimes[2]);
-
-        map.put("totalRunningTime", runningTime);
-
-        // pace 분:초 -> sec 변환
-        String[] paces = runGoalRequestDto.getAveragePace().split(":");
-        int pace = Integer.parseInt(paces[0])*60+Integer.parseInt(paces[1]);
-        map.put("AveragePace", pace);
-
-        return map;
+    // 특정 사용자의 러닝 목표 조회
+    public List<RunGoalResponseDto> getUserRunGoals(Long userId) {
+        List<RunGoalEntity> runGoals = runGoalRepository.findByUserId(userId);
+        return runGoals.stream()
+                .map(RunGoalResponseDto::fromEntity)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/example/runningservice/service/RunGoalServiceTest.java
+++ b/src/test/java/com/example/runningservice/service/RunGoalServiceTest.java
@@ -1,194 +1,186 @@
 package com.example.runningservice.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.example.runningservice.dto.runGoal.RunGoalRequestDto;
 import com.example.runningservice.dto.runGoal.RunGoalResponseDto;
-import com.example.runningservice.entity.MemberEntity;
 import com.example.runningservice.entity.RunGoalEntity;
-import com.example.runningservice.repository.MemberRepository;
 import com.example.runningservice.repository.RunGoalRepository;
-import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
 class RunGoalServiceTest {
-
-    @Mock
-    private RunGoalRepository runGoalRepository;
-
-    @Mock
-    private MemberRepository memberRepository;
 
     @InjectMocks
     private RunGoalService runGoalService;
 
-    private RunGoalEntity runGoalEntity;
-    private MemberEntity memberEntity;
+    @Mock
+    private RunGoalRepository runGoalRepository;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-
-        memberEntity = MemberEntity.builder()
-            .id(1L)
-            .name("Test User")
-            .build();
-
-        runGoalEntity = RunGoalEntity.builder()
-            .id(1L)
-            .userId(memberEntity)
-            .totalDistance(10.0)
-            .totalRunningTime(3600)
-            .averagePace(300)
-            .runCount(10)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
-            .build();
     }
 
     @Test
-    void testFindAll() {
-        when(runGoalRepository.findAll()).thenReturn(Collections.singletonList(runGoalEntity));
-
-        List<RunGoalResponseDto> result = runGoalService.findAll();
-
-        assertNotNull(result);
-        assertEquals(1, result.size());
-        assertEquals(runGoalEntity.getId(), result.getFirst().getId());
-    }
-
-    @Test
-    public void testFindById() {
-        Long id = 1L;
-        MemberEntity memberEntity = MemberEntity.builder()
-            .id(id)
-            .build();
-
-        RunGoalEntity entity = RunGoalEntity.builder()
-            .id(id)
-            .userId(memberEntity) // 널값 체크
-            .totalDistance(10.0)
-            .totalRunningTime(3600)
-            .averagePace(300)
-            .runCount(10)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
-            .build();
-
-        // Mock 설정
-        when(runGoalRepository.findById(id)).thenReturn(Optional.of(entity));
-
-        // 서비스 호출
-        RunGoalResponseDto responseDto = runGoalService.findById(id);
-
-        // Assertions
-        assertNotNull(responseDto);
-        assertEquals(id, responseDto.getId());
-        assertEquals(id, responseDto.getUserId()); // id 체크
-    }
-
-    @Test
-    void testFindByUserId() {
-        when(runGoalRepository.findByUserId_Id(1L)).thenReturn(Collections.singletonList(runGoalEntity));
-
-        List<RunGoalResponseDto> result = runGoalService.findByUserId(1L);
-
-        assertNotNull(result);
-        assertEquals(1, result.size());
-        assertEquals(runGoalEntity.getId(), result.getFirst().getId());
-    }
-
-    @Test
-    void testCreateRunGoal() {
+    void createRunGoal_Success() {
+        // given
         RunGoalRequestDto requestDto = RunGoalRequestDto.builder()
-            .userId(1L)
-            .totalDistance(10.0)
-            .totalRunningTime("00:36:00")
-            .averagePace("06:00")
-            .runCount(10)
-            .build();
+                .startDate(LocalDate.of(2024, 1, 1))
+                .endDate(LocalDate.of(2024, 12, 31))
+                .targetDistance(1000.0)
+                .targetPace(5.0)
+                .targetTime(36000)
+                .build();
 
-        when(memberRepository.findById(1L)).thenReturn(Optional.of(memberEntity));
-        when(runGoalRepository.save(any(RunGoalEntity.class))).thenReturn(runGoalEntity);
+        RunGoalEntity savedEntity = requestDto.toEntity();
 
-        RunGoalResponseDto result = runGoalService.createRunGoal(1L, requestDto);
+        when(runGoalRepository.save(any(RunGoalEntity.class))).thenReturn(savedEntity);
 
-        assertNotNull(result);
-        assertEquals(runGoalEntity.getId(), result.getId());
+        // when
+        RunGoalResponseDto responseDto = runGoalService.createRunGoal(requestDto);
+
+        // then
+        assertNotNull(responseDto);
+        assertEquals(1000.0, responseDto.getTargetDistance());
+        assertEquals(5.0, responseDto.getTargetPace());
     }
 
     @Test
-    public void testUpdateRunGoal() {
+    void getRunGoal_Success() {
+        // given
         Long id = 1L;
-        Long userId = 2L;
+        RunGoalEntity runGoalEntity = RunGoalEntity.builder()
+                .startDate(LocalDate.of(2024, 1, 1))
+                .endDate(LocalDate.of(2024, 12, 31))
+                .targetDistance(1000.0)
+                .targetPace(5.0)
+                .targetTime(36000)
+                .build();
 
-        MemberEntity memberEntity = MemberEntity.builder()
-            .id(userId)
-            .build();
+        when(runGoalRepository.findById(id)).thenReturn(Optional.of(runGoalEntity));
 
+        // when
+        RunGoalResponseDto responseDto = runGoalService.getRunGoal(id);
+
+        // then
+        assertNotNull(responseDto);
+        assertEquals(1000.0, responseDto.getTargetDistance());
+        assertEquals(5.0, responseDto.getTargetPace());
+    }
+
+    @Test
+    void getRunGoal_NotFound() {
+        // given
+        Long id = 1L;
+        when(runGoalRepository.findById(id)).thenReturn(Optional.empty());
+
+        // when / then
+        assertThrows(NoSuchElementException.class, () -> runGoalService.getRunGoal(id));
+    }
+
+    @Test
+    void updateRunGoal_Success() {
+        // given
+        Long id = 1L;
         RunGoalEntity existingEntity = RunGoalEntity.builder()
-            .id(id)
-            .userId(memberEntity)
-            .totalDistance(10.0)
-            .totalRunningTime(3600)
-            .averagePace(300)
-            .runCount(10)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
-            .build();
+                .startDate(LocalDate.of(2024, 1, 1))
+                .endDate(LocalDate.of(2024, 12, 31))
+                .targetDistance(1000.0)
+                .targetPace(5.0)
+                .targetTime(36000)
+                .build();
 
-        RunGoalEntity updatedEntity = RunGoalEntity.builder()
-            .id(id)
-            .userId(memberEntity)
-            .totalDistance(15.0)
-            .totalRunningTime(18000)
-            .averagePace(300)
-            .runCount(12)
-            .createdAt(existingEntity.getCreatedAt())
-            .updatedAt(LocalDateTime.now())
-            .build();
+        RunGoalRequestDto updatedDto = RunGoalRequestDto.builder()
+                .startDate(LocalDate.of(2024, 1, 1))
+                .endDate(LocalDate.of(2024, 12, 31))
+                .targetDistance(1500.0) // 업데이트된 거리
+                .targetPace(4.5)        // 업데이트된 페이스
+                .targetTime(45000)
+                .build();
 
         when(runGoalRepository.findById(id)).thenReturn(Optional.of(existingEntity));
-        when(runGoalRepository.save(any(RunGoalEntity.class))).thenReturn(updatedEntity);
+        when(runGoalRepository.save(any(RunGoalEntity.class))).thenReturn(updatedDto.toEntity());
 
-        RunGoalRequestDto requestDto = RunGoalRequestDto.builder()
-            .totalDistance(15.0)
-            .totalRunningTime("05:00:00")
-            .averagePace("05:00")
-            .runCount(12)
-            .build();
+        // when
+        RunGoalResponseDto responseDto = runGoalService.updateRunGoal(id, updatedDto);
 
-        RunGoalResponseDto responseDto = runGoalService.updateRunGoal(id, requestDto);
-
+        // then
         assertNotNull(responseDto);
-        assertEquals(15.0, responseDto.getTotalDistance());
-        assertEquals(18000, responseDto.getTotalRunningTime());
-        assertEquals(300, responseDto.getAveragePace());
-        assertEquals(12, responseDto.getRunCount());
-        verify(runGoalRepository, times(1)).save(any(RunGoalEntity.class));
+        assertEquals(1500.0, responseDto.getTargetDistance());
+        assertEquals(4.5, responseDto.getTargetPace());
     }
 
+    @Test
+    void deleteRunGoal_Success() {
+        // given
+        Long id = 1L;
 
+        doNothing().when(runGoalRepository).deleteById(id);
+
+        // when
+        runGoalService.deleteRunGoal(id);
+
+        // then
+        verify(runGoalRepository, times(1)).deleteById(id);
+    }
 
     @Test
-    void testDeleteById() {
-        doNothing().when(runGoalRepository).deleteById(1L);
+    void getAllRunGoals_Success() {
+        // given
+        List<RunGoalEntity> runGoalEntities = new ArrayList<>();
+        runGoalEntities.add(RunGoalEntity.builder()
+                .startDate(LocalDate.of(2024, 1, 1))
+                .endDate(LocalDate.of(2024, 12, 31))
+                .targetDistance(1000.0)
+                .targetPace(5.0)
+                .targetTime(36000)
+                .build());
 
-        runGoalService.deleteById(1L);
+        when(runGoalRepository.findAll()).thenReturn(runGoalEntities);
 
-        verify(runGoalRepository, times(1)).deleteById(1L);
+        // when
+        List<RunGoalResponseDto> responseDtos = runGoalService.getAllRunGoals();
+
+        // then
+        assertNotNull(responseDtos);
+        assertFalse(responseDtos.isEmpty());
+        assertEquals(1, responseDtos.size());
+        assertEquals(1000.0, responseDtos.getFirst().getTargetDistance());
+    }
+
+    @Test
+    void getUserRunGoals_Success() {
+        // given
+        Long userId = 1L;
+        List<RunGoalEntity> runGoalEntities = new ArrayList<>();
+        runGoalEntities.add(RunGoalEntity.builder()
+                .startDate(LocalDate.of(2024, 1, 1))
+                .endDate(LocalDate.of(2024, 12, 31))
+                .targetDistance(1000.0)
+                .targetPace(5.0)
+                .targetTime(36000)
+                .build());
+
+        when(runGoalRepository.findByUserId(userId)).thenReturn(runGoalEntities);
+
+        // when
+        List<RunGoalResponseDto> responseDtos = runGoalService.getUserRunGoals(userId);
+
+        // then
+        assertNotNull(responseDtos);
+        assertFalse(responseDtos.isEmpty());
+        assertEquals(1000.0, responseDtos.getFirst().getTargetDistance());
     }
 }


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
RunGoal 재정의 및 req/resp dto 구조 변경
### 이 PR에서 변경된 사항
- RunGoal이 기간 (Startdate, Enddate) 기준으로 목표(누적거리, 평균페이스, 누적시간) 생성하고 동일 기간 중 퍼센트로 표시될 수 있도록 정의
- req/resp dto - 생성자및 @builder 추가, toEntity FromEntity 이동
### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
