### PR TITLE
feat search-post&crew&crewMember

### DIFF
--- a/src/main/java/com/example/runningservice/repository/post/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/runningservice/repository/post/PostRepositoryCustomImpl.java
@@ -106,7 +106,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     }
 
     private BooleanExpression authorContainsIgnoreCase(String author) {
-        return author != null ? QPostEntity.postEntity.member.nickName.containsIgnoreCase(author)
+        return author != null ? QPostEntity.postEntity.member.nickName.contains(author)
             : null;
     }
 }

--- a/src/main/resources/sql/indexing.sql
+++ b/src/main/resources/sql/indexing.sql
@@ -8,3 +8,7 @@ using gin (title gin_bigm_ops);
 create index idx_bigm_content
 on post
 using gin (content gin_bigm_ops);
+--- 칼럼에 bigm 인덱스 추가
+create index idx_bigm_nickName
+on member
+using gin (nick_name gin_bigm_ops);


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 작성자 검색 시에도 검색 성능 향상(이전 PR에서 생략함)

### 이 PR에서 변경된 사항
- Postgresql 인덱스 쿼리 스크립트 추가 : member.nick_name 테이블에 bigm 추가, post.member_id 테이블에 btree 인덱스 추가
- PostRepositoryCustomImpl
  - searchPostsByCrewIdAndKeyword : author(nickname) 검색 시 containsIgnoreCase -> contains 수정
  
### 참고 스크린샷

### 기타
- Post 테이블의 외래키 컬럼(member_id)에 btree 인덱싱
- member 테이블의 nick_name에 bigm 인덱싱하여 like 연산에서의 성능 향상 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [x] API 테스트
